### PR TITLE
Fix frame discrepancy log to report recorded-vs-expected delta

### DIFF
--- a/src/module/redis_listener.py
+++ b/src/module/redis_listener.py
@@ -826,7 +826,7 @@ class RedisListener:
         logging.info(f"Calculated expected number of frames: {expected_frames_total}")
         logging.info(f"Actual number of recorded frames: {recorded_frames_total}")
 
-        diff = expected_frames_total - recorded_frames_total
+        diff = recorded_frames_total - expected_frames_total
         frames_in_sync = abs(diff) <= 1
 
         if frames_in_sync:
@@ -834,12 +834,12 @@ class RedisListener:
                 logging.info("✓ All frames accounted for.")
             else:
                 logging.info(
-                    "Frames within tolerance: %+d frame difference between expected and recorded counts.",
+                    "Frames within tolerance: %+d frame difference between recorded and expected counts.",
                     diff,
                 )
         else:
             logging.warning(
-                f"Discrepancy detected: {diff:+d} frames difference between expected and recorded counts."
+                f"Discrepancy detected: {diff:+d} frames difference between recorded and expected counts."
             )
 
         all_frames_accounted = frames_in_sync


### PR DESCRIPTION
### Motivation
- The framing discrepancy message should report the delta as recorded minus expected so the sign matches a recorded-vs-expected interpretation.
- Log text should consistently describe the comparison as "recorded and expected counts" to avoid confusion.

### Description
- Compute the frame difference as `recorded_frames_total - expected_frames_total` instead of the reverse.
- Update the in-tolerance message to "Frames within tolerance: %+d frame difference between recorded and expected counts.".
- Update the discrepancy warning to "Discrepancy detected: {diff:+d} frames difference between recorded and expected counts.".

### Testing
- Ran `python -m py_compile /workspace/cinemate/src/module/redis_listener.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab25f0ade083328ed7863d325b3c5f)