### PR TITLE
feat: integrate new CFE automount mechanics

### DIFF
--- a/docs/redis-keys.md
+++ b/docs/redis-keys.md
@@ -32,6 +32,8 @@ Each entry explains which component normally writes the key and what happens whe
 | is_writing_buf | Cinemate | Internal countdown after recording stops | No |
 | is_mounted | Cinemate (SSD monitor) | 1 when storage is mounted | No |
 | storage_type | Cinemate (SSD monitor) | Drive type (NVME/USB/SD) | No |
+| storage_mechanical_status | storage-automount.service | Physical status of attached media (`cfe:mounted`, `ssd:unmounted`, …) | No |
+| storage_status_message | storage-automount.service | Human-readable status message from automounter | No |
 | space_left | Cinemate (SSD monitor) | Remaining space in GB | No |
 | write_speed_to_drive | Cinemate (SSD monitor) | Current write speed MB/s | No |
 | file_size | Cinemate | Bytes per frame for current mode | No |


### PR DESCRIPTION
## Summary
- stream storage-automount log output and state updates into Redis so the CLI can mirror runtime activity
- track mount metadata for each device and write mechanical status updates for RAW media
- replace the CFE-HAT worker with the new mounting mechanics while keeping existing SSD/NVMe handling intact

## Testing
- python -m py_compile services/storage-automount/storage-automount.py

------
https://chatgpt.com/codex/tasks/task_e_690cf9a034648332a43c71f3654adf9f