### PR TITLE
Avoid GPIO input/output conflicts and add Raspberry Pi 5 hardware PWM support for REC tone

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -339,7 +339,23 @@ def main():
         sensor_detect=sensor_detect,
     )
 
-    gpio_input = ComponentInitializer(cinepi_controller, settings)
+    gpio_cfg = settings.get("gpio_output", {})
+    rec_tone_pins = gpio_cfg.get("rec_tone_pin")
+    if rec_tone_pins in (None, []):
+        rec_tone_pins = gpio_cfg.get("pwm_pin")
+
+    reserved_output_pins = set(gpio_cfg.get("rec_out_pin", []))
+    if rec_tone_pins is not None:
+        if isinstance(rec_tone_pins, int):
+            reserved_output_pins.add(rec_tone_pins)
+        else:
+            reserved_output_pins.update(int(pin) for pin in rec_tone_pins)
+
+    gpio_input = ComponentInitializer(
+        cinepi_controller,
+        settings,
+        reserved_output_pins=reserved_output_pins,
+    )
 
     # Create CommandExecutor (for both CLI and Serial)
     command_executor = CommandExecutor(

--- a/src/module/gpio_input.py
+++ b/src/module/gpio_input.py
@@ -9,10 +9,13 @@ import logging
 import time
     
 class ComponentInitializer:
-    def __init__(self, cinepi_controller, settings):
+    def __init__(self, cinepi_controller, settings, reserved_output_pins=None):
         self.cinepi_controller = cinepi_controller
         self.settings = settings
         self.logger = logging.getLogger('ComponentInitializer')
+        self.reserved_output_pins = {
+            int(pin) for pin in (reserved_output_pins or [])
+        }
         
         self.smart_buttons_list = []
         
@@ -23,6 +26,14 @@ class ComponentInitializer:
         
         # Initialize Buttons
         for button_config in self.settings.get('buttons', []):
+            pin = int(button_config['pin'])
+            if pin in self.reserved_output_pins:
+                self.logger.warning(
+                    "Skipping button on pin %s because it is reserved for GPIO output",
+                    pin,
+                )
+                continue
+
             press_action_method = self.extract_action_method(button_config.get('press_action'))
             single_click_action_method = self.extract_action_method(button_config.get('single_click_action'))
             double_click_action_method = self.extract_action_method(button_config.get('double_click_action'))
@@ -39,11 +50,11 @@ class ComponentInitializer:
             # Create and store SmartButton instance
             smart_button = SmartButton(
                 cinepi_controller=self.cinepi_controller,
-                pin=button_config['pin'],
+                pin=pin,
                 pull_up=bool(button_config['pull_up']),
                 debounce_time=float(button_config['debounce_time']),
                 actions=button_config,
-                identifier=str(button_config['pin']),
+                identifier=str(pin),
                 combined_actions=combined_actions
             )
             
@@ -51,15 +62,23 @@ class ComponentInitializer:
         
         # Initialize Two-Way Switches
         for switch_config in self.settings.get('two_way_switches', []):
+            pin = int(switch_config['pin'])
+            if pin in self.reserved_output_pins:
+                self.logger.warning(
+                    "Skipping two-way switch on pin %s because it is reserved for GPIO output",
+                    pin,
+                )
+                continue
+
             state_on_action_method = self.extract_action_method(switch_config.get('state_on_action'))
             state_off_action_method = self.extract_action_method(switch_config.get('state_off_action'))
             
-            self.logger.info(f"Two-way switch on pin {switch_config['pin']}:")
+            self.logger.info(f"Two-way switch on pin {pin}:")
             if not "None" in str(state_on_action_method): self.logger.info(f"  State ON action: {state_on_action_method}")
             if not "None" in str(state_off_action_method): self.logger.info(f"  State OFF action: {state_off_action_method}")
 
             SimpleSwitch(cinepi_controller=self.cinepi_controller,
-                         pin=switch_config['pin'],
+                         pin=pin,
                          actions=switch_config)
             
         # Initialize three-way switches

--- a/src/module/gpio_output.py
+++ b/src/module/gpio_output.py
@@ -1,5 +1,6 @@
 import importlib
 import logging
+from pathlib import Path
 from module.rpi_gpio_wrapper import RPi
 
 
@@ -29,14 +30,36 @@ class _SoftwarePWMToneOutput(_ToneOutput):
 
 
 class _HardwarePWMToneOutput(_ToneOutput):
+    @staticmethod
+    def _is_raspberry_pi_5():
+        model_path = Path("/proc/device-tree/model")
+        try:
+            model = model_path.read_text(encoding="utf-8", errors="ignore").strip("\x00\n")
+        except Exception:
+            return False
+        return "Raspberry Pi 5" in model
+
     def __init__(self, pin, frequency_hz, duty_cycle):
         self.pin = pin
         self.frequency_hz = frequency_hz
         self.duty_cycle = duty_cycle
         self._pwm = None
 
-        # rpi_hardware_pwm maps: GPIO 18 -> channel 0, GPIO 19 -> channel 1.
-        channel = 0 if pin == 18 else 1
+        # rpi_hardware_pwm channel mapping differs on Raspberry Pi 5.
+        # - Pi 5: GPIO18->channel 2, GPIO19->channel 3
+        # - Older Pi models: GPIO18->channel 0, GPIO19->channel 1
+        is_pi5 = self._is_raspberry_pi_5()
+        if is_pi5:
+            channel = 2 if pin == 18 else 3
+        else:
+            channel = 0 if pin == 18 else 1
+
+        logging.info(
+            "REC tone using hardware PWM pin=%s channel=%s (pi5=%s)",
+            pin,
+            channel,
+            is_pi5,
+        )
         pwm_module = importlib.import_module("rpi_hardware_pwm")
         self._pwm = pwm_module.HardwarePWM(
             pwm_channel=channel,


### PR DESCRIPTION
### Motivation

- Prevent GPIO input components from being initialized on pins that are reserved for output devices (REC light / REC tone) to avoid hardware conflicts.
- Ensure REC tone PWM uses the correct hardware PWM channels on Raspberry Pi 5 where channel mapping differs from older Pi models.

### Description

- In `main.py` read GPIO output configuration keys (`rec_out_pin`, `rec_tone_pin` fallback to `pwm_pin`) and build a `reserved_output_pins` set of integers to represent pins that must not be used for inputs.  
- Pass `reserved_output_pins` into `ComponentInitializer` so input initialization can avoid reserved pins.  
- In `module/gpio_input.py` add a `reserved_output_pins` constructor parameter, coerce pins to `int`, skip button and two-way-switch initialization when their pin is in the reserved set, and log warnings when skipping components.  
- In `module/gpio_output.py` add detection for Raspberry Pi 5 by reading `/proc/device-tree/model` and select the appropriate `rpi_hardware_pwm` channel mapping for Pi 5 (`GPIO18->2`, `GPIO19->3`) versus older models (`GPIO18->0`, `GPIO19->1`), and log the chosen mapping.  

### Testing

- Ran the project's automated test suite with `pytest` and the existing tests passed.  
- Verified that starting the application does not initialize buttons on reserved pins and that hardware PWM channel selection logs the expected channel for detected Pi model.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc78da834c8332a18878507db39018)