### PR TITLE
Add optional hotspot

### DIFF
--- a/src/module/config_loader.py
+++ b/src/module/config_loader.py
@@ -24,6 +24,17 @@ def load_settings(filename: str | Path) -> dict:
     settings.setdefault("gpio_output",     {})
     settings.setdefault("arrays",          {})
     settings.setdefault("settings",        {"light_hz": [50, 60], "conform_frame_rate": 24})
+    system_cfg = settings.setdefault("system", {})
+    wifi_defaults = {
+        "name": "CinePi",
+        "password": "11111111",
+        "enabled": True,
+    }
+    wifi_cfg = system_cfg.setdefault("wifi_hotspot", {})
+    for k, v in wifi_defaults.items():
+        wifi_cfg.setdefault(k, v)
+    system_cfg["wifi_hotspot"] = wifi_cfg
+    settings["system"] = system_cfg
     settings.setdefault("analog_controls", {})
     settings.setdefault("free_mode",       {
         "iso_free":       False,

--- a/src/settings.json
+++ b/src/settings.json
@@ -4,9 +4,10 @@
   "system": {
     "wifi_hotspot": {
       "name": "CinePi",
-      "password": "11111111"
+      "password": "11111111",
+      "enabled": true
     }
-  },  
+  },
 
   "geometry": {
     "cam0": {


### PR DESCRIPTION
## Summary
- allow disabling the WiFi hotspot with new `system.wifi_hotspot.enabled` setting
- provide defaults for this setting in the config loader
- respect the enabled flag in the WiFiHotspotManager and background service
- update main application logic to start hotspot only when enabled and to expose the web UI whenever any network connection is available