### PR TITLE
Apply cli_relay policy to Cinemate Redis/state relay output

### DIFF
--- a/_test/test_redis_cli_relay.py
+++ b/_test/test_redis_cli_relay.py
@@ -50,12 +50,21 @@ class TestRedisCliRelayPolicy(unittest.TestCase):
         self.assertTrue(policy.should_relay("frame", "Frame 1"))
         self.assertFalse(policy.should_relay("frame", "Frame 2"))
         self.assertTrue(policy.should_relay("frame", "Frame 3"))
-        self.assertFalse(policy.should_relay("event", "Changed value: rec = 1"))
+
+    def test_frame_mode_keeps_event_lines(self):
+        policy = _CliRelayPolicy({"mode": "frame", "filters": [], "frame_sample_n": 2})
+        self.assertTrue(policy.should_relay("event", "Changed value: rec = 1"))
 
     def test_filters_applied_after_mode(self):
         policy = _CliRelayPolicy({"mode": "event", "filters": ["rec"], "frame_sample_n": 1})
         self.assertTrue(policy.should_relay("event", "Changed value: rec = 1"))
         self.assertFalse(policy.should_relay("event", "Changed value: iso = 200"))
+
+    def test_filters_apply_to_frame_mode_events_and_frames(self):
+        policy = _CliRelayPolicy({"mode": "frame", "filters": ["rec"], "frame_sample_n": 1})
+        self.assertTrue(policy.should_relay("event", "Changed value: rec = 1"))
+        self.assertFalse(policy.should_relay("event", "Changed value: iso = 100"))
+        self.assertFalse(policy.should_relay("frame", "Frame 1"))
 
 
 if __name__ == "__main__":

--- a/docs/settings-json.md
+++ b/docs/settings-json.md
@@ -137,9 +137,8 @@ General options for runtime behaviour.
 
 ## cli_relay
 
-Controls how much runtime telemetry is relayed into Cinemate logs/CLI output
-(both `cinepi-raw` stdout relay and Cinemate Redis/state change relay).
-Controls how much `cinepi-raw` stdout is relayed into Cinemate logs/CLI output.
+Controls runtime telemetry relay into Cinemate logs/CLI output for both
+`cinepi-raw` stdout and Cinemate Redis/state change lines.
 
 ```json
 "cli_relay": {
@@ -150,10 +149,10 @@ Controls how much `cinepi-raw` stdout is relayed into Cinemate logs/CLI output.
 }
 ```
 
-- `mode` – `off`, `event`, or `frame`.
+- `mode` – `off`, `event`, or `frame` for both stdout and Redis/state relay paths.
 - `level` – relay lines via `logging.info` or `logging.debug`.
 - `filters` – optional allowlist tokens; when set, a relayed line must contain at least one token.
-- `frame_sample_n` – only used in `frame` mode; relay every Nth frame line.
+- `frame_sample_n` – only used in `frame` mode; relay every Nth frame line (including Cinemate `framecount` relay lines).
 
 Examples:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,4 +1,4 @@
-
 ## CLI relay performance
-If runtime logs feel jittery under heavy frame traffic (including per-frame Redis updates such as frame counters), keep `cli_relay.mode` at `event` (default) or set it to `off`. Use `frame` mode only when you need per-frame diagnostics.
-If runtime logs feel jittery under heavy frame traffic, keep `cli_relay.mode` at `event` (default) or set it to `off`. Use `frame` mode only when you need per-frame diagnostics.
+If runtime logs feel jittery under heavy frame traffic (including per-frame Redis updates such as `framecount`), keep `cli_relay.mode` at `event` (default) or set it to `off`.
+
+Use `frame` mode only when you need per-frame diagnostics, then reduce noise by raising `cli_relay.frame_sample_n` (for example `5` or `10`) and adding targeted `cli_relay.filters` tokens.

--- a/src/module/redis_controller.py
+++ b/src/module/redis_controller.py
@@ -15,14 +15,33 @@ from enum import Enum
 import time, math
 
 
