### PR TITLE
Add Ko-Fi support widget

### DIFF
--- a/docs/acknowledgments.md
+++ b/docs/acknowledgments.md
@@ -14,4 +14,10 @@ Get your sensors and CFE Hats here: (https://www.tindie.com/stores/will123321/)[
 
 ## Supporting the project
 
-[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/G2G21IM9RO)
+<div id="ko-fi-container">
+  <noscript>
+    <a href="https://ko-fi.com/G2G21IM9RO" target="_blank">
+      <img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Support on Ko-fi" />
+    </a>
+  </noscript>
+</div>

--- a/docs/js/ko-fi-widget.js
+++ b/docs/js/ko-fi-widget.js
@@ -1,0 +1,9 @@
+if (document.getElementById('ko-fi-container')) {
+  const script = document.createElement('script');
+  script.src = 'https://storage.ko-fi.com/cdn/widget/Widget_2.js';
+  script.onload = () => {
+    kofiwidget2.init('Support Cinemate on Ko-fi', '#72a4f2', 'G2G21IM9RO');
+    kofiwidget2.draw();
+  };
+  document.getElementById('ko-fi-container').appendChild(script);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,9 +89,11 @@ theme:
       primary: black
       accent: black
 
-extra_css:  
+extra_css:
   - overrides/github-markdown.css
-  - templates/styles.scss  
+  - templates/styles.scss
+extra_javascript:
+  - js/ko-fi-widget.js
 # ───────────────────────────
 # Markdown add-ons
 # ───────────────────────────


### PR DESCRIPTION
## Summary
- add Ko-Fi widget script loader
- enable script in documentation via `extra_javascript`
- embed Ko-Fi container in acknowledgments page

## Testing
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_688697b0eb7c8332a37eb0d452163e54