### PR TITLE
Split storage automount service by media type

### DIFF
--- a/services/Makefile
+++ b/services/Makefile
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------
 # Manage *all* services under cinemate/services/*
 # ---------------------------------------------------------------
-SUBSERVICES := storage-automount wifi-hotspot
+SUBSERVICES := cfe-hat-automount nvme-automount ssd-automount wifi-hotspot
 
 .PHONY: all install enable disable start stop restart status clean uninstall \
         $(addprefix install-,$(SUBSERVICES))  \

--- a/services/cfe-hat-automount/Makefile
+++ b/services/cfe-hat-automount/Makefile
@@ -1,0 +1,41 @@
+PREFIX  ?= /usr/local
+SYSDDIR ?= /etc/systemd/system
+
+SERVICE = cfe-hat-automount.service
+
+.PHONY: all install enable disable start stop restart status clean uninstall
+
+all:
+	@echo "Nothing to build – use 'make install'"
+
+install:
+	$(MAKE) -C ../storage-automount install
+	install -m 644 $(SERVICE) $(SYSDDIR)/$(SERVICE)
+	systemctl daemon-reload
+
+enable: install
+	systemctl enable  $(SERVICE)
+	systemctl start   $(SERVICE)
+
+disable:
+	- systemctl stop    $(SERVICE)
+	- systemctl disable $(SERVICE)
+
+start:
+	systemctl start $(SERVICE)
+
+stop:
+	systemctl stop $(SERVICE)
+
+restart:
+	systemctl restart $(SERVICE)
+
+status:
+	systemctl status $(SERVICE)
+
+clean: disable
+	- rm -f $(SYSDDIR)/$(SERVICE)
+	systemctl daemon-reload
+	@echo "Removed $(SERVICE)"
+
+uninstall: clean

--- a/services/cfe-hat-automount/cfe-hat-automount.service
+++ b/services/cfe-hat-automount/cfe-hat-automount.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Cinemate storage automount (CFE HAT)
+After=systemd-udevd.service multi-user.target
+Wants=systemd-udevd.service
+
+[Service]
+# minimal set: mount/unmount + ignore DAC + change ownership
+CapabilityBoundingSet=CAP_SYS_ADMIN CAP_DAC_READ_SEARCH CAP_DAC_OVERRIDE CAP_CHOWN
+AmbientCapabilities=CAP_CHOWN
+Environment=STORAGE_AUTOMOUNT_LOG=DEBUG
+Environment=STORAGE_AUTOMOUNT_ALLOWED_KINDS=cfe_nvme
+Type=simple
+ExecStart=/usr/bin/python3 /usr/local/bin/storage-automount.py
+Restart=always
+RestartSec=2
+User=root
+# Ensure script can access I²C and GPIO if relevant
+CapabilityBoundingSet=CAP_SYS_ADMIN CAP_DAC_READ_SEARCH
+
+[Install]
+WantedBy=multi-user.target

--- a/services/cinemate-services.Makefile
+++ b/services/cinemate-services.Makefile
@@ -1,11 +1,13 @@
 .PHONY: all install uninstall
 
 install:
-	$(MAKE) -C ssd-automount install
-	$(MAKE) -C nvme-automount install
-	$(MAKE) -C cfe-hat-automount install
+        $(MAKE) -C storage-automount install
+        $(MAKE) -C ssd-automount install
+        $(MAKE) -C nvme-automount install
+        $(MAKE) -C cfe-hat-automount install
 
 uninstall:
-	$(MAKE) -C ssd-automount uninstall
-	$(MAKE) -C nvme-automount uninstall
-	$(MAKE) -C cfe-hat-automount uninstall
+        $(MAKE) -C ssd-automount uninstall
+        $(MAKE) -C nvme-automount uninstall
+        $(MAKE) -C cfe-hat-automount uninstall
+        $(MAKE) -C storage-automount uninstall

--- a/services/nvme-automount/Makefile
+++ b/services/nvme-automount/Makefile
@@ -1,0 +1,41 @@
+PREFIX  ?= /usr/local
+SYSDDIR ?= /etc/systemd/system
+
+SERVICE = nvme-automount.service
+
+.PHONY: all install enable disable start stop restart status clean uninstall
+
+all:
+	@echo "Nothing to build – use 'make install'"
+
+install:
+	$(MAKE) -C ../storage-automount install
+	install -m 644 $(SERVICE) $(SYSDDIR)/$(SERVICE)
+	systemctl daemon-reload
+
+enable: install
+	systemctl enable  $(SERVICE)
+	systemctl start   $(SERVICE)
+
+disable:
+	- systemctl stop    $(SERVICE)
+	- systemctl disable $(SERVICE)
+
+start:
+	systemctl start $(SERVICE)
+
+stop:
+	systemctl stop $(SERVICE)
+
+restart:
+	systemctl restart $(SERVICE)
+
+status:
+	systemctl status $(SERVICE)
+
+clean: disable
+	- rm -f $(SYSDDIR)/$(SERVICE)
+	systemctl daemon-reload
+	@echo "Removed $(SERVICE)"
+
+uninstall: clean

