### PR TITLE
Persist drop-frame state to Redis; show violet background & DROP indicator in simple_gui

### DIFF
--- a/docs/redis-keys.md
+++ b/docs/redis-keys.md
@@ -25,6 +25,9 @@ Each entry explains which component normally writes the key and what happens whe
 | fps_last | Cinemate | Previous stable fps from stats | No |
 | fps_actual | CinePi-raw → Cinemate | Measured FPS from pipeline | No |
 | framecount | CinePi-raw → Cinemate | Total frames recorded | No |
+| drop_frame | Cinemate (RedisListener) | Live drop-frame pulse (1 while active alert is shown) | No |
+| drop_frame_count | Cinemate (RedisListener) | Number of drop-frame detections in the current/last take | No |
+| drop_frame_during_last_take | Cinemate (RedisListener) | 1 if the previous non-preroll take had drop frames | No |
 | buffer | CinePi-raw → Cinemate | Raw frames currently in RAM | No |
 | buffer_size | CinePi-raw  →  Cinemate| Size of RAM buffer in frames | No |
 | is_buffering | CinePi-raw → Cinemate | 1 while buffer pre‑fills | No |

--- a/src/module/redis_controller.py
+++ b/src/module/redis_controller.py
@@ -40,6 +40,9 @@ class ParameterKey(Enum):
     IS_WRITING        = "is_writing"
     IS_WRITING_BUF    = "is_writing_buf"
     STORAGE_PREROLL_ACTIVE = "storage_preroll_active"
+    DROP_FRAME = "drop_frame"
+    DROP_FRAME_DURING_LAST_TAKE = "drop_frame_during_last_take"
+    DROP_FRAME_COUNT = "drop_frame_count"
 
     TC_CAM0           = "tc_cam0"
     TC_CAM1           = "tc_cam1"

--- a/src/module/redis_listener.py
+++ b/src/module/redis_listener.py
@@ -65,6 +65,8 @@ class RedisListener:
 
         self.drop_frame = False
         self.drop_frame_timer = None
+        self.drop_frame_count_current_take = 0
+
 
         self.cinepi_running = True
 
@@ -78,6 +80,9 @@ class RedisListener:
         self.active_sensor_labels: set[str] = set()
         self.redis_controller.set_value(ParameterKey.FRAMES_IN_SYNC.value, 1)
         self.redis_controller.set_value(ParameterKey.FPS_CORRECTION_SUGGESTION.value, 1.0)
+        self.redis_controller.set_value(ParameterKey.DROP_FRAME.value, 0)
+        self.redis_controller.set_value(ParameterKey.DROP_FRAME_DURING_LAST_TAKE.value, 0)
+        self.redis_controller.set_value(ParameterKey.DROP_FRAME_COUNT.value, 0)
         
         self.max_fps_adjustment = 0.1  # Maximum adjustment per iteration
         self.min_fps_adjustment = 0.0001  # Minimum adjustment increment
@@ -374,7 +379,10 @@ class RedisListener:
                             if fps_difference > 1 and not self.drop_frame and not self.user_changing_fps:
 
                                 self.drop_frame = True
-                                logging.info("Drop frame detected")
+                                self.drop_frame_count_current_take += 1
+                                self.redis_controller.set_value(ParameterKey.DROP_FRAME.value, 1)
+                                self.redis_controller.set_value(ParameterKey.DROP_FRAME_COUNT.value, self.drop_frame_count_current_take)
+                                logging.info(f"Drop frame detected (count={self.drop_frame_count_current_take})")
                                 
                                 # Set a timer to reset the drop_frame flag after 0.5 seconds
                                 if self.drop_frame_timer:
@@ -411,6 +419,7 @@ class RedisListener:
                     
     def reset_drop_frame(self):
         self.drop_frame = False
+        self.redis_controller.set_value(ParameterKey.DROP_FRAME.value, 0)
         logging.info("Drop frame flag reset")
         
     # ───────────────────  FPS-change handling  ──────────────────────────────
@@ -518,6 +527,9 @@ class RedisListener:
                     self.is_recording = True
                     self.reset_framecount()
                     self.recording_start_time = datetime.datetime.now()
+                    self.drop_frame_count_current_take = 0
+                    self.redis_controller.set_value(ParameterKey.DROP_FRAME_COUNT.value, 0)
+                    self.redis_controller.set_value(ParameterKey.DROP_FRAME_DURING_LAST_TAKE.value, 0)
                     self.recording_end_time = None
                     logging.info(f"Recording started at: {self.recording_start_time}")
 
@@ -539,6 +551,11 @@ class RedisListener:
 
                     self.framerate = float(self.redis_controller.get_value('fps_user'))  # keep if you still use it elsewhere
                     self.allow_initial_zero = True
+
+                    if self.drop_frame_timer:
+                        self.drop_frame_timer.cancel()
+                    self.drop_frame = False
+                    self.redis_controller.set_value(ParameterKey.DROP_FRAME.value, 0)
 
 
                 elif value_str == '0':
@@ -828,6 +845,20 @@ class RedisListener:
 
         diff = expected_frames_total - recorded_frames_total
         frames_in_sync = abs(diff) <= 1
+
+        drop_detected_this_take = self.drop_frame_count_current_take > 0
+        drop_during_last_take = (not self.recording_was_preroll) and drop_detected_this_take
+        self.redis_controller.set_value(
+            ParameterKey.DROP_FRAME_DURING_LAST_TAKE.value,
+            1 if drop_during_last_take else 0,
+        )
+        self.redis_controller.set_value(
+            ParameterKey.DROP_FRAME_COUNT.value,
+            self.drop_frame_count_current_take,
+        )
+        logging.info(
+            f"Drop frames detected this take: {self.drop_frame_count_current_take}"
+        )
 
         if frames_in_sync:
             if diff == 0:

