### PR TITLE
Add WAV indicator in AUD status boxes

### DIFF
--- a/src/module/simple_gui.py
+++ b/src/module/simple_gui.py
@@ -301,6 +301,7 @@ class SimpleGUI(threading.Thread):
                 "items": [
                     {"key": "mic_sample_rate", "text": lambda v: v.get("mic_sample_rate", "")},
                     {"key": "mic_bit_depth", "text": lambda v: v.get("mic_bit_depth", "")},
+                    {"key": "mic_wav_saved", "text": lambda v: "WAV" if v.get("mic_wav_saved") else ""},
 
                     # {"key": "frames_in_sync", "text": lambda v: "SYNC" if v.get("frames_in_sync") else ""},
                 ],
@@ -464,6 +465,7 @@ class SimpleGUI(threading.Thread):
             "disk_label":     (self.ssd_monitor.device_name or "").upper()[:4],
             "usb_connected":  bool(self.serial_handler.serial_connected),
             "mic_connected":  self.usb_monitor.usb_mic is not None,
+            "mic_wav_saved":  False,
             "keyboard_connected": bool(self.usb_monitor and self.usb_monitor.usb_keyboard),
             "storage_type":   self.redis_controller.get_value(ParameterKey.STORAGE_TYPE.value),
             "write_speed":    self.redis_controller.get_value(ParameterKey.WRITE_SPEED_TO_DRIVE.value) or "0 MB/s",
@@ -499,6 +501,13 @@ class SimpleGUI(threading.Thread):
                 values["frames_in_sync"] = int(self.redis_controller.get_value(ParameterKey.FRAMES_IN_SYNC.value) or 0) == 1
             except (TypeError, ValueError):
                 values["frames_in_sync"] = False
+
+            if self.ssd_monitor:
+                try:
+                    _, dng_count, wav_count = self.ssd_monitor.get_latest_recording_info()
+                    values["mic_wav_saved"] = dng_count > 0 and wav_count > 0
+                except (TypeError, ValueError):
+                    values["mic_wav_saved"] = False
 
         # ── Zoom factor (preview punch-in) ────────────────────────────────
         default_zoom = float(self.settings.get("preview", {}).get("default_zoom", 1.0))


### PR DESCRIPTION
### Motivation
- Provide a safety indicator in the GUI to let the user confirm that a WAV file has been recorded and saved alongside DNG files when a microphone is connected.

### Description
- Add a new AUD item `mic_wav_saved` (labelled `WAV`) to `left_section_layout`, add `mic_wav_saved` to the `values` dict with a default `False`, and set it based on the latest recording info returned by `ssd_monitor.get_latest_recording_info()` (true when both DNG and WAV counts are > 0) in `src/module/simple_gui.py`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698644b25ec883329e26ea1dbf106d0a)