--- a/services/nvme-automount/nvme-automount.service
+++ b/services/nvme-automount/nvme-automount.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Consolidated automount for external storage (USB / NVMe / CFE-HAT)
+Description=Cinemate storage automount (NVMe hats)
 After=systemd-udevd.service multi-user.target
 Wants=systemd-udevd.service
 
@@ -8,6 +8,7 @@ Wants=systemd-udevd.service
 CapabilityBoundingSet=CAP_SYS_ADMIN CAP_DAC_READ_SEARCH CAP_DAC_OVERRIDE CAP_CHOWN
 AmbientCapabilities=CAP_CHOWN
 Environment=STORAGE_AUTOMOUNT_LOG=DEBUG
+Environment=STORAGE_AUTOMOUNT_ALLOWED_KINDS=usb_nvme
 Type=simple
 ExecStart=/usr/bin/python3 /usr/local/bin/storage-automount.py
 Restart=always

--- a/services/ssd-automount/Makefile
+++ b/services/ssd-automount/Makefile
@@ -1,0 +1,41 @@
+PREFIX  ?= /usr/local
+SYSDDIR ?= /etc/systemd/system
+
+SERVICE = ssd-automount.service
+
+.PHONY: all install enable disable start stop restart status clean uninstall
+
+all:
+	@echo "Nothing to build – use 'make install'"
+
+install:
+	$(MAKE) -C ../storage-automount install
+	install -m 644 $(SERVICE) $(SYSDDIR)/$(SERVICE)
+	systemctl daemon-reload
+
+enable: install
+	systemctl enable  $(SERVICE)
+	systemctl start   $(SERVICE)
+
+disable:
+	- systemctl stop    $(SERVICE)
+	- systemctl disable $(SERVICE)
+
+start:
+	systemctl start $(SERVICE)
+
+stop:
+	systemctl stop $(SERVICE)
+
+restart:
+	systemctl restart $(SERVICE)
+
+status:
+	systemctl status $(SERVICE)
+
+clean: disable
+	- rm -f $(SYSDDIR)/$(SERVICE)
+	systemctl daemon-reload
+	@echo "Removed $(SERVICE)"
+
+uninstall: clean

--- a/services/ssd-automount/ssd-automount.service
+++ b/services/ssd-automount/ssd-automount.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Cinemate storage automount (USB SSD)
+After=systemd-udevd.service multi-user.target
+Wants=systemd-udevd.service
+
+[Service]
+# minimal set: mount/unmount + ignore DAC + change ownership
+CapabilityBoundingSet=CAP_SYS_ADMIN CAP_DAC_READ_SEARCH CAP_DAC_OVERRIDE CAP_CHOWN
+AmbientCapabilities=CAP_CHOWN
+Environment=STORAGE_AUTOMOUNT_LOG=DEBUG
+Environment=STORAGE_AUTOMOUNT_ALLOWED_KINDS=usb_ssd
+Type=simple
+ExecStart=/usr/bin/python3 /usr/local/bin/storage-automount.py
+Restart=always
+RestartSec=2
+User=root
+# Ensure script can access I²C and GPIO if relevant
+CapabilityBoundingSet=CAP_SYS_ADMIN CAP_DAC_READ_SEARCH
+
+[Install]
+WantedBy=multi-user.target

--- a/services/storage-automount/Makefile
+++ b/services/storage-automount/Makefile
@@ -1,44 +1,16 @@
-# Makefile for storage-automount
+# Shared install for storage-automount Python helper
 PREFIX  ?= /usr/local
-SYSDDIR ?= /etc/systemd/system
 
 SCRIPT  = storage-automount.py
-SERVICE = storage-automount.service
 
-.PHONY: all install enable disable start stop restart status clean uninstall
+.PHONY: all install uninstall clean
 
 all:
 	@echo "Nothing to build – use 'make install'"
 
 install:
-	install -m 755 $(SCRIPT)  $(PREFIX)/bin/$(SCRIPT)
-	install -m 644 $(SERVICE) $(SYSDDIR)/$(SERVICE)
-	systemctl daemon-reload
+	install -m 755 $(SCRIPT) $(PREFIX)/bin/$(SCRIPT)
 
-enable: install
-	systemctl enable  $(SERVICE)
-	systemctl start   $(SERVICE)
-
-disable:
-	- systemctl stop    $(SERVICE)
-	- systemctl disable $(SERVICE)
-
-start:
-	systemctl start $(SERVICE)
-
-stop:
-	systemctl stop $(SERVICE)
-
-restart:
-	systemctl restart $(SERVICE)
-
-status:
-	systemctl status $(SERVICE)
-
-clean: disable
+clean uninstall:
 	- rm -f $(PREFIX)/bin/$(SCRIPT)
-	- rm -f $(SYSDDIR)/$(SERVICE)
-	systemctl daemon-reload
-	@echo "Removed $(SERVICE)"
-
-uninstall: clean     # alias for convenience
+	@echo "Removed $(SCRIPT)"


### PR DESCRIPTION
## Summary
- add kind filtering to `storage-automount.py` so separate service instances can target specific device classes
- add dedicated systemd units and makefiles for CFE hat, NVMe hat, and USB SSD automount services while sharing the Python helper
- update aggregate service makefiles to reference the new per-media services and shared installer

## Testing
- python -m compileall services/storage-automount/storage-automount.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e48a853508332a94760439d6b5cdb)