### PR TITLE
State-model v2 scaffolding, launch policy hardening, Profile B defaults, and analyzer cp_stats metrics

### DIFF
--- a/_test/test_cinepi_multi_policy.py
+++ b/_test/test_cinepi_multi_policy.py
@@ -1,0 +1,39 @@
+import sys
+import types
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+fake = types.ModuleType("module.redis_controller")
+class _Key:
+    def __init__(self, value):
+        self.value = value
+class ParameterKey:
+    ZOOM = _Key("zoom")
+fake.ParameterKey = ParameterKey
+sys.modules.setdefault("module.redis_controller", fake)
+
+from module.cinepi_multi import _resolve_launch_policy, _resolve_recording_profile
+
+
+class TestCinePiLaunchAndProfile(unittest.TestCase):
+    def test_profile_b_default(self):
+        name, profile = _resolve_recording_profile({
+            "recording_profiles": {
+                "active": "B",
+                "profiles": {"B": {"encode_workers": 2, "disk_workers": 1}},
+            }
+        })
+        self.assertEqual(name, "B")
+        self.assertEqual(profile["encode_workers"], 2)
+
+    def test_launch_policy_defaults(self):
+        policy = _resolve_launch_policy({})
+        self.assertEqual(policy["rt_mode"], "off")
+        self.assertEqual(policy["rt_priority"], 20)
+        self.assertEqual(policy["cpu_affinity"], "1-3")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_test/test_performance_analyzer.py
+++ b/_test/test_performance_analyzer.py
@@ -111,6 +111,16 @@ class TestPerformanceAnalyzer(unittest.TestCase):
         self.assertTrue(dropped)
         self.assertEqual(reason, "timestamp_gap")
 
+    def test_stats_seq_gap_detection(self):
+        analyzer, *_ = self.build_analyzer(Path(tempfile.mkdtemp()), [])
+        seq, gap = analyzer._extract_seq_gap({"stats_seq": 1})
+        self.assertEqual(seq, 1)
+        self.assertEqual(gap, 0)
+
+        seq, gap = analyzer._extract_seq_gap({"stats_seq": 4})
+        self.assertEqual(seq, 4)
+        self.assertEqual(gap, 1)
+
     @patch("module.performance_analyzer.os.path.ismount", return_value=False)
     def test_storage_unavailable_fails_cleanly(self, _ismount):
         tempdir = Path(tempfile.mkdtemp())

