### PR TITLE
Add REC-tone PWM support with hardware/software fallback

### DIFF
--- a/resources/settings/settings_default.json
+++ b/resources/settings/settings_default.json
@@ -1,7 +1,10 @@
 {   
   "gpio_output": {
     "pwm_pin": 19,
-    "rec_out_pin": [6, 21]
+    "rec_out_pin": [6, 21],
+    "rec_tone_pin": [],
+    "rec_tone_frequency_hz": 1000,
+    "rec_tone_duty_cycle": 50
     },
 
   "arrays": {

--- a/src/main.py
+++ b/src/main.py
@@ -226,7 +226,12 @@ def initialize_system(settings):
     sensor_detect = SensorDetect(settings)
     ssd_monitor = SSDMonitor(redis_controller=redis_controller)
     usb_monitor = USBMonitor(ssd_monitor)
-    gpio_output = GPIOOutput(rec_out_pins=settings["gpio_output"]["rec_out_pin"])
+    gpio_output = GPIOOutput(
+        rec_out_pins=settings["gpio_output"]["rec_out_pin"],
+        rec_tone_pins=settings["gpio_output"].get("rec_tone_pin"),
+        rec_tone_frequency_hz=settings["gpio_output"].get("rec_tone_frequency_hz", 1000),
+        rec_tone_duty_cycle=settings["gpio_output"].get("rec_tone_duty_cycle", 50),
+    )
     dmesg_monitor = DmesgMonitor()
     dmesg_monitor.start()
 

--- a/src/module/config_loader.py
+++ b/src/module/config_loader.py
@@ -24,6 +24,9 @@ def load_settings(filename: str | Path) -> dict:
     gpio_defaults = {
         "pwm_pin": 19,
         "rec_out_pin": [6, 21],
+        "rec_tone_pin": [],
+        "rec_tone_frequency_hz": 1000,
+        "rec_tone_duty_cycle": 50,
     }
     gpio_cfg = settings.setdefault("gpio_output", {})
     for k, v in gpio_defaults.items():

--- a/src/module/gpio_output.py
+++ b/src/module/gpio_output.py
@@ -1,17 +1,117 @@
-from module.rpi_gpio_wrapper import RPi
+import importlib
 import logging
+from module.rpi_gpio_wrapper import RPi
+
+
+class _ToneOutput:
+    def start(self):
+        raise NotImplementedError
+
+    def stop(self):
+        raise NotImplementedError
+
+
+class _SoftwarePWMToneOutput(_ToneOutput):
+    def __init__(self, pin, frequency_hz, duty_cycle):
+        self.pin = pin
+        self.frequency_hz = frequency_hz
+        self.duty_cycle = duty_cycle
+        RPi.GPIO.setup(self.pin, RPi.GPIO.OUT)
+
+    def start(self):
+        handle = RPi.GPIO._get_handle()
+        # lgpio PWM uses duty-cycle percentage in the range 0..100.
+        RPi.GPIO.lgpio.tx_pwm(handle, self.pin, self.frequency_hz, self.duty_cycle)
+
+    def stop(self):
+        handle = RPi.GPIO._get_handle()
+        RPi.GPIO.lgpio.tx_pwm(handle, self.pin, 0, 0)
+
+
+class _HardwarePWMToneOutput(_ToneOutput):
+    def __init__(self, pin, frequency_hz, duty_cycle):
+        self.pin = pin
+        self.frequency_hz = frequency_hz
+        self.duty_cycle = duty_cycle
+        self._pwm = None
+
+        # rpi_hardware_pwm maps: GPIO 18 -> channel 0, GPIO 19 -> channel 1.
+        channel = 0 if pin == 18 else 1
+        pwm_module = importlib.import_module("rpi_hardware_pwm")
+        self._pwm = pwm_module.HardwarePWM(
+            pwm_channel=channel,
+            hz=self.frequency_hz,
+            chip=0,
+        )
+
+    def start(self):
+        self._pwm.change_frequency(self.frequency_hz)
+        self._pwm.start(self.duty_cycle)
+
+    def stop(self):
+        self._pwm.stop()
 
 class GPIOOutput:
-    def __init__(self, rec_out_pins=None):
+    HARDWARE_PWM_PINS = {18, 19}
+
+    def __init__(self, rec_out_pins=None, rec_tone_pins=None, rec_tone_frequency_hz=1000, rec_tone_duty_cycle=50):
         self.rec_out_pins = rec_out_pins if rec_out_pins is not None else []  # This is the list of pins for recording
+        self.rec_tone_pins = self._normalize_pins(rec_tone_pins)
+        self.rec_tone_frequency_hz = rec_tone_frequency_hz
+        self.rec_tone_duty_cycle = rec_tone_duty_cycle
+        self._tone_outputs = []
+        self._is_tone_active = False
 
         # Set up each pin in rec_out_pins as an output if the list is provided
         for pin in self.rec_out_pins:
             RPi.GPIO.setup(pin, RPi.GPIO.OUT)
             logging.info(f"REC light instantiated on pin {pin}")
 
+        for pin in self.rec_tone_pins:
+            tone_output = self._create_tone_output(pin)
+            self._tone_outputs.append(tone_output)
+
+    def _normalize_pins(self, pins):
+        if pins is None:
+            return []
+        if isinstance(pins, int):
+            return [pins]
+        return [int(pin) for pin in pins]
+
+    def _create_tone_output(self, pin):
+        if pin in self.HARDWARE_PWM_PINS:
+            try:
+                logging.info(f"REC tone configured for hardware PWM on pin {pin}")
+                return _HardwarePWMToneOutput(pin, self.rec_tone_frequency_hz, self.rec_tone_duty_cycle)
+            except Exception as exc:
+                logging.warning(
+                    "Hardware PWM setup failed on pin %s (%s). Falling back to software PWM.",
+                    pin,
+                    exc,
+                )
+
+        logging.info(f"REC tone configured for software PWM on pin {pin}")
+        return _SoftwarePWMToneOutput(pin, self.rec_tone_frequency_hz, self.rec_tone_duty_cycle)
+
+    def _set_tone(self, active):
+        if active == self._is_tone_active:
+            return
+
+        self._is_tone_active = active
+        for tone_output in self._tone_outputs:
+            try:
+                if active:
+                    tone_output.start()
+                else:
+                    tone_output.stop()
+            except Exception as exc:
+                logging.warning(f"Failed to {'start' if active else 'stop'} REC tone: {exc}")
+
     def set_recording(self, status):
         """Set the status of the recording pins based on the given status."""
+        is_recording = bool(status)
         for pin in self.rec_out_pins:
-            RPi.GPIO.output(pin, RPi.GPIO.HIGH if status else RPi.GPIO.LOW)
-            logging.info(f"GPIO {pin} set to {'HIGH' if status else 'LOW'}")
+            RPi.GPIO.output(pin, RPi.GPIO.HIGH if is_recording else RPi.GPIO.LOW)
+            logging.info(f"GPIO {pin} set to {'HIGH' if is_recording else 'LOW'}")
+
+        self._set_tone(is_recording)

--- a/src/module/rpi_gpio_wrapper.py
+++ b/src/module/rpi_gpio_wrapper.py
@@ -1,6 +1,7 @@
 import lgpio
 
 class GPIO:
+    lgpio = lgpio
     OUT = 'out'
     IN = 'in'
     LOW = 0


### PR DESCRIPTION
### Motivation
- Allow the system to drive a recording tone on user-configurable GPIO pins and play that tone while the camera is recording. 
- Prefer Raspberry Pi hardware PWM on GPIO `18`/`19` when available and fall back to software PWM for other pins or if hardware setup fails.

### Description
- Implemented tone output abstractions in `src/module/gpio_output.py` with `_HardwarePWMToneOutput` (uses `rpi_hardware_pwm`) and `_SoftwarePWMToneOutput` (uses `lgpio.tx_pwm`) and wired them into `GPIOOutput` so tones are started/stopped from `set_recording`.
- Added detection/configuration for hardware-capable pins (`HARDWARE_PWM_PINS = {18, 19}`) and automatic fallback to software PWM on setup errors.
- Wired new configuration through initialization and defaults by adding `rec_tone_pin`, `rec_tone_frequency_hz`, and `rec_tone_duty_cycle` to `src/module/config_loader.py`, `resources/settings/settings_default.json`, and passing the settings into `GPIOOutput` from `src/main.py`.
- Exposed `lgpio` on the GPIO wrapper (`src/module/rpi_gpio_wrapper.py`) so the software PWM implementation can call `tx_pwm` consistently via `RPi.GPIO`.

### Testing
- Compiled the modified modules with `python -m compileall src/module/gpio_output.py src/module/rpi_gpio_wrapper.py src/main.py src/module/config_loader.py` and the compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4831e1f248332b3d00dfd6af4cea2)