### PR TITLE
Limit autostart journal spam

### DIFF
--- a/docs/system-services.md
+++ b/docs/system-services.md
@@ -8,6 +8,8 @@ Responsible for autostart of Cinemate on boot. By default, it is turned off on t
 
 Starting in v3.2 the service now waits for the camera sensor to come online before launching the UI. The helper script `/usr/local/bin/camera-ready.sh` polls `cinepi-raw --list-cameras` for up to 30 seconds and logs progress to the systemd journal so Cinemate does not start with a black screen if the IMX sensor is still initialising.
 
+To keep `journalctl -fu cinemate-autostart` readable when ALSA reports noisy underruns, the unit rate-limits log output (see `LogRateLimitIntervalSec` and `LogRateLimitBurst` in the service file). Adjust those values if you need more or less verbosity.
+
 ### Starting, stopping, enabling and disabling the service
 
 Go to the Cinemate folder:

--- a/services/cinemate-autostart/cinemate-autostart.service
+++ b/services/cinemate-autostart/cinemate-autostart.service
@@ -9,6 +9,9 @@ ExecStart=/home/pi/.cinemate-env/bin/python3 /home/pi/cinemate/src/main.py
 WorkingDirectory=/home/pi/cinemate
 User=pi
 Group=pi
+SyslogIdentifier=cinemate-autostart
+LogRateLimitIntervalSec=30s
+LogRateLimitBurst=20
 TimeoutStopSec=5
 KillSignal=SIGINT
 


### PR DESCRIPTION
### Motivation
- Prevent noisy ALSA underrun messages from flooding `journalctl -fu cinemate-autostart` by rate-limiting service journal output.

### Description
- Add `SyslogIdentifier=cinemate-autostart`, `LogRateLimitIntervalSec=30s` and `LogRateLimitBurst=20` to `services/cinemate-autostart/cinemate-autostart.service` to enable syslog tagging and rate limiting.
- Document the new rate-limiting options in `docs/system-services.md` with guidance on adjusting `LogRateLimitIntervalSec` and `LogRateLimitBurst`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69863d6a822883329db3c11628c4cc05)