--- a/src/module/simple_gui.py
+++ b/src/module/simple_gui.py
@@ -477,6 +477,8 @@ class SimpleGUI(threading.Thread):
             "cam": "CAM", "raw": "RAW", "ram_label": "RAM",
             "cpu_label": "CPU", "cpu_temp_label": "TEMP",
             "media_label": "MEDIA", "mon": "MON",
+            "drop_frame_live": int(self.redis_controller.get_value(ParameterKey.DROP_FRAME.value) or 0) == 1,
+            "drop_frame_during_last_take": int(self.redis_controller.get_value(ParameterKey.DROP_FRAME_DURING_LAST_TAKE.value) or 0) == 1,
 
         }
         # ── audio stats ─────────────────────────────────────────────────
@@ -781,6 +783,14 @@ class SimpleGUI(threading.Thread):
 
                     y += BOX_H + BOX_GAP
 
+            if section == self.left_section_layout[0] and (values.get("drop_frame_live") or values.get("drop_frame_during_last_take")):
+                draw.rectangle([box_x, y, box_x + BOX_W, y + BOX_H], fill=(180, 40, 255))
+                tw, th = draw.textbbox((0, 0), "DROP", font=box_font)[2:]
+                tx = box_x + (BOX_W - tw) // 2
+                ty = y + (BOX_H - th) // 2
+                draw.text((tx, ty), "DROP", font=box_font, fill=TEXT_COLOR)
+                y += BOX_H + BOX_GAP
+
             y += SECTION_GAP
 
         # ── SYS section (USB / MIC / KEY / storage) ──────────────
@@ -870,6 +880,14 @@ class SimpleGUI(threading.Thread):
                     ty = y         + (BOX_H - th)//2
                     draw.text((tx, ty), part, font=box_font, fill=TEXT_COLOR)
                     y += BOX_H + BOX_GAP
+
+            if (values.get("drop_frame_live") or values.get("drop_frame_during_last_take")):
+                draw.rectangle([box_pad_x, y, box_pad_x + BOX_W, y + BOX_H], fill=(180, 40, 255))
+                tw, th = draw.textbbox((0, 0), "DROP", font=box_font)[2:]
+                tx = box_pad_x + (BOX_W - tw) // 2
+                ty = y + (BOX_H - th) // 2
+                draw.text((tx, ty), "DROP", font=box_font, fill=TEXT_COLOR)
+                y += BOX_H + BOX_GAP
             y += SECTION_GAP
 
     def draw_right_vu_meter(self, draw, amplification_factor=4):
@@ -1015,16 +1033,16 @@ class SimpleGUI(threading.Thread):
         except (TypeError, ValueError):
             preroll_active = 0
 
-        if preroll_active:
+        drop_frame_live = int(self.redis_controller.get_value(ParameterKey.DROP_FRAME.value) or 0) == 1
+
+        if drop_frame_live:
+            self.current_background_color = "purple"
+            self.color_mode = "inverse"
+        elif preroll_active:
             self.current_background_color = "blue"
             self.color_mode = "inverse"
 
-        elif int(self.redis_controller.get_value(ParameterKey.REC.value)) and self.redis_listener.drop_frame == 1:
-            # at least one camera is actively recording
-            self.current_background_color = "purple"
-            self.color_mode = "inverse"
-
-        if not preroll_active:
+        if not preroll_active and not drop_frame_live:
             if int(self.redis_controller.get_value(ParameterKey.REC.value)) == 1:
                 # at least one camera is actively recording
                 self.current_background_color = "red"


### PR DESCRIPTION
### Motivation
- Surface drop-frame detections from the stats stream into Redis so the UI and CLI can react and report counts per take. 
- Visually emphasise active drop-frame alerts in the framebuffer UI (violet background) and keep a post‑take flag for the last non-preroll take so users can see DROP after the take ends. 

### Description
- Added three new Redis parameters to `ParameterKey`: `drop_frame`, `drop_frame_count`, and `drop_frame_during_last_take` to hold live alerts, per-take counts, and the persisted last-take flag respectively (`src/module/redis_controller.py`).
- Enhanced `RedisListener` to increment a per-take counter when a drop-frame is detected, publish `drop_frame`/`drop_frame_count` while an alert is active, reset live state at record start, and write `drop_frame_during_last_take` (and the count) at the end of a take except when the take was a storage preroll (`src/module/redis_listener.py`).
- Updated `simple_gui` to read the new Redis keys and:
  - switch the background to violet while `drop_frame` is active and revert to blue for storage-preroll or red for normal recording when the alert clears, and
  - draw a `DROP` box under the CAM sections (left and right) when a drop-frame is active or when `drop_frame_during_last_take` is set (`src/module/simple_gui.py`).
- Documented the new Redis keys in `docs/redis-keys.md`.

### Testing
- Ran `python -m py_compile src/module/redis_controller.py src/module/redis_listener.py src/module/simple_gui.py` and the files compiled successfully. 
- Ran an automated screenshot attempt via Playwright to capture a page artifact in this environment and the script executed and produced an artifact (note: the framebuffer-based GUI is not served via HTTP in this test environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b485a0a9bc833284dec3368fe2cfd5)