### PR TITLE
Add configurable REC tone output with hardware/software PWM and update defaults/docs

### DIFF
--- a/docs/settings-json.md
+++ b/docs/settings-json.md
@@ -99,13 +99,24 @@ Defines pins used for visual feedback or sync signals.
 ```json
 "gpio_output": {
   "pwm_pin": 19,
-  "rec_out_pin": [6, 21]
+  "rec_out_pin": [6, 21],
+  "rec_tone_pin": [18],
+  "rec_tone_frequency_hz": 1000,
+  "rec_tone_duty_cycle": 50
 }
 ```
 
 * `pwm_pin` – outputs a strobe for shutter sync or external devices.
 
 * `rec_out_pin` – list of pins pulled high while recording (useful for tally LEDs).
+
+* `rec_tone_pin` – optional tone output pin(s) that are active while recording. You can pass a single pin or a list of pins.
+  * GPIO `18` and `19` use **hardware PWM** (preferred for stable tone generation).
+  * Any other pin uses **software PWM** fallback.
+
+* `rec_tone_frequency_hz` – tone frequency in hertz.
+
+* `rec_tone_duty_cycle` – PWM duty cycle percentage (`0–100`).
 
 ## arrays
 

--- a/resources/settings/settings_default.json
+++ b/resources/settings/settings_default.json
@@ -1,7 +1,10 @@
 {   
   "gpio_output": {
     "pwm_pin": 19,
-    "rec_out_pin": [6, 21]
+    "rec_out_pin": [6, 21],
+    "rec_tone_pin": [],
+    "rec_tone_frequency_hz": 1000,
+    "rec_tone_duty_cycle": 50
     },
 
   "arrays": {

--- a/src/main.py
+++ b/src/main.py
@@ -226,7 +226,12 @@ def initialize_system(settings):
     sensor_detect = SensorDetect(settings)
     ssd_monitor = SSDMonitor(redis_controller=redis_controller)
     usb_monitor = USBMonitor(ssd_monitor)
-    gpio_output = GPIOOutput(rec_out_pins=settings["gpio_output"]["rec_out_pin"])
+    gpio_output = GPIOOutput(
+        rec_out_pins=settings["gpio_output"]["rec_out_pin"],
+        rec_tone_pins=settings["gpio_output"].get("rec_tone_pin"),
+        rec_tone_frequency_hz=settings["gpio_output"].get("rec_tone_frequency_hz", 1000),
+        rec_tone_duty_cycle=settings["gpio_output"].get("rec_tone_duty_cycle", 50),
+    )
     dmesg_monitor = DmesgMonitor()
     dmesg_monitor.start()
 

--- a/src/module/config_loader.py
+++ b/src/module/config_loader.py
@@ -24,6 +24,9 @@ def load_settings(filename: str | Path) -> dict:
     gpio_defaults = {
         "pwm_pin": 19,
         "rec_out_pin": [6, 21],
+        "rec_tone_pin": [],
+        "rec_tone_frequency_hz": 1000,
+        "rec_tone_duty_cycle": 50,
     }
     gpio_cfg = settings.setdefault("gpio_output", {})
     for k, v in gpio_defaults.items():

--- a/src/module/gpio_output.py
+++ b/src/module/gpio_output.py
@@ -1,17 +1,117 @@
-from module.rpi_gpio_wrapper import RPi
+import importlib
 import logging
+from module.rpi_gpio_wrapper import RPi
+
+
+class _ToneOutput:
+    def start(self):
+        raise NotImplementedError
+
+    def stop(self):
+        raise NotImplementedError
+
+
+class _SoftwarePWMToneOutput(_ToneOutput):
+    def __init__(self, pin, frequency_hz, duty_cycle):
+        self.pin = pin
+        self.frequency_hz = frequency_hz
+        self.duty_cycle = duty_cycle
+        RPi.GPIO.setup(self.pin, RPi.GPIO.OUT)
+
+    def start(self):
+        handle = RPi.GPIO._get_handle()
+        # lgpio PWM uses duty-cycle percentage in the range 0..100.
+        RPi.GPIO.lgpio.tx_pwm(handle, self.pin, self.frequency_hz, self.duty_cycle)
+
+    def stop(self):
+        handle = RPi.GPIO._get_handle()
+        RPi.GPIO.lgpio.tx_pwm(handle, self.pin, 0, 0)
+
+
+class _HardwarePWMToneOutput(_ToneOutput):
+    def __init__(self, pin, frequency_hz, duty_cycle):
+        self.pin = pin
+        self.frequency_hz = frequency_hz
+        self.duty_cycle = duty_cycle
+        self._pwm = None
+
+        # rpi_hardware_pwm maps: GPIO 18 -> channel 0, GPIO 19 -> channel 1.
+        channel = 0 if pin == 18 else 1
+        pwm_module = importlib.import_module("rpi_hardware_pwm")
+        self._pwm = pwm_module.HardwarePWM(
+            pwm_channel=channel,
+            hz=self.frequency_hz,
+            chip=0,
+        )
+
+    def start(self):
+        self._pwm.change_frequency(self.frequency_hz)
+        self._pwm.start(self.duty_cycle)
+
+    def stop(self):
+        self._pwm.stop()
 
 class GPIOOutput:
-    def __init__(self, rec_out_pins=None):
+    HARDWARE_PWM_PINS = {18, 19}
+
+    def __init__(self, rec_out_pins=None, rec_tone_pins=None, rec_tone_frequency_hz=1000, rec_tone_duty_cycle=50):
         self.rec_out_pins = rec_out_pins if rec_out_pins is not None else []  # This is the list of pins for recording
+        self.rec_tone_pins = self._normalize_pins(rec_tone_pins)
+        self.rec_tone_frequency_hz = rec_tone_frequency_hz
+        self.rec_tone_duty_cycle = rec_tone_duty_cycle
+        self._tone_outputs = []
+        self._is_tone_active = False
 
         # Set up each pin in rec_out_pins as an output if the list is provided
         for pin in self.rec_out_pins:
             RPi.GPIO.setup(pin, RPi.GPIO.OUT)
             logging.info(f"REC light instantiated on pin {pin}")
 
+        for pin in self.rec_tone_pins:
+            tone_output = self._create_tone_output(pin)
+            self._tone_outputs.append(tone_output)
+
+    def _normalize_pins(self, pins):
+        if pins is None:
+            return []
+        if isinstance(pins, int):
+            return [pins]
+        return [int(pin) for pin in pins]
+
+    def _create_tone_output(self, pin):
+        if pin in self.HARDWARE_PWM_PINS:
+            try:
+                logging.info(f"REC tone configured for hardware PWM on pin {pin}")
+                return _HardwarePWMToneOutput(pin, self.rec_tone_frequency_hz, self.rec_tone_duty_cycle)
+            except Exception as exc:
+                logging.warning(
+                    "Hardware PWM setup failed on pin %s (%s). Falling back to software PWM.",
+                    pin,
+                    exc,
+                )
+
+        logging.info(f"REC tone configured for software PWM on pin {pin}")
+        return _SoftwarePWMToneOutput(pin, self.rec_tone_frequency_hz, self.rec_tone_duty_cycle)
+
+    def _set_tone(self, active):
+        if active == self._is_tone_active:
+            return
+
+        self._is_tone_active = active
+        for tone_output in self._tone_outputs:
+            try:
+                if active:
+                    tone_output.start()
+                else:
+                    tone_output.stop()
+            except Exception as exc:
+                logging.warning(f"Failed to {'start' if active else 'stop'} REC tone: {exc}")
+
     def set_recording(self, status):
         """Set the status of the recording pins based on the given status."""
+        is_recording = bool(status)
         for pin in self.rec_out_pins:
-            RPi.GPIO.output(pin, RPi.GPIO.HIGH if status else RPi.GPIO.LOW)
-            logging.info(f"GPIO {pin} set to {'HIGH' if status else 'LOW'}")
+            RPi.GPIO.output(pin, RPi.GPIO.HIGH if is_recording else RPi.GPIO.LOW)
+            logging.info(f"GPIO {pin} set to {'HIGH' if is_recording else 'LOW'}")
+
+        self._set_tone(is_recording)

--- a/src/module/rpi_gpio_wrapper.py
+++ b/src/module/rpi_gpio_wrapper.py
@@ -1,6 +1,7 @@
 import lgpio
 
 class GPIO:
+    lgpio = lgpio
     OUT = 'out'
     IN = 'in'
     LOW = 0


### PR DESCRIPTION
### Motivation

- Provide an audible REC tone during recording that can be configured per-pin and works reliably on Raspberry Pi hardware and other pins.
- Ensure the new behavior is documented and has safe defaults so missing settings do not break startup.

### Description

- Add new REC tone settings to docs (`docs/settings-json.md`) and the built-in defaults (`resources/settings/settings_default.json`), including `rec_tone_pin`, `rec_tone_frequency_hz`, and `rec_tone_duty_cycle`.
- Populate defaults in `load_settings` so `gpio_output` always contains `rec_tone_pin`, `rec_tone_frequency_hz`, and `rec_tone_duty_cycle` when calling `load_settings`.
- Extend `initialize_system` in `src/main.py` to pass the tone configuration into `GPIOOutput` via `rec_tone_pins`, `rec_tone_frequency_hz`, and `rec_tone_duty_cycle`.
- Implement tone outputs in `src/module/gpio_output.py` with two implementations: `_HardwarePWMToneOutput` using `rpi_hardware_pwm` for GPIO 18/19 and `_SoftwarePWMToneOutput` using `lgpio` PWM calls as a fallback, and wire them into `GPIOOutput` so `set_recording` starts/stops tone output along with `rec_out_pin` LEDs.
- Expose the `lgpio` module on the wrapper as `GPIO.lgpio` in `src/module/rpi_gpio_wrapper.py` so the software PWM implementation can access `lgpio` handles.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4831e1f248332b3d00dfd6af4cea2)