### PR TITLE
Add Phase-1 Cinemate performance analyzer CLI with CSV export

### DIFF
--- a/_test/test_cli_analyze.py
+++ b/_test/test_cli_analyze.py
@@ -1,0 +1,38 @@
+import unittest
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from module.cli_commands import CommandExecutor
+
+
+class TestAnalyzeCLI(unittest.TestCase):
+    def setUp(self):
+        self.controller = MagicMock()
+        self.controller.ssd_monitor = MagicMock()
+        self.app = MagicMock()
+        self.analyzer = MagicMock()
+        self.executor = CommandExecutor(
+            self.controller,
+            self.app,
+            storage_preroll=None,
+            performance_analyzer=self.analyzer,
+        )
+
+    def test_analyze_seconds_alias(self):
+        self.executor.handle_received_data("analyze seconds 3")
+        self.analyzer.start.assert_called_once_with("seconds", 3.0)
+
+    def test_analyze_frames_alias(self):
+        self.executor.handle_received_data("analyze frames 120")
+        self.analyzer.start.assert_called_once_with("frames", 120)
+
+    def test_analyze_rejects_non_positive(self):
+        self.executor.handle_received_data("analyze s 0")
+        self.analyzer.start.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_test/test_performance_analyzer.py
+++ b/_test/test_performance_analyzer.py
@@ -1,0 +1,124 @@
+import csv
+import json
+import tempfile
+import unittest
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from module.performance_analyzer import PerformanceAnalyzer
+
+
+class DummyPubSub:
+    def __init__(self, messages):
+        self._messages = messages
+
+    def subscribe(self, _channel):
+        return None
+
+    def listen(self):
+        for msg in self._messages:
+            yield msg
+
+    def close(self):
+        return None
+
+
+class DummyRedisClient:
+    def __init__(self, messages):
+        self._messages = messages
+
+    def pubsub(self):
+        return DummyPubSub(self._messages)
+
+
+class TestPerformanceAnalyzer(unittest.TestCase):
+    def build_analyzer(self, tempdir, messages):
+        redis_controller = MagicMock()
+        redis_controller.get_value.side_effect = lambda key, default=None: {
+            "is_recording": "0",
+            "fps": "24",
+            "fps_actual": "24",
+            "buffer_size": "128",
+            "is_buffering": "0",
+            "is_writing_buf": "0",
+            "write_speed_to_drive": "100 MB/s",
+            "storage_type": "ssd",
+        }.get(key, default)
+
+        cinepi_controller = MagicMock()
+        ssd_monitor = MagicMock()
+        ssd_monitor.is_mounted = True
+
+        analyzer = PerformanceAnalyzer(
+            redis_controller=redis_controller,
+            cinepi_controller=cinepi_controller,
+            ssd_monitor=ssd_monitor,
+            dmesg_monitor=MagicMock(undervoltage_flag=False),
+            usb_monitor=MagicMock(usb_mic=None, audio_monitor=MagicMock(sample_rate=None, channels=None)),
+            analysis_root=tempdir,
+            redis_client=DummyRedisClient(messages),
+        )
+        return analyzer, redis_controller, cinepi_controller, ssd_monitor
+
+    def test_timestamp_fallback_and_key(self):
+        analyzer, *_ = self.build_analyzer(Path(tempfile.mkdtemp()), [])
+
+        ts, key = analyzer._extract_sensor_timestamp({"sensorTimestamp": 1234})
+        self.assertEqual(ts, 1234)
+        self.assertEqual(key, "sensorTimestamp")
+
+        ts, key = analyzer._extract_sensor_timestamp({"timestamp": 5678})
+        self.assertEqual(ts, 5678)
+        self.assertEqual(key, "timestamp")
+
+    @patch("module.performance_analyzer.os.path.ismount", return_value=True)
+    def test_csv_creation_with_headers(self, _ismount):
+        tempdir = Path(tempfile.mkdtemp())
+        messages = [
+            {"type": "message", "data": b'{"timestamp": 1000, "frameCount": 1, "framerate": 24, "bufferSize": 0}'},
+            {"type": "message", "data": b'{"timestamp": 2000, "frameCount": 2, "framerate": 24, "bufferSize": 0}'},
+        ]
+        analyzer, _redis, controller, _ssd = self.build_analyzer(tempdir, messages)
+
+        started = analyzer.start("f", 2)
+        self.assertTrue(started)
+        analyzer._thread.join(timeout=2)
+
+        csv_files = list(tempdir.glob("*_analyze.csv"))
+        self.assertEqual(len(csv_files), 1)
+
+        with csv_files[0].open() as f:
+            reader = csv.reader(f)
+            header = next(reader)
+        self.assertEqual(header, PerformanceAnalyzer.CSV_FIELDS)
+
+        summary_files = list(tempdir.glob("*_summary.json"))
+        self.assertEqual(len(summary_files), 1)
+        summary = json.loads(summary_files[0].read_text())
+        self.assertEqual(summary["rows_written"], 2)
+        controller.rec.assert_called_once()
+
+    def test_timestamp_gap_drop_detection(self):
+        analyzer, *_ = self.build_analyzer(Path(tempfile.mkdtemp()), [])
+        dropped, reason = analyzer._detect_drop(1_000_000_000, 1, fps_expected=24, fps_actual=24)
+        self.assertFalse(dropped)
+        self.assertEqual(reason, "")
+
+        dropped, reason = analyzer._detect_drop(1_100_000_000, 2, fps_expected=24, fps_actual=24)
+        self.assertTrue(dropped)
+        self.assertEqual(reason, "timestamp_gap")
+
+    @patch("module.performance_analyzer.os.path.ismount", return_value=False)
+    def test_storage_unavailable_fails_cleanly(self, _ismount):
+        tempdir = Path(tempfile.mkdtemp())
+        analyzer, *_ = self.build_analyzer(tempdir, [])
+        analyzer.ssd_monitor.is_mounted = False
+        started = analyzer.start("s", 1)
+        self.assertFalse(started)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -24,6 +24,7 @@ corresponding controller methods.
 | Command                                    | Argument        | Example                                 |  Function                                      |
 |--------------------------------------------|-------------------|-----------------------------------------|-------------------------------------------------|
 | `rec` / `stop`                             | `[s <seconds>] \| [f <frames>]` | `rec s 10`                           | Toggle recording or schedule an automatic stop after a timed duration or frame count |
