### PR TITLE
Improve HDMI GUI responsiveness: frame timing, resync, and font caching

### DIFF
--- a/docs/simple-gui.md
+++ b/docs/simple-gui.md
@@ -9,3 +9,20 @@ Simple GUI is available via browser and/or attached HDMI monitor.
 Buffer meter in the lower left indicates number of frames in buffer. Useful when testing storage media.
 
 When a compatible USB microphone is connected, VU meters appear on the right side of the GUI so you can monitor audio levels.
+## Improving real-time GUI rendering
+
+To make `simple_gui` feel more real-time on HDMI output, you can tune the `hdmi_gui` settings in `settings.json`:
+
+```json
+{
+  "hdmi_gui": {
+    "target_fps": 15,
+    "max_frame_skip_ms": 5
+  }
+}
+```
+
+- `target_fps`: GUI refresh target. Higher values improve responsiveness at the cost of CPU usage.
+- `max_frame_skip_ms`: how far behind a frame may fall before the renderer resynchronizes, which helps avoid accumulating lag and stutter.
+
+The renderer now also caches font objects to reduce per-frame overhead, which improves frame consistency when many text elements are redrawn.

--- a/src/module/config_loader.py
+++ b/src/module/config_loader.py
@@ -111,6 +111,8 @@ def load_settings(filename: str | Path) -> dict:
     hdmi_gui_defaults = {
         "buffer_vu_meter": True,
         "vu_meter_hatch_lines": True,
+        "target_fps": 15,
+        "max_frame_skip_ms": 5,
     }
     hdmi_gui_cfg = settings.setdefault("hdmi_gui", {})
     for k, v in hdmi_gui_defaults.items():

--- a/src/module/simple_gui.py
+++ b/src/module/simple_gui.py
@@ -10,6 +10,7 @@ from sugarpie import pisugar
 from flask_socketio import SocketIO
 import re
 from statistics import mean
+from typing import Dict, Tuple
 from module.utils import Utils
 from module.redis_controller import ParameterKey
 import json
@@ -80,6 +81,12 @@ class SimpleGUI(threading.Thread):
         else:
             self.show_buffer_vu = True
             self.vu_meter_hatch_lines = True
+
+        self.target_fps = max(1, int((self.settings.get("hdmi_gui", {}) or {}).get("target_fps", 15)))
+        self.max_frame_skip_ms = max(0, int((self.settings.get("hdmi_gui", {}) or {}).get("max_frame_skip_ms", 5)))
+        self.frame_interval = 1.0 / self.target_fps
+
+        self._font_cache: Dict[Tuple[str, int], ImageFont.FreeTypeFont] = {}
 
         self.background_color_changed = False
         
@@ -705,9 +712,15 @@ class SimpleGUI(threading.Thread):
     # ─────────────────────────────────────────────────────────────
     # LEFT-HAND COLUMN  (CAM / MON / SYS …)
     # ─────────────────────────────────────────────────────────────
+    def get_font(self, font_path: str, font_size: int):
+        key = (os.path.realpath(font_path), int(font_size))
+        if key not in self._font_cache:
+            self._font_cache[key] = ImageFont.truetype(key[0], key[1])
+        return self._font_cache[key]
+
     def draw_left_sections(self, draw, values):
-        label_font = ImageFont.truetype(self.regular_font_path, 26)
-        box_font   = ImageFont.truetype(self.bold_font_path,     26)
+        label_font = self.get_font(self.regular_font_path, 26)
+        box_font   = self.get_font(self.bold_font_path, 26)
 
         BOX_H, BOX_W  = 40, 60
         BOX_COLOR     = (136, 136, 136)
@@ -814,8 +827,8 @@ class SimpleGUI(threading.Thread):
     # RIGHT-HAND MIRROR COLUMN
     # ─────────────────────────────────────────────────────────────
     def draw_right_sections(self, draw, values):
-        label_font = ImageFont.truetype(self.regular_font_path, 26)
-        box_font   = ImageFont.truetype(self.bold_font_path,     24)
+        label_font = self.get_font(self.regular_font_path, 26)
+        box_font   = self.get_font(self.bold_font_path, 24)
 
         BOX_H, BOX_W  = 40, 60
         BOX_COLOR     = (136, 136, 136)
