### PR TITLE
Add live frame sync monitoring and FPS correction suggestion

### DIFF
--- a/src/module/redis_controller.py
+++ b/src/module/redis_controller.py
@@ -29,6 +29,7 @@ class ParameterKey(Enum):
     FPS_LAST          = "fps_last"
     FPS_MAX           = "fps_max"
     FPS_USER          = "fps_user"
+    FPS_CORRECTION_SUGGESTION = "fps_correction_suggestion"
     FRAMECOUNT        = "framecount"
     GUI_LAYOUT        = "gui_layout"
     HEIGHT            = "height"
@@ -72,6 +73,7 @@ class ParameterKey(Enum):
     RECORDING_TIME         = "recording_time"      # elapsed-time in seconds   
     RECORDING_TC_REC     = "recording_tc_rec"    # elapsed-time time-code
     RECORDING_TC_TOD   = "recording_time_tod"    # time-of-day time-code
+    FRAMES_IN_SYNC      = "frames_in_sync"
 
 
 # ────────────────────────── tiny pub‑sub helper ──────────────────────


### PR DESCRIPTION
## Summary
- add redis keys to expose frame sync status and fps correction suggestions
- monitor expected frame counts during recording to toggle the `frames_in_sync` flag with ±1 leeway
- reuse the recording analysis to publish a suggested fps correction factor after each take

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_69027363eb9c8332b8367c476fb139d4