+| `analyze`                                  | `s\|sec\|seconds <N>` / `f\|frame\|frames <N>` | `analyze s 10` | Start bounded performance analysis, auto-stop at N seconds or frames, and export CSV/summary under `/media/RAW/_analysis` |
 | `set iso <value>`                          | int               | `set iso 800`                           | Set ISO to nearest allowed step                 |
 | `inc iso` / `dec iso`                      | -              |                                | Step ISO up or down                             |
 | `set shutter a <angle>`                    | float             | `set shutter a 180`                     | Set actual shutter angle (snaps unless free/sync)|
@@ -88,3 +89,58 @@ Both actions require the RAW drive to be mounted; otherwise the CLI reports an e
 
 See [Storage pre-roll warm-up](storage-preroll.md) for a detailed walkthrough of the workflow and tips on when to run it manually.
 
+
+
+## Performance analyzer (phase 1)
+
+Use the new analyzer command to record per-frame and system performance metrics to CSV during a bounded window:
+
+- `analyze s <seconds>` (also accepts `sec`, `seconds`)
+- `analyze f <frames>` (also accepts `frame`, `frames`)
+
+Behavior:
+
+- Reuses the same scheduling semantics as `rec s/f` and validates `N > 0`.
+- If recording is not already running, Cinemate starts recording automatically before analysis.
+- Recording and analysis both stop automatically when the requested window is reached.
+- Output files are written to mounted RAW storage at:
+  - `/media/RAW/_analysis/<YYYYmmdd_HHMMSS>_analyze.csv`
+  - `/media/RAW/_analysis/<YYYYmmdd_HHMMSS>_summary.json`
+- If `/media/RAW` is not mounted or not writable, the command fails cleanly and logs an error.
+
+### CSV fields
+
+Minimum schema written by the analyzer:
+
+`monotonic_seq, wall_time_iso, sensor_timestamp_ns, timestamp_key_used, frame_count, fps_expected, fps_actual, dropped_frame_flag, drop_reason, buffer_used, buffer_size, is_buffering, is_writing_buf, write_speed_mb_s, cpu_percent_total, cpu_percent_per_core, ram_percent, cpu_temp_c, loadavg_1m, disk_write_bytes_delta, net_tx_bytes_delta, net_rx_bytes_delta, undervoltage_flag, storage_type, is_mounted, mic_connected, mic_sample_rate, mic_channels, proc_cpu_cinepi_raw, proc_cpu_cinemate, proc_cpu_redis, proc_cpu_arecord`
+
+### Timestamp normalization
+
+For each `cp_stats` sample, analyzer timestamp selection is:
+
+1. `sensorTimestamp` (preferred)
+2. fallback to `timestamp`
+
+Both are normalized into `sensor_timestamp_ns`, and `timestamp_key_used` records which key was used (`sensorTimestamp` or `timestamp`).
+
+### Drop-frame candidate detection
+
+Phase-1 drop detection combines:
+
+- timestamp gap check using `expected_period_ns = 1e9 / fps_expected`; a gap above `1.5x` period marks `timestamp_gap`
+- framecount discontinuity checks (`framecount_discontinuity`)
+- FPS deviation-only marker (`fps_deviation_only`)
+
+### How to run
+
+Examples:
+
+- `analyze s 15`
+- `analyze f 240`
+
+Quick validation:
+
+1. Run one command above.
+2. Confirm files exist in `/media/RAW/_analysis/`.
+3. Open CSV and verify non-empty rows plus expected headers.
+4. Open summary JSON and confirm `rows_written` and `drop_candidates`.

