### PR TITLE
Refactor background color and recording-state logic in SimpleGUI

### DIFF
--- a/src/module/simple_gui.py
+++ b/src/module/simple_gui.py
@@ -1003,7 +1003,13 @@ class SimpleGUI(threading.Thread):
         previous_background_color = self.get_background_color()
 
         # ─── choose background colour & colour-mode ────────────────────
-        prev_bg = self.get_background_color()      # ← fixed () call
+        rec_flag = int(self.redis_controller.get_value(ParameterKey.REC.value) or 0) == 1
+        is_recording_flag = int(self.redis_controller.get_value(ParameterKey.IS_RECORDING.value) or 0) == 1
+        rec_active = rec_flag or is_recording_flag
+
+        drop_frame_detected = bool(self.redis_listener.drop_frame)
+        frames_in_sync = int(self.redis_controller.get_value(ParameterKey.FRAMES_IN_SYNC.value) or 1)
+        frame_count_mismatch = rec_active and frames_in_sync == 0
         
         try:
             preroll_active = int(
@@ -1015,41 +1021,45 @@ class SimpleGUI(threading.Thread):
         except (TypeError, ValueError):
             preroll_active = 0
 
-        if preroll_active:
-            self.current_background_color = "blue"
-            self.color_mode = "inverse"
-
-        elif int(self.redis_controller.get_value(ParameterKey.REC.value)) and self.redis_listener.drop_frame == 1:
-            # at least one camera is actively recording
+        if drop_frame_detected:
+            # drop-frame warning pulse (drop_frame is timed in redis_listener)
             self.current_background_color = "purple"
             self.color_mode = "inverse"
 
-        if not preroll_active:
-            if int(self.redis_controller.get_value(ParameterKey.REC.value)) == 1:
-                # at least one camera is actively recording
-                self.current_background_color = "red"
-                self.color_mode = "inverse"
+        elif frame_count_mismatch:
+            # expected frame count differs from actual frame count
+            self.current_background_color = "orange"
+            self.color_mode = "inverse"
 
-            elif int(self.redis_controller.get_value(ParameterKey.IS_WRITING_BUF.value) or 0):
-                # recording has stopped but buffer still flushing to disk
-                self.current_background_color = "green"
-                self.color_mode = "inverse"
+        elif rec_active:
+            # actively recording: default recording state
+            self.current_background_color = "red"
+            self.color_mode = "inverse"
 
-            elif int(self.redis_controller.get_value(ParameterKey.IS_BUFFERING.value) or 0):
-                # cameras are building up the RAM buffer
-                self.current_background_color = "green"
-                self.color_mode = "inverse"
+        elif preroll_active:
+            self.current_background_color = "blue"
+            self.color_mode = "inverse"
 
-            elif int(values["ram_load"].rstrip('%')) > 95:
-                # safety: RAM nearly full – warn & auto-stop
-                self.current_background_color = "yellow"
-                self.color_mode = "inverse"
-                self.cinepi_controller.rec()        # stop recording
+        elif int(self.redis_controller.get_value(ParameterKey.IS_WRITING_BUF.value) or 0):
+            # recording has stopped but buffer still flushing to disk
+            self.current_background_color = "green"
+            self.color_mode = "inverse"
 
-            else:
-                # idle
-                self.current_background_color = "black"
-                self.color_mode = "normal"
+        elif int(self.redis_controller.get_value(ParameterKey.IS_BUFFERING.value) or 0):
+            # cameras are building up the RAM buffer
+            self.current_background_color = "green"
+            self.color_mode = "inverse"
+
+        elif int(values["ram_load"].rstrip('%')) > 95:
+            # safety: RAM nearly full – warn & auto-stop
+            self.current_background_color = "yellow"
+            self.color_mode = "inverse"
+            self.cinepi_controller.rec()        # stop recording
+
+        else:
+            # idle
+            self.current_background_color = "black"
+            self.color_mode = "normal"
             
         if self.current_background_color != previous_background_color:
             self.background_color_changed = True


### PR DESCRIPTION
### Motivation

- Improve and centralize background color selection to handle new recording and sync states (drop-frame, frame-count mismatch, preroll, buffering, RAM overflow). 
- Make recording detection more robust by checking both `ParameterKey.REC` and `ParameterKey.IS_RECORDING` and using `redis_listener.drop_frame` and `ParameterKey.FRAMES_IN_SYNC` for sync-related warnings.

### Description

- Replace previous inline checks with consolidated flags `rec_active`, `drop_frame_detected`, and `frame_count_mismatch` derived from `redis_controller` and `redis_listener` values. 
- Reorder and simplify background color selection to produce distinct color states: purple for drop-frame, orange for frame-count mismatch, red for active recording, blue for preroll, green for buffering/writing, yellow for high RAM (and call `cinepi_controller.rec()` to stop recording), and black for idle, and set `color_mode` to `inverse` for warning/active states. 
- Preserve previous-background detection and emit change events via `emit_background_color_change()` with error logging on exceptions. 
- Minor cleanup: removed an unused `prev_bg` variable and fixed EOF newline.

### Testing

- Ran the project's unit test suite with `pytest` against the modified `SimpleGUI` code and the tests passed. 
- Ran linter checks with `flake8` and no new style errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab325b23688332a7c5d829e1c1f158)