### PR TITLE
Handle non-UTF8 output when probing audio devices

### DIFF
--- a/src/module/usb_monitor.py
+++ b/src/module/usb_monitor.py
@@ -129,6 +129,8 @@ class AudioMonitor:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
             )
         except OSError as exc:
             logging.error("Failed to launch '%s': %s", cmd, exc)


### PR DESCRIPTION
## Summary
- ensure the USB audio probe tolerates non-UTF-8 output by decoding with replacement

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691506ba0098833294a28465403adf04)