--- a/src/main.py
+++ b/src/main.py
@@ -26,6 +26,7 @@ from module.gpio_input import ComponentInitializer
 from module.battery_monitor import BatteryMonitor
 from module.wifi_hotspot import WiFiHotspotManager
 from module.cli_commands import CommandExecutor
+from module.performance_analyzer import PerformanceAnalyzer
 from module.storage_preroll import StoragePreroll
 from module.dmesg_monitor import DmesgMonitor
 from module.app import create_app
@@ -327,9 +328,20 @@ def main():
 
     gpio_input = ComponentInitializer(cinepi_controller, settings)
 
+    performance_analyzer = PerformanceAnalyzer(
+        redis_controller=redis_controller,
+        cinepi_controller=cinepi_controller,
+        ssd_monitor=ssd_monitor,
+        dmesg_monitor=dmesg_monitor,
+        usb_monitor=usb_monitor,
+    )
+
     # Create CommandExecutor (for both CLI and Serial)
     command_executor = CommandExecutor(
-        cinepi_controller, cinepi, storage_preroll=storage_preroll
+        cinepi_controller,
+        cinepi,
+        storage_preroll=storage_preroll,
+        performance_analyzer=performance_analyzer,
     )
     command_executor.start()  # CLI thread
 

--- a/src/module/cli_commands.py
+++ b/src/module/cli_commands.py
@@ -6,11 +6,12 @@ import os
 import logging  
 
 class CommandExecutor(threading.Thread):
-    def __init__(self, cinepi_controller, cinepi_app, storage_preroll=None):
+    def __init__(self, cinepi_controller, cinepi_app, storage_preroll=None, performance_analyzer=None):
         threading.Thread.__init__(self, daemon=True)  # Initialize thread
         self.cinepi_controller = cinepi_controller  # Set controller object reference
         self.cinepi_app = cinepi_app
         self.storage_preroll = storage_preroll
+        self.performance_analyzer = performance_analyzer
         self.running = True  # Flag to control the thread's execution
 
         # ---------------------------------------------------------------------------
@@ -67,6 +68,7 @@ class CommandExecutor(threading.Thread):
             'erase'                  : (cinepi_controller.erase_drive,    None),
             'format'                 : (cinepi_controller.format_drive,   [str, None]),
             'storage preroll'        : (storage_preroll.trigger_manual,   None) if storage_preroll else None,
+            'analyze'                : (self.handle_analyze_command,      None),
 
             # ── Info / diagnostics ────────────────────────────────────────────────
             'time'                   : (self.display_time,                None),
@@ -174,6 +176,10 @@ class CommandExecutor(threading.Thread):
             self.handle_rec_command(command_args)
             return
 
+        if command_name == 'analyze':
+            self.handle_analyze_command(command_args)
+            return
+
         # Handle commands with arguments or those that can be called without arguments
         if isinstance(expected_types, list):  # If the command can take multiple types
             if command_args:  # Arguments provided
