### PR TITLE
Fix fallback detection for USB mic aliases

### DIFF
--- a/docs/audio-recording.md
+++ b/docs/audio-recording.md
@@ -4,6 +4,8 @@ Cinemate records audio alongside the image sequence. Support is currently limite
  - **RØDE VideoMic NTG** – recorded in stereo at 24‑bit/48 kHz.
  - **USB PnP microphones** – recorded in mono at 16‑bit/48 kHz.
 
+Other class‑compliant USB microphones are now detected automatically by probing the ALSA hardware devices reported by `arecord -l`. Cinemate will fall back to using the matching USB device (via `plughw:<card>,<device>`) if the `mic_24bit` or `mic_16bit` aliases are not available.
+
 Audio is written as `.wav` files into the same folder as the `.dng` frames. The implementation is still experimental and audio/video synchronization needs further investigation.
 
 ### .asoundrc Setup

--- a/src/module/usb_monitor.py
+++ b/src/module/usb_monitor.py
@@ -188,6 +188,40 @@ class AudioMonitor:
         )
         return False
 
+    def find_hw_device_aliases(self) -> list[str]:
+        """Return ALSA device aliases derived from arecord -l output, prioritizing the current mic."""
+
+        aliases: list[tuple[int, str]] = []
+        try:
+            output = subprocess.check_output(
+                ["arecord", "-l"],
+                stderr=subprocess.DEVNULL,
+                text=True,
+            )
+        except FileNotFoundError:
+            logging.error("arecord not found; cannot inspect hardware devices.")
+            return []
+        except subprocess.CalledProcessError:
+            logging.error("arecord -l failed while inspecting hardware devices.")
+            return []
+
+        pattern = re.compile(r"card (\d+): [^\[]+\[([^\]]+)\], device (\d+): [^\[]+\[([^\]]+)\]")
+        for card_num, card_name, device_num, device_name in pattern.findall(output):
+            alias = f"plughw:{card_num},{device_num}"
+            score = 0
+            card_name_lower = card_name.lower()
+            device_name_lower = device_name.lower()
+
+            if self.model and (self.model in card_name_lower or self.model in device_name_lower):
+                score += 2
+            if "usb" in card_name_lower or "usb" in device_name_lower:
+                score += 1
+
+            aliases.append((score, alias))
+
+        aliases.sort(key=lambda entry: entry[0], reverse=True)
+        return [alias for _, alias in aliases]
+
     def parse_hardware_params(self) -> None:
         self.sample_rate = self.audio_sample_rate
         if self.try_audio_config("mic_24bit", "S24_3LE", 2, self.sample_rate):
@@ -205,6 +239,24 @@ class AudioMonitor:
             self.bit_depth = 16
             logging.info("parse_hardware_params(): using mic_16bit")
         else:
+            for device_alias in self.find_hw_device_aliases():
+                for channels in (1, 2):
+                    if self.try_audio_config(device_alias, "S16_LE", channels, self.sample_rate):
+                        self.format = "S16_LE"
+                        self.channels = channels
+                        self.device_alias = device_alias
+                        self.can_record_audio = True
+                        self.bit_depth = 16
+                        logging.info(
+                            "parse_hardware_params(): using fallback alias %s (%s ch)",
+                            device_alias,
+                            channels,
+                        )
+                        break
+                if self.can_record_audio:
+                    break
+
+        if not self.can_record_audio:
             self.format = None
             self.device_alias = None
             self.channels = None


### PR DESCRIPTION
## Summary
- move hardware alias discovery into the AudioMonitor so fallback probing no longer raises attribute errors
- keep automatic plughw fallback selection for USB microphones without predefined aliases

## Testing
- python -m compileall src

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f6f211d588332aa433111a3172765)