### PR TITLE
Add camera readiness script for autostart service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,12 @@ SERVICE_NAME        := cinemate-autostart
 # where systemd expects it
 SYSTEMD_DIR         := /etc/systemd/system
 SERVICE_FILE_PATH   := $(SYSTEMD_DIR)/$(SERVICE_NAME).service
+SCRIPT_PATH         := /usr/local/bin/camera-ready.sh
 
 # where the service file lives inside the repo
 SERVICE_DIR         := services/$(SERVICE_NAME)
 LOCAL_SERVICE_FILE  := $(SERVICE_DIR)/$(SERVICE_NAME).service
+LOCAL_SCRIPT_FILE   := $(SERVICE_DIR)/camera-ready.sh
 
 .PHONY: all install enable disable start stop restart status clean help
 
@@ -22,9 +24,11 @@ all: help
 # Install / update the service file
 # -------------------------------------------------------------------
 install:
-	sudo install -m 644 $(LOCAL_SERVICE_FILE) $(SERVICE_FILE_PATH)
-	sudo systemctl daemon-reload
-	@echo "Installed $(SERVICE_FILE_PATH)"
+        sudo install -m 755 $(LOCAL_SCRIPT_FILE) $(SCRIPT_PATH)
+        sudo install -m 644 $(LOCAL_SERVICE_FILE) $(SERVICE_FILE_PATH)
+        sudo systemctl daemon-reload
+        @echo "Installed $(SERVICE_FILE_PATH)"
+        @echo "Installed $(SCRIPT_PATH)"
 
 # -------------------------------------------------------------------
 # Enable / disable (boot autostart)
@@ -59,6 +63,7 @@ clean:
 	- sudo systemctl stop    $(SERVICE_NAME)
 	- sudo systemctl disable $(SERVICE_NAME)
 	- sudo rm -f             $(SERVICE_FILE_PATH)
+	- sudo rm -f             $(SCRIPT_PATH)
 	 sudo systemctl daemon-reload
 	@echo "Removed $(SERVICE_NAME)"
 

--- a/docs/installation-steps copy 2.md
+++ b/docs/installation-steps copy 2.md
@@ -501,6 +501,8 @@ make start          # launch now
 
 After enabling the service, Cinemate should autostart on boot.
 
+> **Tip:** `sudo make install` also places `/usr/local/bin/camera-ready.sh` on the system. The script waits for `cinepi-raw` to report a camera before systemd launches Cinemate, preventing the black-screen-on-boot issue that occurred when the GUI started before the sensor initialised.
+
 !!! info "Thinking about the wifi-hotspot service"
 
     The optional `wifi-hotspot` service gives the Pi its own wireless network so you

--- a/docs/installation-steps.md
+++ b/docs/installation-steps.md
@@ -513,6 +513,8 @@ make start          # launch now
 
 After enabling the service, Cinemate should autostart on boot.
 
+> **Tip:** `sudo make install` also places `/usr/local/bin/camera-ready.sh` on the system. The script waits for `cinepi-raw` to report a camera before systemd launches Cinemate, preventing the black-screen-on-boot issue that occurred when the GUI started before the sensor initialised.
+
 You now have a 12 bit RAW image capturing system on your Raspberry Pi!
 
 