@@ -255,3 +261,38 @@ class CommandExecutor(threading.Thread):
 
                 if data.strip():  # Proceed only if there is some non-whitespace input
                     self.handle_received_data(data)  # Directly handle the received data
+
+    def handle_analyze_command(self, args):
+        """Handle performance analyzer command with bounded windows."""
+        if self.performance_analyzer is None:
+            logging.info("Performance analyzer is not available in this build.")
+            return
+
+        if len(args) < 2:
+            logging.info("Analyze command requires mode and amount: analyze s <seconds> | analyze f <frames>.")
+            return
+
+        mode = args[0].lower()
+        amount_raw = args[1]
+
+        if mode in {"s", "sec", "secs", "second", "seconds"}:
+            try:
+                amount = float(amount_raw)
+            except ValueError:
+                logging.info("Invalid seconds value for analyze command.")
+                return
+        elif mode in {"f", "frame", "frames"}:
+            try:
+                amount = int(amount_raw)
+            except ValueError:
+                logging.info("Invalid frame count for analyze command.")
+                return
+        else:
+            logging.info("Unknown analyze mode. Use 's' for seconds or 'f' for frames.")
+            return
+
+        if amount <= 0:
+            logging.info("Analyze amount must be greater than zero.")
+            return
+
+        self.performance_analyzer.start(mode, amount)

