### PR TITLE
Exit CLI loop on EOF/KeyboardInterrupt to stop repeated logs

### DIFF
--- a/src/module/cli_commands.py
+++ b/src/module/cli_commands.py
@@ -244,10 +244,14 @@ class CommandExecutor(threading.Thread):
                 time.sleep(0.1)  # Pause for 100 ms
                 try:
                     data = input("\n> ")  # Read the input as a single string
-                except (EOFError, KeyboardInterrupt) as e:
+                except EOFError as e:
                     logging.info(f"CLI input interrupted: {e}")
-                    continue
+                    self.running = False
+                    break
+                except KeyboardInterrupt as e:
+                    logging.info(f"CLI input interrupted: {e}")
+                    self.running = False
+                    break
 
                 if data.strip():  # Proceed only if there is some non-whitespace input
                     self.handle_received_data(data)  # Directly handle the received data
-


### PR DESCRIPTION
### Motivation
- Prevent the CLI thread from repeatedly logging `EOFError`/`KeyboardInterrupt` when stdin is closed (for example under systemd autostart) by exiting the input loop instead of continuing to retry.

### Description
- In `src/module/cli_commands.py` updated the `run` loop to handle `EOFError` and `KeyboardInterrupt` separately and set `self.running = False` and `break` out of the loop so the thread stops instead of repeatedly logging interruptions.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698638d817c48332a2d80f502f4a6283)