### PR TITLE
Highlight preview zoom when deviating from default

### DIFF
--- a/src/module/simple_gui.py
+++ b/src/module/simple_gui.py
@@ -46,6 +46,10 @@ class SimpleGUI(threading.Thread):
         
         # Load settings, not sure when the settings will be None so left the code here
         self.settings = settings or load_settings("/home/pi/cinemate/src/settings.json")
+        try:
+            self.preview_default_zoom = float(self.settings.get("preview", {}).get("default_zoom", 1.0))
+        except (TypeError, ValueError):
+            self.preview_default_zoom = 1.0
         
         self.setup_resources()
         self.check_display()
@@ -455,7 +459,8 @@ class SimpleGUI(threading.Thread):
             "exposure_time":  str(self.cinepi_controller.exposure_time_fractions),
 
             # misc labels / live data
-            "zoom_factor": "",   # will be filled below if ≠ 1.0
+            "zoom_factor": "",   # will be filled below if ≠ default zoom
+            "zoom_is_default": True,
             "anamorphic_factor": f"{self.redis_controller.get_value(ParameterKey.ANAMORPHIC_FACTOR.value)}X",
             "ram_load":       Utils.memory_usage(),
             "cpu_load":       Utils.cpu_load(),
@@ -504,7 +509,9 @@ class SimpleGUI(threading.Thread):
             z = float(self.redis_controller.get_value(ParameterKey.ZOOM.value) or 1.0)
         except (TypeError, ValueError):
             z = 1.0
-        if abs(z - 1.0) > 1e-3:                    # only show when ≠ 1.0
+        zoom_is_default = abs(z - self.preview_default_zoom) <= 1e-3
+        values["zoom_is_default"] = zoom_is_default
+        if not zoom_is_default:                    # only show when ≠ default
             values["zoom_factor"] = f"{z:.1f}"
 
         # ─── recording time ───
@@ -740,7 +747,7 @@ class SimpleGUI(threading.Thread):
                 for part in str(val).split('\n'):
                     # choose box colour depending on item
                     if item["key"] == "zoom_factor":
-                        box_fill = (249, 249, 249)   # white box
+                        box_fill = (255, 215, 0)   # yellow highlight
                     else:
                         box_fill = BOX_COLOR         # default grey
                     draw.rectangle([box_x, y, box_x + BOX_W, y + BOX_H],
@@ -1100,6 +1107,8 @@ class SimpleGUI(threading.Thread):
         preview_y = (frame_height - preview_h) // 2
 
         line_color = (249, 249, 249)
+        if not values.get("zoom_is_default", True):
+            line_color = (255, 215, 0)
 
         draw.rectangle(
             [preview_x, preview_y, preview_x + preview_w, preview_y + preview_h],


### PR DESCRIPTION
### Motivation
- Make it visually obvious when the preview is zoomed to a value other than the configured default by changing the preview border and the zoom-factor box color.

### Description
- Load the configured default preview zoom from settings into `self.preview_default_zoom` during `SimpleGUI` initialization.
- Compute `zoom_is_default` in `populate_values()` and only populate `values["zoom_factor"]` when the current zoom differs from the default.
- Set `values["zoom_is_default"]` and use it to change the preview border color to yellow when not default (previously always white).
- Change the zoom-factor box fill from grey/white to yellow when the zoom factor is displayed.

### Testing
- No automated tests were run for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977d429d8408332b43de0ba42d5749a)