### PR TITLE
Improve background color logic to handle recording flags, drop-frame and frame-count mismatch

### DIFF
--- a/src/module/simple_gui.py
+++ b/src/module/simple_gui.py
@@ -1003,7 +1003,13 @@ class SimpleGUI(threading.Thread):
         previous_background_color = self.get_background_color()
 
         # ─── choose background colour & colour-mode ────────────────────
-        prev_bg = self.get_background_color()      # ← fixed () call
+        rec_flag = int(self.redis_controller.get_value(ParameterKey.REC.value) or 0) == 1
+        is_recording_flag = int(self.redis_controller.get_value(ParameterKey.IS_RECORDING.value) or 0) == 1
+        rec_active = rec_flag or is_recording_flag
+
+        drop_frame_detected = bool(self.redis_listener.drop_frame)
+        frames_in_sync = int(self.redis_controller.get_value(ParameterKey.FRAMES_IN_SYNC.value) or 1)
+        frame_count_mismatch = rec_active and frames_in_sync == 0
         
         try:
             preroll_active = int(
@@ -1019,23 +1025,28 @@ class SimpleGUI(threading.Thread):
             self.current_background_color = "blue"
             self.color_mode = "inverse"
 
-        elif int(self.redis_controller.get_value(ParameterKey.REC.value)) and self.redis_listener.drop_frame == 1:
-            # at least one camera is actively recording
+        elif rec_active and drop_frame_detected:
+            # drop-frame warning pulse (drop_frame is timed in redis_listener)
             self.current_background_color = "purple"
             self.color_mode = "inverse"
 
+        elif frame_count_mismatch:
+            # expected frame count differs from actual frame count
+            self.current_background_color = "orange"
+            self.color_mode = "inverse"
+
         if not preroll_active:
-            if int(self.redis_controller.get_value(ParameterKey.REC.value)) == 1:
+            if rec_active and not (drop_frame_detected or frame_count_mismatch):
                 # at least one camera is actively recording
                 self.current_background_color = "red"
                 self.color_mode = "inverse"
 
-            elif int(self.redis_controller.get_value(ParameterKey.IS_WRITING_BUF.value) or 0):
+            elif (not rec_active) and int(self.redis_controller.get_value(ParameterKey.IS_WRITING_BUF.value) or 0):
                 # recording has stopped but buffer still flushing to disk
                 self.current_background_color = "green"
                 self.color_mode = "inverse"
 
-            elif int(self.redis_controller.get_value(ParameterKey.IS_BUFFERING.value) or 0):
+            elif (not rec_active) and int(self.redis_controller.get_value(ParameterKey.IS_BUFFERING.value) or 0):
                 # cameras are building up the RAM buffer
                 self.current_background_color = "green"
                 self.color_mode = "inverse"


### PR DESCRIPTION
### Motivation
- Clarify and correct background color/state selection when recording and when preroll, drop-frame, or frame-count mismatches occur.
- Ensure buffer/buffering warnings don't override active recording state and unify multiple recording indicators into a single `rec_active` condition.

### Description
- Introduced `rec_flag` and `is_recording_flag` and combined them into `rec_active` to account for multiple recording indicators from Redis.
- Added `drop_frame_detected`, `frames_in_sync`, and `frame_count_mismatch` checks and use them to drive new color states: purple for drop-frame warnings and orange for frame-count mismatches.
- Updated background color selection so that preroll still forces blue, recording sets red only when not in drop/frame-mismatch states, and buffer/buffering green states only apply when not `rec_active`.
- Removed an unused previous variable and cleaned up the end-of-file newline.

### Testing
- Ran the project's unit test suite with `pytest`, and all tests passed.
- Ran static checks with `flake8`, and no new issues were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab325b23688332a7c5d829e1c1f158)