--- a/docs/system-services.md
+++ b/docs/system-services.md
@@ -10,6 +10,8 @@ Cinemate uses three system services for its operation.
 
 Responsible for autostart of Cinemate on boot. By default, it is turned off on the [downloadable image file](https://github.com/Tiramisioux/cinemate/releases/tag/3.1).
 
+Starting in v3.2 the service now waits for the camera sensor to come online before launching the UI. The helper script `/usr/local/bin/camera-ready.sh` polls `cinepi-raw --list-cameras` for up to 30 seconds and logs progress to the systemd journal so Cinemate does not start with a black screen if the IMX sensor is still initialising.
+
 ### Starting, stopping, enabling and disabling the service
 
 Go to the Cinemate folder:
@@ -25,6 +27,8 @@ make status    # check status
 make disable   # disable autostart
 make clean     # remove the service
 ```
+
+The `make install` step also copies `camera-ready.sh` into `/usr/local/bin/` with execute permissions so that the systemd unit can call it from `ExecStartPre`.
 
 ## storage-automount.service
 

--- a/services/cinemate-autostart/camera-ready.sh
+++ b/services/cinemate-autostart/camera-ready.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+#
+# camera-ready.sh - Camera Detection Verification Script
+#
+# This script waits for the camera sensor to be properly initialized before
+# allowing the Cinemate service to start. This solves the "black screen on boot"
+# issue where the GUI starts before the IMX283 (or other) sensor is ready.
+#
+# Used by: systemd cinemate-autostart.service
+# Location: /usr/local/bin/camera-ready.sh
+#
+# Exit Codes:
+#   0 - Camera detected and ready
+#   1 - Camera not detected after timeout
+#
+# Author: Cinemate Community
+# Version: 1.0.0
+# Date: 2025-10-15
+#
+
+set -euo pipefail
+
+# Configuration
+readonly MAX_ATTEMPTS=30           # Maximum number of detection attempts
+readonly RETRY_INTERVAL=1          # Seconds between attempts
+readonly LOG_TAG="camera-ready"    # Tag for systemd journal logging
+
+# Colors for console output (when running manually)
+readonly RED='\033[0;31m'
+readonly GREEN='\033[0;32m'
+readonly YELLOW='\033[1;33m'
+readonly BLUE='\033[0;34m'
+readonly NC='\033[0m' # No Color
+
+# ────────────────────────────────────────────────────────────────────────────
+# Logging Functions
+# ────────────────────────────────────────────────────────────────────────────
+
+# Log to systemd journal with priority
+log_info() {
+    echo "<6>${LOG_TAG}: $1" >&2
+}
+
+log_warning() {
+    echo "<4>${LOG_TAG}: $1" >&2
+}
+
+log_error() {
+    echo "<3>${LOG_TAG}: $1" >&2
+}
+
+# Console output (for manual testing)
+print_info() {
+    if [[ -t 1 ]]; then
+        echo -e "${BLUE}[INFO]${NC} $1"
+    fi
+}
+
+print_success() {
+    if [[ -t 1 ]]; then
+        echo -e "${GREEN}[OK]${NC} $1"
+    fi
+}
+
+print_warning() {
+    if [[ -t 1 ]]; then
+        echo -e "${YELLOW}[WARN]${NC} $1"
+    fi
+}
+
+print_error() {
+    if [[ -t 1 ]]; then
+        echo -e "${RED}[ERROR]${NC} $1"
+    fi
+}
+
+# ────────────────────────────────────────────────────────────────────────────
+# Pre-flight Checks
+# ────────────────────────────────────────────────────────────────────────────
+
+# Check if cinepi-raw command exists
+check_cinepi_command() {
+    if ! command -v cinepi-raw &> /dev/null; then
+        log_error "cinepi-raw command not found"
+        print_error "cinepi-raw command not found in PATH"
+        return 1
+    fi
+    return 0
+}
+
+# Check if I2C is enabled (required for camera communication)
+check_i2c_enabled() {
+    if [[ ! -e /dev/i2c-0 ]] && [[ ! -e /dev/i2c-1 ]]; then
+        log_warning "No I2C devices found - camera may not be accessible"
+        print_warning "No I2C devices found (/dev/i2c-0 or /dev/i2c-1)"
+        # Don't fail - continue with detection attempt
+    fi
+}
+
+# ────────────────────────────────────────────────────────────────────────────
+# Camera Detection
+# ────────────────────────────────────────────────────────────────────────────
+
+# Check if any camera is detected by cinepi-raw
+detect_camera() {
+    local attempt="$1"
+
+    # Run cinepi-raw --list-cameras and capture output
+    local output
+    local exit_code=0
+
+    output=$(cinepi-raw --list-cameras 2>&1) || exit_code=$?
+
+    # Check if we got any camera output
+    # cinepi-raw lists cameras as: "0 : imx283 [5472x3648 ...] (...)"
+    if echo "$output" | grep -qE "^\s*[0-9]+\s*:\s*imx"; then
+        # Camera found!
+        local camera_name
+        camera_name=$(echo "$output" | grep -oE "imx[0-9]+" | head -n 1)
+
+        log_info "Camera detected: ${camera_name} (attempt ${attempt}/${MAX_ATTEMPTS})"
+        print_success "Camera detected: ${camera_name} (attempt ${attempt}/${MAX_ATTEMPTS})"
+
+        return 0
+    fi
+
+    # No camera detected
+    if [[ ${attempt} -eq 1 ]]; then
+        # First attempt - log at info level
+        log_info "Waiting for camera initialization (attempt ${attempt}/${MAX_ATTEMPTS})"
+        print_info "Waiting for camera initialization (attempt ${attempt}/${MAX_ATTEMPTS})..."
+    elif [[ ${attempt} -eq $((MAX_ATTEMPTS / 2)) ]]; then
+        # Halfway through - log a warning
+        log_warning "Camera not yet detected after ${attempt} attempts (${attempt}s elapsed)"
+        print_warning "Camera not detected after ${attempt} seconds..."
+    fi
+
+    return 1
+}
+
+# ────────────────────────────────────────────────────────────────────────────
+# Main Detection Loop
+# ────────────────────────────────────────────────────────────────────────────
+
+main() {
+    local attempt=1
+
+    log_info "Camera detection starting (timeout: ${MAX_ATTEMPTS}s)"
+    print_info "Checking camera readiness..."
+
+    # Pre-flight checks
+    if ! check_cinepi_command; then
+        log_error "Pre-flight check failed: cinepi-raw not found"
+        print_error "Cannot proceed without cinepi-raw command"
+        exit 1
+    fi
+
+    check_i2c_enabled
+
+    # Detection loop
+    while [[ ${attempt} -le ${MAX_ATTEMPTS} ]]; do
+        if detect_camera "${attempt}"; then
+            # Camera detected - success!
+            log_info "Camera ready - Cinemate can start"
+            print_success "Camera ready - proceeding with Cinemate startup"
+            exit 0
+        fi
+
+        # Wait before next attempt
+        sleep "${RETRY_INTERVAL}"
+        ((attempt++))
+    done
+
+    # Timeout reached - camera not detected
+    log_error "Camera detection timeout after ${MAX_ATTEMPTS} attempts (${MAX_ATTEMPTS}s)"
+    print_error "Camera not detected after ${MAX_ATTEMPTS} seconds"
+    print_error "Cinemate may start with black screen"
+
+    # Log helpful troubleshooting info
+    log_error "Troubleshooting hints:"
+    log_error "1. Check /boot/firmware/config.txt for correct dtoverlay"
+    log_error "2. Verify camera cable connection"
+    log_error "3. Check 'dmesg | grep -i imx' for driver errors"
+    log_error "4. Ensure I2C is enabled: 'sudo raspi-config nonint do_i2c 0'"
+
+    print_error ""
+    print_error "Troubleshooting:"
+    print_error "  - Check camera cable connection"
+    print_error "  - Verify /boot/firmware/config.txt has correct dtoverlay"
+    print_error "  - Check: dmesg | grep -i imx"
+    print_error "  - Check: journalctl -u cinemate-autostart"
+
+    exit 1
+}
+
+# ────────────────────────────────────────────────────────────────────────────
+# Entry Point
+# ────────────────────────────────────────────────────────────────────────────
+
+main "$@"

--- a/services/cinemate-autostart/cinemate-autostart.service
+++ b/services/cinemate-autostart/cinemate-autostart.service
@@ -3,6 +3,7 @@ Description=Cinemate Application Service
 After=network.target
 
 [Service]
+ExecStartPre=/usr/local/bin/camera-ready.sh
 ExecStartPre=/bin/sleep 5
 ExecStart=/home/pi/.cinemate-env/bin/python3 /home/pi/cinemate/src/main.py
 WorkingDirectory=/home/pi/cinemate


### PR DESCRIPTION
## Summary
- add a camera-ready.sh helper that blocks startup until cinepi-raw detects a camera
- update the cinemate-autostart systemd unit and Makefile to install the readiness probe
- document the new startup guard in the system services and installation guides

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911176fb6f48332be0c2533b50664f8)