### PR TITLE
Add CLI support to erase and format RAW drive

### DIFF
--- a/src/module/cinepi_controller.py
+++ b/src/module/cinepi_controller.py
@@ -787,7 +787,7 @@ class CinePiController:
     
     def mount(self):
         self.ssd_monitor.mount_drive()
-    
+
     def unmount(self):
         # if self.ssd_monitor.is_mounted:
         self.ssd_monitor.unmount_drive()
@@ -800,6 +800,12 @@ class CinePiController:
 
     def toggle_mount(self):
         self.ssd_monitor.toggle_mount_drive()
+
+    def erase_drive(self):
+        self.ssd_monitor.erase_drive()
+
+    def format_drive(self, filesystem: str = "ext4"):
+        self.ssd_monitor.format_drive(filesystem)
     
     def calculate_dynamic_shutter_angles(self, fps):
         if fps <= 0:

--- a/src/module/cli_commands.py
+++ b/src/module/cli_commands.py
@@ -63,6 +63,8 @@ class CommandExecutor(threading.Thread):
             'mount'                  : (cinepi_controller.mount,          None),
             'unmount'                : (cinepi_controller.unmount,        None),
             'toggle mount'           : (cinepi_controller.toggle_mount,   None),
+            'erase'                  : (cinepi_controller.erase_drive,    None),
+            'format'                 : (cinepi_controller.format_drive,   [str, None]),
 
             # ── Info / diagnostics ────────────────────────────────────────────────
             'time'                   : (self.display_time,                None),


### PR DESCRIPTION
## Summary
- add SSDMonitor helpers to erase the mounted RAW volume and format it as ext4 or NTFS
- expose the new storage operations through the controller and CLI command table

## Testing
- python -m compileall src/module/ssd_monitor.py src/module/cli_commands.py src/module/cinepi_controller.py

------
https://chatgpt.com/codex/tasks/task_e_68f7fdbe00d883328d908fc9f886e2f3