@@ -891,7 +904,7 @@ class SimpleGUI(threading.Thread):
             draw_bar(x, bar_width, vu_levels[i], vu_peaks[i])
 
         # Optional: Draw channel labels
-        label_font = ImageFont.truetype(self.regular_font_path, 16)
+        label_font = self.get_font(self.regular_font_path, 16)
         labels = ["L", "R"] if n_channels == 2 else [str(i+1) for i in range(n_channels)]
         for i, label in enumerate(labels):
             text_bbox = draw.textbbox((0, 0), label, font=label_font)
@@ -1123,9 +1136,9 @@ class SimpleGUI(threading.Thread):
             position = [info["pos"][0] * shrink_x, info["pos"][1] * shrink_y]
             font_size = info.get("size", 12) * min(min(shrink_x, shrink_y), 1) 
             # 12 is the default font size, min with 1 makes sure the font stays same in bigger displays
-            font = ImageFont.truetype(
-                os.path.realpath(self.bold_font_path if info.get("font", "bold") == "bold" else self.regular_font_path),
-                font_size
+            font = self.get_font(
+                self.bold_font_path if info.get("font", "bold") == "bold" else self.regular_font_path,
+                int(font_size)
             )
             value = str(values.get(element, ''))
             color_mode = self.color_mode
@@ -1143,7 +1156,6 @@ class SimpleGUI(threading.Thread):
             else:
                 draw.text(position, value, font=font, fill=color)
                 
-        self.update_smoothed_vu_levels()
         self.draw_right_vu_meter(draw)
         if self.show_buffer_vu:
             self.draw_framebuffer_vu_meter(draw)
@@ -1162,7 +1174,7 @@ class SimpleGUI(threading.Thread):
         self.fb.show(image)
         
     def draw_rounded_box(self, draw, text, position, font_size, padding, text_color, fill_color, image, extra_height=-17, reduce_top=12):
-        font = ImageFont.truetype(os.path.realpath(self.font_path), font_size)
+        font = self.get_font(self.font_path, int(font_size))
         bbox = draw.textbbox((0, 0), text, font=font)
         text_width = bbox[2] - bbox[0]
         text_height = bbox[3] - bbox[1] + extra_height  # Increase height by extra_height
@@ -1218,12 +1230,21 @@ class SimpleGUI(threading.Thread):
             self.vu_left_smoothed = 0
             self.vu_right_smoothed = 0
             self.vu_decay_factor = 0.2
+            next_frame_at = time.monotonic()
 
             while self._running:
                 values = self.populate_values()
                 self.update_smoothed_vu_levels()
                 self.draw_gui(values)
-                time.sleep(0.2)
+
+                next_frame_at += self.frame_interval
+                now = time.monotonic()
+                sleep_for = next_frame_at - now
+                if sleep_for > 0:
+                    time.sleep(sleep_for)
+                elif abs(sleep_for) > (self.max_frame_skip_ms / 1000):
+                    # When rendering falls behind, resync to avoid accumulating lag.
+                    next_frame_at = now
         finally:
             pass
  


### PR DESCRIPTION
### Motivation

- Reduce visible lag and stutter on HDMI/simple_gui by allowing a tunable refresh target and resynchronization threshold. 
- Reduce per-frame overhead when rendering many text elements by caching font objects. 
- Provide documentation and sane defaults so users can easily tune HDMI GUI responsiveness via `settings.json`.

### Description

- Add `target_fps` and `max_frame_skip_ms` default settings under `hdmi_gui` in `load_settings`, and document the tuning options in `docs/simple-gui.md` with an example `settings.json`. 
- Read `hdmi_gui` settings in `SimpleGUI.__init__`, compute `frame_interval`, and implement a monotonic-timed render loop that sleeps to maintain `target_fps` and resynchronizes when behind by more than `max_frame_skip_ms`. 
- Introduce an in-memory font cache (`_font_cache`) and `get_font(...)` helper, and replace direct `ImageFont.truetype` calls with cached lookups to reduce per-frame font construction overhead. 
- Minor typing additions and changes to various draw helpers to use the cached fonts and improve frame consistency; `draw_rounded_box` now uses `get_font`.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab0fa2d76c8332b5280e1206ac9b26)