--- a/_test/test_recording_state.py
+++ b/_test/test_recording_state.py
@@ -1,0 +1,30 @@
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from module.recording_state import RecordingStateAggregator
+
+
+class TestRecordingStateAggregator(unittest.TestCase):
+    def test_ingest_and_seq_gap(self):
+        agg = RecordingStateAggregator()
+        snap1 = agg.ingest_cp_stats({"frameCount": 10, "sensorTimestamp": 1000, "stats_seq": 1})
+        self.assertEqual(snap1.frame_count, 10)
+        self.assertEqual(snap1.sensor_timestamp_ns, 1000)
+        self.assertEqual(snap1.gap_count, 0)
+
+        snap2 = agg.ingest_cp_stats({"frameCount": 11, "sensorTimestamp": 1040, "stats_seq": 4})
+        self.assertEqual(snap2.frame_count, 11)
+        self.assertEqual(snap2.gap_count, 1)
+
+    def test_missing_fields_are_safe(self):
+        agg = RecordingStateAggregator()
+        snap = agg.ingest_cp_stats({"frameCount": "x", "encode_latency_ms": "12.3"})
+        self.assertIsNone(snap.frame_count)
+        self.assertEqual(snap.encode_latency_ms, 12.3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/redis-keys.md
+++ b/docs/redis-keys.md
@@ -48,3 +48,10 @@ Each entry explains which component normally writes the key and what happens whe
 | shutter_angle_transient | Cinemate | Temporary value during ramping | No |
 | exposure_time | Cinemate | Current exposure time in seconds | No |
 | wb_user | Cinemate | Kelvin value set before converting to cg_rb | No |
+
+## cp_stats fields (v2 migration additions)
+
+- `sensorTimestamp` (preferred capture timestamp source).
+- `encode_queue_size`, `disk_queue_size`, `ram_buffers`.
+- `encode_latency_ms`, `disk_latency_ms` (sampled).
+- `stats_seq` for continuity / gap detection.

--- a/docs/state-model-migration.md
+++ b/docs/state-model-migration.md
@@ -1,0 +1,117 @@
+# Recording state-model migration (v1 → v2)
+
+## Scope
+This migration introduces a canonical runtime recording state model in Cinemate that is driven by `cp_stats` messages rather than per-frame stdout metadata.
+
+## Signal layers
+
+### Authoritative signals
+- `cp_stats` fields from cinepi-raw, including timestamps and frame counters.
+- Explicit queue and latency fields (when emitted):
+  - `sensorTimestamp`
+  - `encode_queue_size`
+  - `disk_queue_size`
+  - `ram_buffers`
+  - `encode_latency_ms`
+  - `disk_latency_ms`
+  - `stats_seq`
+
+### Derived signals
+- GUI and CLI status values such as timecode presentation, buffering indicators, and sync summaries.
+
+## State model feature flag
+`settings.json` supports:
+
+```json
+"state_model": "v1" | "v2"
+```
+
+- `v1` remains the default rollback path during migration validation.
+- `v2` enables `RecordingStateAggregator` as canonical state source for live recording state.
+
+## v1 vs v2 behavior
+- **v1**: direct ad-hoc `cp_stats` field reads in `RedisListener` and historic fallback patterns.
+- **v2**: `RecordingStateAggregator` ingests `cp_stats` and exposes canonical snapshot fields to listener logic.
+
+## Launch policy settings
+New settings:
+
+```json
+"launch": {
+  "rt_mode": "off" | "fifo",
+  "rt_priority": 20,
+  "cpu_affinity": "1-3"
+}
+```
+
+- Default migration posture is `rt_mode=off`.
+- `rt_mode=fifo` requires explicit opt-in and permissions.
+
+## Recording profile mechanism
+
+```json
+"recording_profiles": {
+  "active": "B",
+  "profiles": {
+    "A": {...},
+    "B": {...},
+    "C": {...},
+    "custom": {...}
+  }
+}
+```
+
+Temporary baseline default remains **Profile B**:
+- `encode_workers=2`
+- `disk_workers=1`
+- `encode_affinity=2-3`
+- `disk_affinity=1`
+- `encode_nice=-6`
+- `disk_nice=-12`
+
+## stdout metadata deprecation path
+- stdout `DNG written:` parsing is now a best-effort path controlled by:
+
+```json
+"stdout_metadata": { "enabled": false }
+```
+
+- Core state/control behavior should not depend on per-frame stdout metadata.
+
+## Analyzer CSV additions
+Added columns:
+- `cp_stats_seq`
+- `cp_stats_seq_gap`
+- `cp_stats_timestamp_gap`
+- `encode_queue_size`
+- `disk_queue_size`
+- `ram_buffers`
+- `encode_latency_ms`
+- `disk_latency_ms`
+
+Summary JSON includes:
+- `stats_seq_gap_events`
+- `timestamp_gap_events`
+
+## 60-second validation workflow
+1. Start runtime with migration baseline settings (`active=B`, `state_model=v2` for v2 validation).
+2. Run:
+   - `analyze s 60`
+3. Check artifacts under `/media/RAW/_analysis/`:
+   - `*_analyze.csv`
+   - `*_summary.json`
+4. Compare criteria:
+   - No control regressions in start/stop/restart.
+   - Low/acceptable `stats_seq_gap_events` and `timestamp_gap_events`.
+   - Stable framecount progression and expected/recorded tolerance.
+
+## Risk matrix (short)
+- **Launch policy regression**: misconfigured `fifo` priority or affinity can reduce stability.
+- **State-model regression**: v2 mapping gaps can affect derived UI status.
+- **Analyzer schema drift**: consumers expecting old CSV headers may need update.
+
+## Rollback checklist
+1. Set `"state_model": "v1"`.
+2. Set `"launch": {"rt_mode": "off" ...}` (or previous launch policy).
+3. Keep `"recording_profiles": {"active": "B"}` for baseline.
+4. Restart Cinemate service.

--- a/src/main.py
+++ b/src/main.py
@@ -301,7 +301,7 @@ def main():
     redis_controller.set_value(ParameterKey.RECORDING_TIME.value, 0)
     
     # Initialize CinePi application
-    cinepi = CinePi(redis_controller, sensor_detect)
+    cinepi = CinePi(redis_controller, sensor_detect, settings=settings)
     
     cinepi.start_all()
 
@@ -367,7 +367,7 @@ def main():
     t.start()
 
 
-    redis_listener = RedisListener(redis_controller, ssd_monitor)
+    redis_listener = RedisListener(redis_controller, ssd_monitor, state_model=settings.get("state_model", "v1"))
     battery_monitor = BatteryMonitor()
 
     simple_gui = SimpleGUI(

--- a/src/module/cinepi_multi.py
+++ b/src/module/cinepi_multi.py
@@ -16,22 +16,38 @@ from module.redis_controller import ParameterKey
 
 # Path to settings file
 SETTINGS_FILE = "/home/pi/cinemate/src/settings.json"
-# Load global settings
 _SETTINGS = load_settings(SETTINGS_FILE)
 
 _READY_RX   = re.compile(r"Encoder configured")      # line printed by DngEncoder
 _READY_WAIT = 2.0                                   # seconds to wait for all cams
 
-def _rt_permitted():
+def _rt_permitted(priority: int):
     if shutil.which("chrt") is None:
         return False
     try:
         # Will only succeed if this user has CAP_SYS_NICE
-        subprocess.run(["chrt", "-f", "70", "/bin/true"],
+        subprocess.run(["chrt", "-f", str(priority), "/bin/true"],
                     stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True)
         return True
     except Exception:
         return False
+
+
+def _resolve_recording_profile(settings: dict) -> tuple[str, dict]:
+    profiles_cfg = settings.get("recording_profiles", {})
+    active = str(profiles_cfg.get("active", "B"))
+    table = profiles_cfg.get("profiles", {})
+    profile = table.get(active) or table.get("B") or {}
+    return active, profile
+
+
+def _resolve_launch_policy(settings: dict) -> dict:
+    launch_cfg = settings.get("launch", {})
+    return {
+        "rt_mode": str(launch_cfg.get("rt_mode", "off")).lower(),
+        "rt_priority": int(launch_cfg.get("rt_priority", 20)),
+        "cpu_affinity": launch_cfg.get("cpu_affinity", "1-3"),
+    }
 
 # ───────────────────────── zoom default ──────────────────────────
 def _seed_default_zoom(redis_ctl):
@@ -134,16 +150,24 @@ class CinePiProcess(Thread):
         self,
         redis_controller,
         sensor_detect,
+        settings,
         cam: CameraInfo,
         primary: bool,
         multi: bool,
+        profile_name: str,
+        profile: dict,
+        launch_policy: dict,
     ):
         super().__init__(daemon=True)
         self.redis_controller = redis_controller
         self.sensor_detect = sensor_detect
+        self.settings = settings
         self.cam = cam
         self.primary = primary
         self.multi = multi
+        self.profile_name = profile_name
+        self.profile = profile
+        self.launch_policy = launch_policy
         self.proc: Optional[subprocess.Popen] = None
         self.message = Event()
         self.out_q, self.err_q = Queue(), Queue()
@@ -160,31 +184,34 @@ class CinePiProcess(Thread):
         self.redis_channel = 'cinepi.last_dng'          # publish JSON here
         
         # load per-camera geometry from settings
-        geo = _SETTINGS.get('geometry', {})
+        geo = self.settings.get('geometry', {})
         self.geometry = geo.get(self.cam.port, {})
         
         # load per-camera output settings (e.g., HDMI port)
-        out_cfg = _SETTINGS.get('output', {})
+        out_cfg = self.settings.get('output', {})
         self.output = out_cfg.get(self.cam.port, {})
+        self.stdout_metadata_enabled = bool(self.settings.get("stdout_metadata", {}).get("enabled", False))
 
 
     def run(self):
         cine_cmd = ['cinepi-raw'] + self._build_args()
 
         prefix = []
-        if _rt_permitted():
-            # SCHED_FIFO 70 for the whole process (capture threads benefit most)
-            prefix += ["chrt", "-f", "70"]
-        else:
-            logging.warning("[%s] RT scheduling not permitted; running without chrt", self.cam.port)
+        if self.launch_policy["rt_mode"] == "fifo":
+            prio = self.launch_policy["rt_priority"]
+            if _rt_permitted(prio):
+                prefix += ["chrt", "-f", str(prio)]
+            else:
+                logging.warning("[%s] RT scheduling requested but unavailable; launching without chrt", self.cam.port)
 
         # Best-effort I/O (no CAP_SYS_ADMIN needed)
         if shutil.which("ionice"):
             prefix += ["ionice", "-c2", "-n0"]
 
         # Keep the entire process off CPU0; allow 1–3 (GUI/OS left on 0)
-        if shutil.which("taskset"):
-            prefix += ["taskset", "-c", "1-3"]
+        affinity = self.launch_policy.get("cpu_affinity")
+        if affinity and shutil.which("taskset"):
+            prefix += ["taskset", "-c", str(affinity)]
 
         cmd = (prefix + cine_cmd) if prefix else cine_cmd
         logging.info('[%s] Launch: %s', self.cam, cmd)
@@ -223,7 +250,7 @@ class CinePiProcess(Thread):
 
             # 3. special-case the new encoder message --------------------------
             m = dng_rx.search(line)
-            if m:
+            if m and self.stdout_metadata_enabled:
                 fname   = m.group(1)
                 payload = {
                     'type': 'dng',
@@ -275,7 +302,7 @@ class CinePiProcess(Thread):
         anam = float(self.redis_controller.get_value(ParameterKey.ANAMORPHIC_FACTOR.value) or 1.0)
         
         # Get HDMI resolution from settings
-        hdmi_config = _SETTINGS.get("hdmi_display", {})
+        hdmi_config = self.settings.get("hdmi_display", {})
         fw, fh = hdmi_config.get("width", 1920), hdmi_config.get("height", 1080)
         
         px, py = 94, 50
@@ -355,14 +382,21 @@ class CinePiProcess(Thread):
         else:
             args += ['--nopreview']
             
-        # ───── Option A: Stable 24p (3 enc, 1 writer; keep CPU3 mostly free for capture) ─────
+        # Runtime profile (B is baseline for IMX585 migration)
+        encode_workers = int(self.profile.get("encode_workers", 2))
+        disk_workers = int(self.profile.get("disk_workers", 1))
+        encode_affinity = str(self.profile.get("encode_affinity", "2-3"))
+        disk_affinity = str(self.profile.get("disk_affinity", "1"))
+        encode_nice = int(self.profile.get("encode_nice", -6))
+        disk_nice = int(self.profile.get("disk_nice", -12))
+
         args += [
-            "--encode-workers",  "4",
-            "--disk-workers",    "2",
-            "--encode-affinity", "1-2",   # encoders on CPUs 1–2
-            "--disk-affinity",   "2",     # writer on CPU 2 (near NVMe IRQs you’ll pin)
-            "--encode-nice",     "-10",
-            "--disk-nice",       "-5",
+            "--encode-workers",  str(encode_workers),
+            "--disk-workers",    str(disk_workers),
+            "--encode-affinity", encode_affinity,
+            "--disk-affinity",   disk_affinity,
+            "--encode-nice",     str(encode_nice),
+            "--disk-nice",       str(disk_nice),
         ]
         
         return args
@@ -383,9 +417,10 @@ class CinePiManager:
     the very first REC edge is seen by every camera.
     """
 
-    def __init__(self, redis_controller, sensor_detect):
+    def __init__(self, redis_controller, sensor_detect, settings=None):
         self.redis_controller = redis_controller
         self.sensor_detect    = sensor_detect
+        self.settings = settings or load_settings(SETTINGS_FILE)
         self.processes: List[CinePiProcess] = []
         self.message = Event()                        # fan-out for log relay
 
@@ -403,6 +438,11 @@ class CinePiManager:
         # Seed the zoom factor before cinepi-raw processes read it
         # ------------------------------------------------------------------
         _seed_default_zoom(self.redis_controller)
+
+        profile_name, profile = _resolve_recording_profile(self.settings)
+        launch_policy = _resolve_launch_policy(self.settings)
+        logging.info("launch_policy=%s", json.dumps(launch_policy, separators=(",", ":")))
+        logging.info("recording_profile=%s resolved=%s", profile_name, json.dumps(profile, separators=(",", ":")))
 
         # ── 1. discovery ───────────────────────────────────────────
         cams = discover_cameras()                    # helper unchanged
@@ -463,9 +503,13 @@ class CinePiManager:
             proc = CinePiProcess(
                 self.redis_controller,
                 self.sensor_detect,
+                self.settings,
                 cam,
                 primary=(i == 0),
                 multi=multi,
+                profile_name=profile_name,
+                profile=profile,
+                launch_policy=launch_policy,
             )
             proc.message.subscribe(self.message.emit)
             proc.start()

--- a/src/module/config_loader.py
+++ b/src/module/config_loader.py
@@ -58,6 +58,57 @@ def load_settings(filename: str | Path) -> dict:
     )
     settings.setdefault("welcome_message", "THIS IS A COOL MACHINE")
     settings.setdefault("welcome_image", None)
+    settings.setdefault("state_model", "v1")
+
+    launch_cfg = settings.setdefault("launch", {})
+    launch_cfg.setdefault("rt_mode", "off")
+    launch_cfg.setdefault("rt_priority", 20)
+    launch_cfg.setdefault("cpu_affinity", "1-3")
+    settings["launch"] = launch_cfg
+
+    recording_profiles = settings.setdefault("recording_profiles", {})
+    recording_profiles.setdefault("active", "B")
+    profile_table = recording_profiles.setdefault("profiles", {})
+    profile_table.setdefault(
+        "A",
+        {
+            "encode_workers": 3,
+            "disk_workers": 2,
+            "encode_affinity": "1-2",
+            "disk_affinity": "2",
+            "encode_nice": -10,
+            "disk_nice": -5,
+        },
+    )
+    profile_table.setdefault(
+        "B",
+        {
+            "encode_workers": 2,
+            "disk_workers": 1,
+            "encode_affinity": "2-3",
+            "disk_affinity": "1",
+            "encode_nice": -6,
+            "disk_nice": -12,
+        },
+    )
+    profile_table.setdefault(
+        "C",
+        {
+            "encode_workers": 2,
+            "disk_workers": 2,
+            "encode_affinity": "1-2",
+            "disk_affinity": "3",
+            "encode_nice": -8,
+            "disk_nice": -8,
+        },
+    )
+    profile_table.setdefault("custom", dict(profile_table["B"]))
+    recording_profiles["profiles"] = profile_table
+    settings["recording_profiles"] = recording_profiles
+
+    stdout_metadata_cfg = settings.setdefault("stdout_metadata", {})
+    stdout_metadata_cfg.setdefault("enabled", False)
+    settings["stdout_metadata"] = stdout_metadata_cfg
 
     # ── preview / zoom defaults ──────────────────────────────────────────
     preview_defaults = {

--- a/src/module/performance_analyzer.py
+++ b/src/module/performance_analyzer.py
@@ -42,6 +42,9 @@ class PerformanceAnalyzer:
         "wall_time_iso",
         "sensor_timestamp_ns",
         "timestamp_key_used",
+        "cp_stats_seq",
+        "cp_stats_seq_gap",
+        "cp_stats_timestamp_gap",
         "frame_count",
         "fps_expected",
         "fps_actual",
@@ -52,6 +55,11 @@ class PerformanceAnalyzer:
         "is_buffering",
         "is_writing_buf",
         "write_speed_mb_s",
+        "encode_queue_size",
+        "disk_queue_size",
+        "ram_buffers",
+        "encode_latency_ms",
+        "disk_latency_ms",
         "cpu_percent_total",
         "cpu_percent_per_core",
         "ram_percent",
@@ -105,6 +113,9 @@ class PerformanceAnalyzer:
         self._drop_count = 0
         self._prev_timestamp_ns = None
         self._prev_frame_count = None
+        self._prev_stats_seq = None
+        self._stats_seq_gap_events = 0
+        self._timestamp_gap_events = 0
         self._start_monotonic = None
         self._last_disk_write_bytes = None
         self._last_net_tx = None
@@ -220,6 +231,9 @@ class PerformanceAnalyzer:
         self._drop_count = 0
         self._prev_timestamp_ns = None
         self._prev_frame_count = None
+        self._prev_stats_seq = None
+        self._stats_seq_gap_events = 0
+        self._timestamp_gap_events = 0
         self._start_monotonic = time.monotonic()
 
         disk = psutil.disk_io_counters() if psutil and hasattr(psutil, "disk_io_counters") else None
@@ -304,6 +318,7 @@ class PerformanceAnalyzer:
 
         sensor_timestamp_ns, timestamp_key_used = self._extract_sensor_timestamp(stats_data)
         frame_count = self._to_int(stats_data.get("frameCount"))
+        cp_stats_seq, cp_stats_seq_gap = self._extract_seq_gap(stats_data)
 
         fps_expected = self._read_float(ParameterKey.FPS.value)
         fps_actual = self._to_float(stats_data.get("framerate"))
@@ -311,6 +326,9 @@ class PerformanceAnalyzer:
             fps_actual = self._read_float(ParameterKey.FPS_ACTUAL.value)
 
         dropped_frame_flag, drop_reason = self._detect_drop(sensor_timestamp_ns, frame_count, fps_expected, fps_actual)
+        cp_stats_timestamp_gap = 1 if drop_reason == "timestamp_gap" else 0
+        if cp_stats_timestamp_gap:
+            self._timestamp_gap_events += 1
 
         buffer_used = self._to_int(stats_data.get("bufferSize"))
         if buffer_used is None:
@@ -324,6 +342,9 @@ class PerformanceAnalyzer:
             "wall_time_iso": now_iso,
             "sensor_timestamp_ns": sensor_timestamp_ns,
             "timestamp_key_used": timestamp_key_used,
+            "cp_stats_seq": cp_stats_seq,
+            "cp_stats_seq_gap": cp_stats_seq_gap,
+            "cp_stats_timestamp_gap": cp_stats_timestamp_gap,
             "frame_count": frame_count,
             "fps_expected": fps_expected,
             "fps_actual": fps_actual,
@@ -334,6 +355,11 @@ class PerformanceAnalyzer:
             "is_buffering": self._read_bool(ParameterKey.IS_BUFFERING.value),
             "is_writing_buf": self._read_bool(ParameterKey.IS_WRITING_BUF.value),
             "write_speed_mb_s": self._parse_write_speed(self.redis_controller.get_value(ParameterKey.WRITE_SPEED_TO_DRIVE.value)),
+            "encode_queue_size": self._to_int(stats_data.get("encode_queue_size")),
+            "disk_queue_size": self._to_int(stats_data.get("disk_queue_size")),
+            "ram_buffers": self._to_int(stats_data.get("ram_buffers")),
+            "encode_latency_ms": self._to_float(stats_data.get("encode_latency_ms")),
+            "disk_latency_ms": self._to_float(stats_data.get("disk_latency_ms")),
             "cpu_percent_total": psutil.cpu_percent(interval=None) if psutil else None,
             "cpu_percent_per_core": json.dumps(psutil.cpu_percent(interval=None, percpu=True)) if psutil else "[]",
             "ram_percent": psutil.virtual_memory().percent if psutil else None,
@@ -355,6 +381,16 @@ class PerformanceAnalyzer:
         }
 
         return row
+
+    def _extract_seq_gap(self, stats_data):
+        seq = self._to_int(stats_data.get("stats_seq"))
+        gap = 0
+        if seq is not None and self._prev_stats_seq is not None and seq > self._prev_stats_seq + 1:
+            gap = 1
+            self._stats_seq_gap_events += 1
+        if seq is not None:
+            self._prev_stats_seq = seq
+        return seq, gap
 
     def _should_finish(self, row):
         if self._target_mode == "seconds":
@@ -409,6 +445,8 @@ class PerformanceAnalyzer:
             "target_amount": self._target_amount,
             "rows_written": self._rows,
             "drop_candidates": self._drop_count,
+            "stats_seq_gap_events": self._stats_seq_gap_events,
+            "timestamp_gap_events": self._timestamp_gap_events,
             "start_recording_already_active": self._start_is_recording,
             "finished_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
         }

--- a/src/module/recording_state.py
+++ b/src/module/recording_state.py
@@ -1,0 +1,80 @@
+import threading
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RecordingStateSnapshot:
+    frame_count: int | None = None
+    framerate: float | None = None
+    sensor_timestamp_ns: int | None = None
+    timestamp_ns: int | None = None
+    timestamp_cam0_ns: int | None = None
+    timestamp_cam1_ns: int | None = None
+    buffer_size: int | None = None
+    encode_queue_size: int | None = None
+    disk_queue_size: int | None = None
+    ram_buffers: int | None = None
+    encode_latency_ms: float | None = None
+    disk_latency_ms: float | None = None
+    stats_seq: int | None = None
+    gap_count: int = 0
+
+
+class RecordingStateAggregator:
+    """Authoritative cp_stats -> canonical runtime recording state."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._state = RecordingStateSnapshot()
+        self._last_stats_seq: int | None = None
+
+    @staticmethod
+    def _to_int(value):
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _to_float(value):
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    def ingest_cp_stats(self, stats_data: dict) -> RecordingStateSnapshot:
+        with self._lock:
+            current = self._state
+            stats_seq = self._to_int(stats_data.get("stats_seq"))
+            gap_count = current.gap_count
+            if stats_seq is not None and self._last_stats_seq is not None and stats_seq > self._last_stats_seq + 1:
+                gap_count += 1
+            if stats_seq is not None:
+                self._last_stats_seq = stats_seq
+
+            sensor_timestamp = self._to_int(stats_data.get("sensorTimestamp"))
+            timestamp = self._to_int(stats_data.get("timestamp"))
+            timestamp_cam0 = self._to_int(stats_data.get("timestamp_cam0"))
+            timestamp_cam1 = self._to_int(stats_data.get("timestamp_cam1"))
+
+            self._state = RecordingStateSnapshot(
+                frame_count=self._to_int(stats_data.get("frameCount")),
+                framerate=self._to_float(stats_data.get("framerate")),
+                sensor_timestamp_ns=sensor_timestamp,
+                timestamp_ns=timestamp,
+                timestamp_cam0_ns=timestamp_cam0,
+                timestamp_cam1_ns=timestamp_cam1,
+                buffer_size=self._to_int(stats_data.get("bufferSize")),
+                encode_queue_size=self._to_int(stats_data.get("encode_queue_size")),
+                disk_queue_size=self._to_int(stats_data.get("disk_queue_size")),
+                ram_buffers=self._to_int(stats_data.get("ram_buffers")),
+                encode_latency_ms=self._to_float(stats_data.get("encode_latency_ms")),
+                disk_latency_ms=self._to_float(stats_data.get("disk_latency_ms")),
+                stats_seq=stats_seq,
+                gap_count=gap_count,
+            )
+            return self._state
+
+    def snapshot(self) -> RecordingStateSnapshot:
+        with self._lock:
+            return self._state

--- a/src/module/redis_listener.py
+++ b/src/module/redis_listener.py
@@ -5,6 +5,7 @@ import datetime
 import json
 from collections import deque
 from module.redis_controller import ParameterKey
+from module.recording_state import RecordingStateAggregator
 
 import os
 import re
@@ -13,7 +14,7 @@ import math
 import statistics
 
 class RedisListener:
-    def __init__(self, redis_controller, ssd_monitor, framerate_callback=None, host='localhost', port=6379, db=0):
+    def __init__(self, redis_controller, ssd_monitor, framerate_callback=None, host='localhost', port=6379, db=0, state_model='v1'):
         self.redis_client = redis.StrictRedis(host=host, port=port, db=db)
         
         self.pubsub_stats = self.redis_client.pubsub()
@@ -98,6 +99,9 @@ class RedisListener:
 
         self.fps_at_rec_start = None
         self.fps_correction_factor_at_rec_start: float | None = None
+        self.state_model = state_model
+        self.state_aggregator = RecordingStateAggregator() if state_model == 'v2' else None
+        logging.info("recording_state_model=%s", self.state_model)
 
         self.recording_was_preroll = False
 
@@ -306,14 +310,25 @@ class RedisListener:
                 if message_data.startswith("{") and message_data.endswith("}"):
                     try:
                         stats_data = json.loads(message_data)
-                        buffer_size = stats_data.get('bufferSize', None)
-                        self.frame_count = stats_data.get('frameCount', None)
+                        if self.state_aggregator is not None:
+                            snapshot = self.state_aggregator.ingest_cp_stats(stats_data)
+                            buffer_size = snapshot.buffer_size
+                            self.frame_count = snapshot.frame_count
+                            sensor_timestamp = snapshot.sensor_timestamp_ns
+                            timestamp = snapshot.timestamp_ns
+                            timestamp_cam0 = snapshot.timestamp_cam0_ns
+                            timestamp_cam1 = snapshot.timestamp_cam1_ns
+                            self.current_framerate = snapshot.framerate
+                        else:
+                            buffer_size = stats_data.get('bufferSize', None)
+                            self.frame_count = stats_data.get('frameCount', None)
+                            sensor_timestamp = stats_data.get('sensorTimestamp', None)
+                            timestamp = stats_data.get('timestamp')
+                            timestamp_cam0 = stats_data.get('timestamp_cam0')
+                            timestamp_cam1 = stats_data.get('timestamp_cam1')
+                            self.current_framerate = stats_data.get('framerate', None)
+
                         color_temp = stats_data.get('colorTemp', None)
-                        sensor_timestamp = stats_data.get('sensorTimestamp', None)
-                        timestamp = stats_data.get('timestamp')
-                        timestamp_cam0 = stats_data.get('timestamp_cam0')
-                        timestamp_cam1 = stats_data.get('timestamp_cam1')
-                        self.current_framerate = stats_data.get('framerate', None)
 
                         if color_temp:
                             self.colorTemp = color_temp

--- a/src/settings.json
+++ b/src/settings.json
@@ -1,9 +1,7 @@
 {
   "$schema": "./settings.schema.json",
-
   "welcome_message": "THIS IS A COOL MACHINE",
   "welcome_image": null,
-
   "system": {
     "wifi_hotspot": {
       "name": "CinePi",
@@ -11,7 +9,6 @@
       "enabled": true
     }
   },
-
   "geometry": {
     "cam0": {
       "rotate_180": false,
@@ -21,10 +18,9 @@
     "cam1": {
       "rotate_180": false,
       "horizontal_flip": false,
-      "vertical_flip":false
+      "vertical_flip": false
     }
   },
-
   "output": {
     "cam0": {
       "hdmi_port": 0
@@ -33,143 +29,253 @@
       "hdmi_port": 1
     }
   },
-
   "hdmi_gui": {
     "buffer_vu_meter": false,
     "vu_meter_hatch_lines": true
   },
-
   "hdmi_display": {
     "width": 1920,
     "height": 1080
   },
-
   "preview": {
     "default_zoom": 1.2,
-    "zoom_steps":   [1.1, 2.0]
+    "zoom_steps": [
+      1.1,
+      2.0
+    ]
   },
-
   "anamorphic_preview": {
-      "default_anamorphic_factor": 1,
-    "anamorphic_steps": [1, 1.33, 2.0]
+    "default_anamorphic_factor": 1,
+    "anamorphic_steps": [
+      1,
+      1.33,
+      2.0
+    ]
   },
-
   "gpio_output": {
     "pwm_pin": 19,
-    "rec_out_pin": [6, 21]
+    "rec_out_pin": [
+      6,
+      21
+    ]
   },
-  
   "arrays": {
-    "iso_steps": [100, 200, 400, 640, 800, 1200, 1600, 2500, 3200],
-    "shutter_a_steps": [1, 45, 90, 135, 172.8, 180, 225, 270, 315, 346.6, 360],
-    "fps_steps": [1, 2, 4, 8, 12, 16, 18, 24, 25, 33, 40, 50],
-    "wb_steps": [3200, 4400, 5600]
+    "iso_steps": [
+      100,
+      200,
+      400,
+      640,
+      800,
+      1200,
+      1600,
+      2500,
+      3200
+    ],
+    "shutter_a_steps": [
+      1,
+      45,
+      90,
+      135,
+      172.8,
+      180,
+      225,
+      270,
+      315,
+      346.6,
+      360
+    ],
+    "fps_steps": [
+      1,
+      2,
+      4,
+      8,
+      12,
+      16,
+      18,
+      24,
+      25,
+      33,
+      40,
+      50
+    ],
+    "wb_steps": [
+      3200,
+      4400,
+      5600
+    ]
   },
-  
   "settings": {
-    "light_hz": [50, 60],
+    "light_hz": [
+      50,
+      60
+    ],
     "conform_frame_rate": 24
   },
-  
   "analog_controls": {
     "iso_pot": "None",
     "shutter_a_pot": "None",
     "fps_pot": "None",
     "wb_pot": "None"
   },
-  
   "free_mode": {
     "iso_free": false,
     "shutter_a_free": false,
     "fps_free": true,
     "wb_free": false
   },
-
   "resolutions": {
-    "k_steps": [1.5, 2, 4],
-    "bit_depths": [10, 12],
+    "k_steps": [
+      1.5,
+      2,
+      4
+    ],
+    "bit_depths": [
+      10,
+      12
+    ],
     "custom_modes": {}
   },
-
-"buttons": [
+  "buttons": [
     {
       "pin": 5,
       "pull_up": true,
       "debounce_time": 0.1,
-      "press_action": {"method": "rec"}
+      "press_action": {
+        "method": "rec"
+      }
     },
     {
       "pin": 7,
       "pull_up": true,
       "debounce_time": 0.1,
-      "press_action": {"method": "rec"}
+      "press_action": {
+        "method": "rec"
+      }
     },
     {
       "pin": 16,
       "pull_up": true,
       "debounce_time": 0.1,
-      "press_action": {"method": "set_fps_double"}
+      "press_action": {
+        "method": "set_fps_double"
+      }
     },
     {
       "pin": 13,
       "pull_up": "False",
       "debounce_time": "0.1",
       "press_action": "None",
-      "single_click_action": {"method": "set_resolution"},
-      "double_click_action": {"method": "restart_cinemate"},
-      "triple_click_action": {"method": "reboot"},
-      "hold_action": {"method": "toggle_mount"}
+      "single_click_action": {
+        "method": "set_resolution"
+      },
+      "double_click_action": {
+        "method": "restart_cinemate"
+      },
+      "triple_click_action": {
+        "method": "reboot"
+      },
+      "hold_action": {
+        "method": "toggle_mount"
+      }
     }
   ],
-
   "two_way_switches": [
-      {
-        "pin": 24,
-        "state_on_action": {"method": "set_zoom", "args": [2]},
-        "state_off_action": {"method": "set_zoom", "args": [1]}
+    {
+      "pin": 24,
+      "state_on_action": {
+        "method": "set_zoom",
+        "args": [
+          2
+        ]
       },
+      "state_off_action": {
+        "method": "set_zoom",
+        "args": [
+          1
+        ]
+      }
+    },
     {
       "pin": 22,
-      "state_on_action": {"method": "set_shutter_a_sync_mode", "args": [1]},
-      "state_off_action": {"method": "set_shutter_a_sync_mode", "args": [0]}
+      "state_on_action": {
+        "method": "set_shutter_a_sync_mode",
+        "args": [
+          1
+        ]
+      },
+      "state_off_action": {
+        "method": "set_shutter_a_sync_mode",
+        "args": [
+          0
+        ]
+      }
     },
     {
       "pin": 18,
-      "state_on_action": {"method": "set_filter", "args": [0]},
-      "state_off_action": {"method": "set_filter", "args": [1]}
+      "state_on_action": {
+        "method": "set_filter",
+        "args": [
+          0
+        ]
+      },
+      "state_off_action": {
+        "method": "set_filter",
+        "args": [
+          1
+        ]
+      }
     }
   ],
-  
   "quad_rotary_controller": {
     "enabled": false,
     "encoders": {
       "0": {
         "setting_name": "iso",
         "button": {
-	  "press_action": {"method": "set_zoom"},
-	  "hold_action": {"method": "safe_shutdown"}}
+          "press_action": {
+            "method": "set_zoom"
+          },
+          "hold_action": {
+            "method": "safe_shutdown"
+          }
+        }
       },
       "1": {
         "setting_name": "shutter_a",
-        "button": {"press_action": {"method": "set_shutter_a_sync_mode"}}
+        "button": {
+          "press_action": {
+            "method": "set_shutter_a_sync_mode"
+          }
+        }
       },
       "2": {
         "setting_name": "fps",
-        "button": {"press_action": {"method": "set_fps_double"}}
+        "button": {
+          "press_action": {
+            "method": "set_fps_double"
+          }
+        }
       },
       "3": {
         "setting_name": "wb",
         "button": {
           "press_action": "None",
-          "single_click_action": {"method": "set_resolution"},
-          "double_click_action": {"method": "restart_cinemate"},
-          "triple_click_action": {"method": "reboot"},
-          "hold_action": {"method": "toggle_mount"}
+          "single_click_action": {
+            "method": "set_resolution"
+          },
+          "double_click_action": {
+            "method": "restart_cinemate"
+          },
+          "triple_click_action": {
+            "method": "reboot"
+          },
+          "hold_action": {
+            "method": "toggle_mount"
+          }
+        }
       }
     }
-    }
   },
-
   "i2c_oled": {
     "enabled": false,
     "width": 128,
@@ -179,8 +285,52 @@
       "iso",
       "tc_cam0",
       "RECORDING_TC"
-
     ]
+  },
+  "state_model": "v1",
+  "launch": {
+    "rt_mode": "off",
+    "rt_priority": 20,
+    "cpu_affinity": "1-3"
+  },
+  "recording_profiles": {
+    "active": "B",
+    "profiles": {
+      "A": {
+        "encode_workers": 3,
+        "disk_workers": 2,
+        "encode_affinity": "1-2",
+        "disk_affinity": "2",
+        "encode_nice": -10,
+        "disk_nice": -5
+      },
+      "B": {
+        "encode_workers": 2,
+        "disk_workers": 1,
+        "encode_affinity": "2-3",
+        "disk_affinity": "1",
+        "encode_nice": -6,
+        "disk_nice": -12
+      },
+      "C": {
+        "encode_workers": 2,
+        "disk_workers": 2,
+        "encode_affinity": "1-2",
+        "disk_affinity": "3",
+        "encode_nice": -8,
+        "disk_nice": -8
+      },
+      "custom": {
+        "encode_workers": 2,
+        "disk_workers": 1,
+        "encode_affinity": "2-3",
+        "disk_affinity": "1",
+        "encode_nice": -6,
+        "disk_nice": -12
+      }
+    }
+  },
+  "stdout_metadata": {
+    "enabled": false
   }
-  
 }


### PR DESCRIPTION
### Motivation
- Reduce scheduler-starvation risk by making cinepi-raw RT scheduling and CPU affinity configurable and conservative by default (`rt_mode=off`).
- Decouple Cinemate runtime state from noisy per-frame stdout metadata so core logic no longer relies on `DNG written:` log lines.
- Improve observability for 4K@25 IMX585 workflows by ingesting explicit low-overhead `cp_stats` fields (queue sizes, latencies, sequence) and adding continuity diagnostics.
- Keep Profile B as the temporary default tuning baseline while enabling a clean state-model migration path with rollback to `state_model=v1`.

### Description
- Added a canonical runtime recording state aggregator in `src/module/recording_state.py` (`RecordingStateAggregator`) which ingests `cp_stats` and exposes an immutable `RecordingStateSnapshot` to consumers, with simple gap detection via `stats_seq`.
- Introduced the `state_model` feature flag (`v1|v2`) in config and wired `RedisListener` to use the aggregator when `state_model='v2'`, preserving `v1` behavior as a rollback path; `main.py` now propagates the chosen `state_model` to the listener.
- Hardened process-launch policy in `cinepi_multi` by adding config-only knobs (`launch.rt_mode`, `launch.rt_priority`, `launch.cpu_affinity`) and a profile resolver for `recording_profiles` (`A/B/C/custom`), keeping Profile B as the default baseline; effective launch policy and resolved profile are logged on startup.
- Removed reliance on per-frame stdout metadata for core state by making `DNG written:` parsing optional and controlled via `stdout_metadata.enabled` (default: `false`), so stdout metadata becomes best-effort only.
- Extended `PerformanceAnalyzer` to ingest and persist new cp_stats-derived metrics and continuity diagnostics: added CSV columns (`cp_stats_seq`, `cp_stats_seq_gap`, `cp_stats_timestamp_gap`, `encode_queue_size`, `disk_queue_size`, `ram_buffers`, `encode_latency_ms`, `disk_latency_ms`) and summary counters (`stats_seq_gap_events`, `timestamp_gap_events`).
- Updated config loader defaults and `src/settings.json` to include `state_model`, `launch`, `recording_profiles`, and `stdout_metadata` settings; added migration docs (`docs/state-model-migration.md`) and cp_stats fields note in `docs/redis-keys.md`.
- Tests and small helpers: added `/_test/test_recording_state.py`, `/_test/test_cinepi_multi_policy.py` and extended analyzer tests in `_test/test_performance_analyzer.py` to cover seq-gap logic and profile/launch resolvers.

### Testing
- Ran unit tests: `python -m pytest -q _test/test_performance_analyzer.py _test/test_recording_state.py _test/test_cinepi_multi_policy.py` and all tests passed (`9 passed`).
- Compiled modules to smoke-check bytecode: `python -m compileall -q src/module` and compilation succeeded.
- Notes on runtime validation: include recommended `analyze` validation step in docs (`analyze s 60`) to produce `_analysis` CSV + summary with the new metrics for live cp_stats validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad71ad0fe08332a8a5c8d5aa6bbca1)