+_CLI_RELAY_MODES = {"off", "event", "frame"}
+_CLI_RELAY_LEVELS = {"info", "debug"}
+
+_SUPPRESSED_EVENT_KEYS = {
+    "recording_time",
+    "recording_tc_rec",
+    "recording_time_tod",
+    "framecount_expected",
+    "tc_cam0",
+    "tc_cam1",
+    "fps_actual",
+    "buffer",
+}
+
+
 def _resolve_cli_relay(settings: dict | None) -> dict:
-    relay_cfg = (settings or {}).get("cli_relay", {})
-    mode = relay_cfg.get("mode", "event")
-    if mode not in {"off", "event", "frame"}:
+    settings = settings or {}
+    relay_cfg = settings.get("cli_relay", {})
+    if not isinstance(relay_cfg, dict):
+        relay_cfg = {}
+
+    mode = str(relay_cfg.get("mode", "event")).lower()
+    if mode not in _CLI_RELAY_MODES:
         mode = "event"
 
-    level = relay_cfg.get("level", "info")
-    if level not in {"info", "debug"}:
+    level = str(relay_cfg.get("level", "info")).lower()
+    if level not in _CLI_RELAY_LEVELS:
         level = "info"
 
     filters = relay_cfg.get("filters", [])
@@ -59,7 +78,7 @@ class _CliRelayPolicy:
         if self.mode == "event" and kind != "event":
             return False
 
-        if self.mode == "frame" and kind != "frame":
+        if self.mode == "frame" and kind not in {"frame", "event"}:
             return False
 
         if kind == "frame" and self.mode == "frame":
@@ -224,51 +243,43 @@ class RedisController:
         # cli_relay controls what Cinemate-originated Redis updates are emitted
         # to the CLI/log output path. Core Redis writes/subscriptions are always
         # performed regardless of relay settings.
-        if key_name == ParameterKey.FRAMECOUNT.value:
-            # Consolidated once-per-frame entry
-            rec_secs = self.cache.get(ParameterKey.RECORDING_TIME.value, "0")
-            rec_tc   = self.cache.get(ParameterKey.RECORDING_TC_REC.value, "00:00:00:00")
-            tod_tc   = self.cache.get(ParameterKey.RECORDING_TC_TOD.value, "00:00:00:00")
-            cam0_tc  = self.cache.get(ParameterKey.TC_CAM0.value,          "—")
-            cam1_tc  = self.cache.get(ParameterKey.TC_CAM1.value,          "—")
-
-            # format seconds nicely (fallback to raw string if not numeric)
-            try:
-                rec_secs_fmt = f"{float(rec_secs):.3f}"
-            except ValueError:
-                rec_secs_fmt = rec_secs
-
-            self._relay_cli_line(
-                "frame",
-                (
-                    f"Frame {value} ┃rec={rec_secs_fmt}s "
-                    f"┃tc_rec={rec_tc} ┃tc_tod={tod_tc} "
-                    f"┃cam0={cam0_tc} ┃cam1={cam1_tc}"
-                ),
-            )
-
-        elif key_name.startswith("last_dng_cam"):
-            ram = psutil.virtual_memory().percent
-            self._relay_cli_line("event", f"Changed value: {key_name} = {value} ┃RAM: {ram:.0f}%")
-
-        elif key_name in (
-            ParameterKey.RECORDING_TIME.value,
-            ParameterKey.RECORDING_TC_REC.value,
-            ParameterKey.RECORDING_TC_TOD.value,
-            ParameterKey.FRAMECOUNT_EXPECTED.value,
-            ParameterKey.TC_CAM0.value,
-            ParameterKey.TC_CAM1.value,
-            ParameterKey.FPS_ACTUAL.value,
-            ParameterKey.BUFFER.value,
-        ):
-            # Suppress high-frequency keys
-            pass
-
-        else:
-            self._relay_cli_line("event", f"Changed value: {key_name} = {value}")
+        self._emit_relay_log(key_name, value)
 
         # ─── immediate local notification to subscribers ─────────────
         self.redis_parameter_changed.emit({"key": key_name, "value": str(value)})