--- a/src/module/performance_analyzer.py
+++ b/src/module/performance_analyzer.py
@@ -1,0 +1,533 @@
+import csv
+import datetime
+import json
+import logging
+import os
+import threading
+import time
+from pathlib import Path
+
+try:
+    import psutil
+except ImportError:  # pragma: no cover - allows running unit tests in minimal environments
+    psutil = None
+
+try:
+    import redis
+except ImportError:  # pragma: no cover - allows running unit tests in minimal environments
+    redis = None
+
+try:
+    from module.redis_controller import ParameterKey
+except Exception:  # pragma: no cover - tests can run without full runtime deps
+    class _Key:
+        def __init__(self, value):
+            self.value = value
+
+    class ParameterKey:
+        IS_RECORDING = _Key("is_recording")
+        FPS = _Key("fps")
+        FPS_ACTUAL = _Key("fps_actual")
+        BUFFER = _Key("buffer")
+        BUFFER_SIZE = _Key("buffer_size")
+        IS_BUFFERING = _Key("is_buffering")
+        IS_WRITING_BUF = _Key("is_writing_buf")
+        WRITE_SPEED_TO_DRIVE = _Key("write_speed_to_drive")
+        STORAGE_TYPE = _Key("storage_type")
+
+
+class PerformanceAnalyzer:
+    CSV_FIELDS = [
+        "monotonic_seq",
+        "wall_time_iso",
+        "sensor_timestamp_ns",
+        "timestamp_key_used",
+        "frame_count",
+        "fps_expected",
+        "fps_actual",
+        "dropped_frame_flag",
+        "drop_reason",
+        "buffer_used",
+        "buffer_size",
+        "is_buffering",
+        "is_writing_buf",
+        "write_speed_mb_s",
+        "cpu_percent_total",
+        "cpu_percent_per_core",
+        "ram_percent",
+        "cpu_temp_c",
+        "loadavg_1m",
+        "disk_write_bytes_delta",
+        "net_tx_bytes_delta",
+        "net_rx_bytes_delta",
+        "undervoltage_flag",
+        "storage_type",
+        "is_mounted",
+        "mic_connected",
+        "mic_sample_rate",
+        "mic_channels",
+        "proc_cpu_cinepi_raw",
+        "proc_cpu_cinemate",
+        "proc_cpu_redis",
+        "proc_cpu_arecord",
+    ]
+
+    def __init__(
+        self,
+        redis_controller,
+        cinepi_controller,
+        ssd_monitor,
+        dmesg_monitor=None,
+        usb_monitor=None,
+        analysis_root="/media/RAW/_analysis",
+        redis_client=None,
+    ):
+        self.redis_controller = redis_controller
+        self.cinepi_controller = cinepi_controller
+        self.ssd_monitor = ssd_monitor
+        self.dmesg_monitor = dmesg_monitor
+        self.usb_monitor = usb_monitor
+        self.analysis_root = Path(analysis_root)
+        if redis_client is not None:
+            self.redis_client = redis_client
+        elif redis is not None:
+            self.redis_client = redis.StrictRedis(host="localhost", port=6379, db=0)
+        else:
+            raise RuntimeError("redis package is required when redis_client is not provided")
+
+        self._thread = None
+        self._stop_event = threading.Event()
+        self._active = False
+        self._lock = threading.Lock()
+
+        self._seq = 0
+        self._rows = 0
+        self._drop_count = 0
+        self._prev_timestamp_ns = None
+        self._prev_frame_count = None
+        self._start_monotonic = None
+        self._last_disk_write_bytes = None
+        self._last_net_tx = None
+        self._last_net_rx = None
+
+        self._target_mode = None
+        self._target_amount = None
+        self._target_seconds = None
+        self._target_frames = None
+        self._start_is_recording = False
+
+        self._csv_path = None
+        self._summary_path = None
+
+    @property
+    def is_active(self):
+        return self._active
+
+    def start(self, mode, amount):
+        with self._lock:
+            if self._active:
+                logging.info("Performance analyzer is already running.")
+                return False
+
+            normalized_mode = self._normalize_mode(mode)
+            if normalized_mode is None:
+                logging.info("Unknown analyze mode. Use 's' for seconds or 'f' for frames.")
+                return False
+
+            validated_amount = self._validate_amount(normalized_mode, amount)
+            if validated_amount is None:
+                return False
+
+            if not self._prepare_output_paths():
+                return False
+
+            self._target_mode = normalized_mode
+            self._target_amount = validated_amount
+            if normalized_mode == "seconds":
+                self._target_seconds = float(validated_amount)
+                self._target_frames = None
+            else:
+                self._target_frames = int(validated_amount)
+                self._target_seconds = None
+
+            self._reset_session_state()
+
+            self._start_is_recording = str(self.redis_controller.get_value(ParameterKey.IS_RECORDING.value, "0")) == "1"
+            self.cinepi_controller.rec(mode, validated_amount)
+
+            self._stop_event.clear()
+            self._thread = threading.Thread(target=self._run, daemon=True, name="PerformanceAnalyzer")
+            self._active = True
+            self._thread.start()
+            logging.info(
+                "Performance analyzer started (%s=%s). Writing to %s",
+                normalized_mode,
+                validated_amount,
+                self._csv_path,
+            )
+            return True
+
+    def stop(self):
+        with self._lock:
+            if not self._active:
+                return
+            self._stop_event.set()
+
+    def _normalize_mode(self, mode):
+        mode_key = str(mode).strip().lower()
+        if mode_key in {"s", "sec", "secs", "second", "seconds"}:
+            return "seconds"
+        if mode_key in {"f", "frame", "frames"}:
+            return "frames"
+        return None
+
+    def _validate_amount(self, mode, amount):
+        try:
+            value = float(amount) if mode == "seconds" else int(amount)
+        except (TypeError, ValueError):
+            logging.info("Analyze amount must be numeric.")
+            return None
+
+        if value <= 0:
+            logging.info("Analyze amount must be greater than zero.")
+            return None
+
+        return value
+
+    def _prepare_output_paths(self):
+        if not getattr(self.ssd_monitor, "is_mounted", False):
+            logging.error("Analyze failed: RAW storage is not mounted.")
+            return False
+
+        if not os.path.ismount("/media/RAW"):
+            logging.error("Analyze failed: /media/RAW is unavailable.")
+            return False
+
+        try:
+            self.analysis_root.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            logging.error("Analyze failed: unable to create output folder %s (%s)", self.analysis_root, exc)
+            return False
+
+        stamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        self._csv_path = self.analysis_root / f"{stamp}_analyze.csv"
+        self._summary_path = self.analysis_root / f"{stamp}_summary.json"
+        return True
+
+    def _reset_session_state(self):
+        self._seq = 0
+        self._rows = 0
+        self._drop_count = 0
+        self._prev_timestamp_ns = None
+        self._prev_frame_count = None
+        self._start_monotonic = time.monotonic()
+
+        disk = psutil.disk_io_counters() if psutil and hasattr(psutil, "disk_io_counters") else None
+        net = psutil.net_io_counters() if psutil and hasattr(psutil, "net_io_counters") else None
+        self._last_disk_write_bytes = getattr(disk, "write_bytes", None)
+        self._last_net_tx = getattr(net, "bytes_sent", None)
+        self._last_net_rx = getattr(net, "bytes_recv", None)
+
+        if psutil:
+            psutil.cpu_percent(interval=None)
+            psutil.cpu_percent(interval=None, percpu=True)
+            for process in psutil.process_iter(attrs=["name"]):
+                process.cpu_percent(None)
+
+    def _run(self):
+        pubsub = self.redis_client.pubsub()
+        pubsub.subscribe("cp_stats")
+
+        try:
+            with self._csv_path.open("w", newline="", buffering=1, encoding="utf-8") as csv_file:
+                writer = csv.DictWriter(csv_file, fieldnames=self.CSV_FIELDS)
+                writer.writeheader()
+
+                for message in pubsub.listen():
+                    if self._stop_event.is_set():
+                        break
+                    if message.get("type") != "message":
+                        continue
+                    stats_data = self._decode_stats(message.get("data"))
+                    if stats_data is None:
+                        continue
+
+                    row = self._build_row(stats_data)
+                    writer.writerow(row)
+                    self._rows += 1
+
+                    if self._should_finish(row):
+                        break
+        finally:
+            try:
+                pubsub.close()
+            except Exception:
+                pass
+            self._finalize()
+            with self._lock:
+                self._active = False
+
+    def _decode_stats(self, payload):
+        if payload is None:
+            return None
+        if isinstance(payload, bytes):
+            text = payload.decode("utf-8", errors="ignore").strip()
+        else:
+            text = str(payload).strip()
+        if not text.startswith("{"):
+            return None
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            return None
+
+    def _extract_sensor_timestamp(self, stats_data):
+        sensor_ts = stats_data.get("sensorTimestamp")
+        if sensor_ts is not None:
+            try:
+                return int(sensor_ts), "sensorTimestamp"
+            except (TypeError, ValueError):
+                pass
+
+        fallback_ts = stats_data.get("timestamp")
+        if fallback_ts is not None:
+            try:
+                return int(fallback_ts), "timestamp"
+            except (TypeError, ValueError):
+                pass
+
+        return None, ""
+
+    def _build_row(self, stats_data):
+        self._seq += 1
+        now_iso = datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+        sensor_timestamp_ns, timestamp_key_used = self._extract_sensor_timestamp(stats_data)
+        frame_count = self._to_int(stats_data.get("frameCount"))
+
+        fps_expected = self._read_float(ParameterKey.FPS.value)
+        fps_actual = self._to_float(stats_data.get("framerate"))
+        if fps_actual is None:
+            fps_actual = self._read_float(ParameterKey.FPS_ACTUAL.value)
+
+        dropped_frame_flag, drop_reason = self._detect_drop(sensor_timestamp_ns, frame_count, fps_expected, fps_actual)
+
+        buffer_used = self._to_int(stats_data.get("bufferSize"))
+        if buffer_used is None:
+            buffer_used = self._read_int(ParameterKey.BUFFER.value)
+
+        disk_delta = self._sample_disk_delta()
+        net_tx_delta, net_rx_delta = self._sample_net_delta()
+
+        row = {
+            "monotonic_seq": self._seq,
+            "wall_time_iso": now_iso,
+            "sensor_timestamp_ns": sensor_timestamp_ns,
+            "timestamp_key_used": timestamp_key_used,
+            "frame_count": frame_count,
+            "fps_expected": fps_expected,
+            "fps_actual": fps_actual,
+            "dropped_frame_flag": int(dropped_frame_flag),
+            "drop_reason": drop_reason,
+            "buffer_used": buffer_used,
+            "buffer_size": self._read_int(ParameterKey.BUFFER_SIZE.value),
+            "is_buffering": self._read_bool(ParameterKey.IS_BUFFERING.value),
+            "is_writing_buf": self._read_bool(ParameterKey.IS_WRITING_BUF.value),
+            "write_speed_mb_s": self._parse_write_speed(self.redis_controller.get_value(ParameterKey.WRITE_SPEED_TO_DRIVE.value)),
+            "cpu_percent_total": psutil.cpu_percent(interval=None) if psutil else None,
+            "cpu_percent_per_core": json.dumps(psutil.cpu_percent(interval=None, percpu=True)) if psutil else "[]",
+            "ram_percent": psutil.virtual_memory().percent if psutil else None,
+            "cpu_temp_c": self._cpu_temp_c(),
+            "loadavg_1m": os.getloadavg()[0] if hasattr(os, "getloadavg") else None,
+            "disk_write_bytes_delta": disk_delta,
+            "net_tx_bytes_delta": net_tx_delta,
+            "net_rx_bytes_delta": net_rx_delta,
+            "undervoltage_flag": int(bool(getattr(self.dmesg_monitor, "undervoltage_flag", False))),
+            "storage_type": self.redis_controller.get_value(ParameterKey.STORAGE_TYPE.value) or "",
+            "is_mounted": int(bool(getattr(self.ssd_monitor, "is_mounted", False))),
+            "mic_connected": int(bool(getattr(self.usb_monitor, "usb_mic", None))),
+            "mic_sample_rate": getattr(getattr(self.usb_monitor, "audio_monitor", None), "sample_rate", None),
+            "mic_channels": getattr(getattr(self.usb_monitor, "audio_monitor", None), "channels", None),
+            "proc_cpu_cinepi_raw": self._process_cpu("cinepi-raw"),
+            "proc_cpu_cinemate": self._process_cpu("python"),
+            "proc_cpu_redis": self._process_cpu("redis"),
+            "proc_cpu_arecord": self._process_cpu("arecord"),
+        }
+
+        return row
+
+    def _should_finish(self, row):
+        if self._target_mode == "seconds":
+            elapsed = time.monotonic() - self._start_monotonic
+            return elapsed >= self._target_seconds
+
+        if self._target_mode == "frames":
+            frame_count = row.get("frame_count")
+            if frame_count is not None:
+                return frame_count >= self._target_frames
+            return self._rows >= self._target_frames
+
+        return False
+
+    def _detect_drop(self, sensor_timestamp_ns, frame_count, fps_expected, fps_actual):
+        dropped = False
+        reason = ""
+
+        if sensor_timestamp_ns is not None and self._prev_timestamp_ns is not None and fps_expected and fps_expected > 0:
+            expected_period_ns = int(1_000_000_000 / fps_expected)
+            delta = sensor_timestamp_ns - self._prev_timestamp_ns
+            if delta > int(expected_period_ns * 1.5):
+                dropped = True
+                reason = "timestamp_gap"
+
+        if not dropped and frame_count is not None and self._prev_frame_count is not None:
+            if frame_count - self._prev_frame_count > 1:
+                dropped = True
+                reason = "framecount_discontinuity"
+
+        if not dropped and fps_expected and fps_actual is not None and abs(fps_actual - fps_expected) > 1:
+            dropped = True
+            reason = "fps_deviation_only"
+
+        if dropped and not reason:
+            reason = "unknown"
+
+        if dropped:
+            self._drop_count += 1
+
+        if sensor_timestamp_ns is not None:
+            self._prev_timestamp_ns = sensor_timestamp_ns
+        if frame_count is not None:
+            self._prev_frame_count = frame_count
+
+        return dropped, reason
+
+    def _finalize(self):
+        summary = {
+            "csv_path": str(self._csv_path),
+            "target_mode": self._target_mode,
+            "target_amount": self._target_amount,
+            "rows_written": self._rows,
+            "drop_candidates": self._drop_count,
+            "start_recording_already_active": self._start_is_recording,
+            "finished_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        }
+
+        try:
+            with self._summary_path.open("w", encoding="utf-8") as handle:
+                json.dump(summary, handle, indent=2)
+            logging.info("Performance analyzer complete. Summary: %s", self._summary_path)
+        except OSError as exc:
+            logging.error("Failed to write analyzer summary: %s", exc)
+
+    def _sample_disk_delta(self):
+        if not psutil:
+            return None
+        counters = psutil.disk_io_counters()
+        if counters is None:
+            return None
+
+        current = getattr(counters, "write_bytes", None)
+        if current is None or self._last_disk_write_bytes is None:
+            self._last_disk_write_bytes = current
+            return None
+
+        delta = max(0, current - self._last_disk_write_bytes)
+        self._last_disk_write_bytes = current
+        return delta
+
+    def _sample_net_delta(self):
+        if not psutil:
+            return None, None
+        counters = psutil.net_io_counters()
+        if counters is None:
+            return None, None
+
+        tx = getattr(counters, "bytes_sent", None)
+        rx = getattr(counters, "bytes_recv", None)
+
+        tx_delta = None if tx is None or self._last_net_tx is None else max(0, tx - self._last_net_tx)
+        rx_delta = None if rx is None or self._last_net_rx is None else max(0, rx - self._last_net_rx)
+
+        self._last_net_tx = tx
+        self._last_net_rx = rx
+
+        return tx_delta, rx_delta
+
+    def _cpu_temp_c(self):
+        if not psutil:
+            return None
+        try:
+            temps = psutil.sensors_temperatures() or {}
+        except Exception:
+            return None
+
+        for readings in temps.values():
+            if not readings:
+                continue
+            first = readings[0]
+            value = getattr(first, "current", None)
+            if value is not None:
+                return value
+        return None
+
+    def _process_cpu(self, name_hint):
+        total = 0.0
+        hint = name_hint.lower()
+        if not psutil:
+            return 0.0
+        for process in psutil.process_iter(attrs=["name"]):
+            name = (process.info.get("name") or "").lower()
+            if hint in name:
+                try:
+                    total += process.cpu_percent(None)
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    continue
+        return round(total, 3)
+
+    def _read_bool(self, key):
+        value = self.redis_controller.get_value(key)
+        if value is None:
+            return 0
+        text = str(value).strip().lower()
+        if text in {"1", "true", "yes", "on"}:
+            return 1
+        if text in {"0", "false", "no", "off", ""}:
+            return 0
+        try:
+            return 1 if int(text) else 0
+        except (TypeError, ValueError):
+            return 0
+
+    def _read_float(self, key):
+        return self._to_float(self.redis_controller.get_value(key))
+
+    def _read_int(self, key):
+        return self._to_int(self.redis_controller.get_value(key))
+
+    @staticmethod
+    def _to_int(value):
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _to_float(value):
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _parse_write_speed(value):
+        if value is None:
+            return None
+        text = str(value)
+        number = "".join(c for c in text if c.isdigit() or c in {".", "-"})
+        if not number:
+            return None
+        try:
+            return float(number)
+        except ValueError:
+            return None


### PR DESCRIPTION
### Motivation
- Provide a low-overhead, Cinemate-only Phase‑1 analyzer to capture per-frame and system metrics during a bounded window and produce CSVs for bottleneck analysis.
- Preserve existing `rec` semantics while enabling quick bounded measurements without modifying cinepi-raw in this phase.

### Description
- Add `src/module/performance_analyzer.py`, a thread-driven analyzer that subscribes to `cp_stats`, samples system/process metrics, detects drop candidates, writes incremental CSV rows and a final summary JSON, and enforces output under `/media/RAW/_analysis/<YYYYmmdd_HHMMSS>_analyze.csv` and `_summary.json`.
- Implement timestamp normalization using `sensorTimestamp` with fallback to `timestamp`, exporting `sensor_timestamp_ns` and `timestamp_key_used` and populate the minimum CSV schema requested.
- Add Phase‑1 drop detection combining timestamp-gap (delta > 1.5× expected period), framecount discontinuity, and FPS-deviation-only heuristics with `drop_reason` labels (`timestamp_gap`, `framecount_discontinuity`, `fps_deviation_only`, `unknown`).
- Integrate CLI handling in `src/module/cli_commands.py` with an `analyze` command and aliases (`s|sec|seconds` and `f|frame|frames`), validate `N > 0`, auto-start recording when needed, and wire analyzer construction/injection in `src/main.py` without changing existing `rec` behavior.
- Add docs in `docs/cli-commands.md` describing usage, CSV fields, timestamp rules, drop-detection notes and output locations.
- Add unit tests covering CLI parsing, timestamp fallback, CSV/header + summary generation, timestamp-gap drop detection, and clean failure when storage is unavailable (tests live under `_test/`).
- No cinepi-raw changes were made and analyzer avoids blocking capture threads and handles missing runtime deps gracefully in test environments.

### Testing
- Compiled key modules with `python -m py_compile src/module/performance_analyzer.py src/module/cli_commands.py src/main.py` which completed successfully.
- Ran unit tests `python -m unittest _test/test_cli_analyze.py _test/test_performance_analyzer.py -v` and all tests passed (CSV/header and summary creation, timestamp fallback, drop detection, CLI parsing, and storage-unavailable checks).
- Performed lightweight runtime validations in tests that confirm CSV file creation, header equality to the declared schema and a written summary JSON with `rows_written` and `drop_candidates` fields.

No Codex skills were invoked for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad6171cab08332a4c887a48bc5d5f7)