+
+    def _emit_relay_log(self, key_name: str, value) -> None:
+        if key_name == ParameterKey.FRAMECOUNT.value:
+            self._relay_cli_line("frame", self._format_frame_relay_message(value))
+            return
+
+        if key_name.startswith("last_dng_cam"):
+            ram = psutil.virtual_memory().percent
+            self._relay_cli_line("event", f"Changed value: {key_name} = {value} ┃RAM: {ram:.0f}%")
+            return
+
+        if key_name in _SUPPRESSED_EVENT_KEYS:
+            return
+
+        self._relay_cli_line("event", f"Changed value: {key_name} = {value}")
+
+    def _format_frame_relay_message(self, frame_value) -> str:
+        rec_secs = self.cache.get(ParameterKey.RECORDING_TIME.value, "0")
+        rec_tc = self.cache.get(ParameterKey.RECORDING_TC_REC.value, "00:00:00:00")
+        tod_tc = self.cache.get(ParameterKey.RECORDING_TC_TOD.value, "00:00:00:00")
+        cam0_tc = self.cache.get(ParameterKey.TC_CAM0.value, "—")
+        cam1_tc = self.cache.get(ParameterKey.TC_CAM1.value, "—")
+
+        try:
+            rec_secs_fmt = f"{float(rec_secs):.3f}"
+        except (TypeError, ValueError):
+            rec_secs_fmt = rec_secs
+
+        return (
+            f"Frame {frame_value} ┃rec={rec_secs_fmt}s "
+            f"┃tc_rec={rec_tc} ┃tc_tod={tod_tc} "
+            f"┃cam0={cam0_tc} ┃cam1={cam1_tc}"
+        )
 
     def _relay_cli_line(self, kind: str, message: str) -> None:
         if not self.cli_relay_policy.should_relay(kind, message):

--- a/src/stream.py
+++ b/src/stream.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import logging
 from app import create_app
 
@@ -5,8 +6,10 @@ def run_app(host='0.0.0.0', port=5000):
     from module.cinepi_controller import CinePiController
     from module.redis_controller import RedisController
     from module.simple_gui import SimpleGUI
+    from module.config_loader import load_settings
 
-    redis_controller = RedisController()
+    settings = load_settings(Path(__file__).with_name("settings.json"))
+    redis_controller = RedisController(settings=settings)
     cinepi_controller = CinePiController()
     simple_gui = SimpleGUI()
 


### PR DESCRIPTION
### Motivation

- Suppress noisy per-frame CLI output emitted from Cinemate-originated Redis updates while preserving all Redis writes and pub/sub behavior. 
- Ensure the runtime `cli_relay` block in `settings.json` controls both `cinepi-raw` stdout relay and Cinemate’s own Redis/state CLI relay path. 
- Centralize relay logic so sampling, mode, level and filters behave consistently for both stdout and Redis/state lines. 
- Add focused unit coverage and docs to make relay semantics and troubleshooting clear.

### Description

- Add normalized relay constants and validation in `redis_controller` (`_CLI_RELAY_MODES`, `_CLI_RELAY_LEVELS`) and robust `_resolve_cli_relay()` to clamp/clean `mode`, `level`, `filters`, and `frame_sample_n`.
- Introduce `_SUPPRESSED_EVENT_KEYS` and central relay helpers `_emit_relay_log()` and `_format_frame_relay_message()` in `RedisController` so Redis/state emission is routed through `_relay_cli_line()` and obeys the same policy/filters/sampling as stdout relay.
- Adjust `_CliRelayPolicy.should_relay()` so `off` drops all, `event` preserves only event lines, and `frame` samples frame lines while still allowing event lines through the same filter gate.
- Wire runtime settings into the web `stream.py` bootstrap by loading `settings.json` and passing `settings` into `RedisController` so the configured `cli_relay` block is used at startup.
- Extend unit tests in `_test/test_redis_cli_relay.py` to cover defaults, validation, `off`/`event`/`frame` behavior, sampling, and filters; update docs (`docs/settings-json.md`, `docs/troubleshooting.md`) to clarify that `cli_relay` now controls both stdout and Redis/state relay and provide jitter troubleshooting guidance.

### Testing

- Ran `python -m unittest _test/test_redis_cli_relay.py _test/test_config_loader_cli_relay.py` which executed the focused relay/config tests; all tests passed (`Ran 11 tests … OK`).
- No other automated test suites were modified or executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af3e0e882c83328f10ec9c46f897ec)