### PR TITLE
Improve SimpleGUI refresh responsiveness

### DIFF
--- a/docs/simple-gui-refresh-tuning.md
+++ b/docs/simple-gui-refresh-tuning.md
@@ -1,0 +1,161 @@
+# Simple GUI Refresh Tuning
+
+This page explains the timing-related settings in `src/module/simple_gui.py` that control how responsive the HDMI Simple GUI feels and how much work it asks the Pi to do.
+
+The current redraw model is event-driven:
+
+- fast-changing UI state is redrawn on demand when Redis values change
+- redraws are capped so the GUI does not repaint faster than the configured frame rate
+- expensive system stats are refreshed on a slower interval
+
+That means the main tuning goal is to balance responsiveness against framebuffer bandwidth and CPU use.
+
+## The main timing settings
+
+These values live near the top of `SimpleGUI.__init__()`.
+
+### `self.target_fps = 12`
+
+This is the maximum redraw rate for the GUI fast path.
+
+- Higher values make frame count, timecode, buffer state, recording state, and VU motion feel more immediate.
+- Lower values reduce CPU load and reduce full-screen framebuffer writes.
+- The GUI will still redraw on demand, but never faster than this cap.
+
+Recommended range on the Pi:
+
+- `10` to `12`: good default balance
+- `15`: snappier, but worth testing for thermals and CPU load
+- above `15`: usually not recommended with the current full-screen PIL-to-framebuffer path
+
+### `self.min_frame_interval = 1 / self.target_fps`
+
+This is the derived minimum time between redraws.
+
+- At `12 FPS`, the minimum interval is about `0.083 s`
+- At `10 FPS`, it is `0.100 s`
+- At `15 FPS`, it is `0.067 s`
+
+You normally should not edit this directly. Change `target_fps` instead.
+
+### `self.slow_refresh_interval = 1.0`
+
+This controls how often the GUI refreshes the heavy, slow-changing values.
+
+These currently include:
+
+- CPU load
+- CPU temperature
+- latest recording info from the storage scan
+
+Effects:
+
+- Lower values make system stats and latest-recording status update sooner.
+- Higher values reduce background work and keep the hot redraw path lighter.
+
+Recommended range:
+
+- `1.0`: good default
+- `0.5`: more live system stats, slightly more overhead
+- `1.5` to `2.0`: lighter background load if you only care about fast camera-state updates
+
+## Audio meter timing
+
+These values affect how the right-side VU meter feels.
+
+### `self.vu_decay_factor = 0.2`
+
+The runtime loop currently sets `self.vu_decay_factor = 0.2` in `run()`, and that is the value that controls how quickly the displayed VU bars fall when the signal drops.
+
+- Higher value: faster fall
+- Lower value: slower fall, more lingering meter
+
+Practical examples:
+
+- `0.1`: slower, smoother decay
+- `0.2`: current behavior
+- `0.3`: faster, more reactive falloff
+
+### `self.vu_smoothing_alpha = 0.4`
+
+This value is defined in `__init__()`, but the current `update_smoothed_vu_levels()` implementation does not use it.
+
+Right now:
+
+- changing `vu_smoothing_alpha` does not change GUI behavior
+- only `vu_decay_factor` affects the displayed smoothing/decay feel
+
+If the VU algorithm is expanded later, this would be the likely place to control how quickly rising levels are smoothed.
+
+## Advanced timing knob
+
+### `self._redraw_event.wait(timeout=0.1)`
+
+Inside `run()`, the GUI waits up to `0.1` seconds when there is no work queued.
+
+In normal use, Redis changes wake the loop immediately, so this timeout is mostly just a fallback sleep while idle.
+
+- Lowering it can make idle polling a little tighter
+- raising it can reduce tiny amounts of background wake activity
+
+This is usually not the first thing to tune. `target_fps` and `slow_refresh_interval` matter much more.
+
+## What to change for common goals
+
+### Make the GUI feel more live
+
+Try:
+
+```python
+self.target_fps = 15
+self.slow_refresh_interval = 1.0
+```
+
+Use this if framecount, buffer, and timecode updates still feel a little too stepped.
+
+### Reduce CPU and framebuffer pressure
+
+Try:
+
+```python
+self.target_fps = 8
+self.slow_refresh_interval = 1.5
+```
+
+Use this if the Pi is busy and the GUI does not need to feel as immediate.
+
+### Keep camera-state updates fast, but make system stats more live
+
+Try:
+
+```python
+self.target_fps = 12
+self.slow_refresh_interval = 0.5
+```
+
+Use this if you want CPU temp/load and recording-info updates more often without pushing the redraw cap much higher.
+
+## Suggested workflow when tuning
+
+1. Change `target_fps` first.
+2. Test for a few minutes while watching CPU load and overall UI smoothness.
+3. Adjust `slow_refresh_interval` only if the system-stat freshness is not where you want it.
+4. Adjust `vu_decay_factor` only if the audio meter feel needs changing.
+
+## Where to edit
+
+File:
+
+- `src/module/simple_gui.py`
+
+Primary timing lines:
+
+- `self.target_fps = 12`
+- `self.min_frame_interval = 1 / self.target_fps`
+- `self.slow_refresh_interval = 1.0`
+- `self.vu_smoothing_alpha = 0.4`
+- `self.vu_decay_factor = 0.2` inside `run()`
+
+## Important note
+
+The current GUI still redraws the whole PIL image and writes the whole framebuffer for each draw. Because of that, increasing `target_fps` always has a real cost. Small increases are usually fine, but very high values are likely to give diminishing returns on the Pi.

--- a/docs/simple-gui.md
+++ b/docs/simple-gui.md
@@ -10,3 +10,4 @@ Buffer meter in the lower left indicates number of frames in buffer. Useful when
 
 When a compatible USB microphone is connected, VU meters appear on the right side of the GUI so you can monitor audio levels.
 
+For redraw timing and performance tuning, see `docs/simple-gui-refresh-tuning.md`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
     - Configuring the Wi-Fi hotspot: hotspot-logic.md
   - Using the camera:
       - Simple GUI: simple-gui.md
+      - Simple GUI refresh tuning: simple-gui-refresh-tuning.md
       - Camera sensors and frame rates: sensors.md
       - Audio recording: audio-recording.md
       - FPS correction and audio sync: fps-correction.md

--- a/src/module/simple_gui.py
+++ b/src/module/simple_gui.py
@@ -22,6 +22,7 @@ def _to_bool(value) -> bool:
         return value.strip().lower() in {"1", "true", "yes", "on"}
     return bool(value)
 
+
 class SimpleGUI(threading.Thread):
     def __init__(self, 
                 redis_controller, 
@@ -82,9 +83,22 @@ class SimpleGUI(threading.Thread):
             self.vu_meter_hatch_lines = True
 
         self.background_color_changed = False
+        self.target_fps = 12
+        self.min_frame_interval = 1 / self.target_fps
+        self.slow_refresh_interval = 1.0
+        self._redraw_event = threading.Event()
+        self._fast_dirty = True
+        self._slow_dirty = True
+        self._last_draw_ts = 0.0
+        self._last_slow_refresh_ts = 0.0
+        self._font_cache = {}
+        self._cached_cams_json = None
+        self._cached_cams = []
+        self._slow_values = {}
         
         # Load sensor values from Redis upon instantiation
         self.load_sensor_values_from_redis()
+        self.redis_controller.redis_parameter_changed.subscribe(self._handle_redis_change)
 
         self.start()
 
@@ -341,16 +355,12 @@ class SimpleGUI(threading.Thread):
             resolution_value = "N/A"
         return resolution_value
     
-    def _update_cam_section_labels(self):
+    def _update_cam_section_labels(self, cams=None):
         """
         Look at the CAMERAS json stored by CinePiManager and set the
         column headers (CAM0 / CAM1 / MON) and which layouts to draw.
         """
-        cams_json = self.redis_controller.get_value(ParameterKey.CAMERAS.value) or '[]'
-        try:
-            cams = json.loads(cams_json)
-        except (ValueError, TypeError):
-            cams = []
+        cams = cams or []
 
         # defaults (no camera data yet)
         l_lbl, r_lbl = "CAM", "MON"
@@ -367,18 +377,79 @@ class SimpleGUI(threading.Thread):
         self.left_section_layout[0]["label"]  = l_lbl
         self.right_section_layout[0]["label"] = r_lbl
 
+    def _get_camera_list(self):
+        cams_json = self.redis_controller.get_value(ParameterKey.CAMERAS.value) or "[]"
+        if cams_json != self._cached_cams_json:
+            try:
+                cams = json.loads(cams_json)
+            except (ValueError, TypeError):
+                cams = []
+            if cams:
+                cams.sort(key=lambda c: c.get("port", ""))
+            self._cached_cams_json = cams_json
+            self._cached_cams = cams
+        return self._cached_cams
+
+    def _refresh_slow_values(self):
+        latest_recording_info = self._slow_values.get("latest_recording_info", (None, 0, 0))
+        cpu_load = self._slow_values.get("cpu_load", "0%")
+        cpu_temp = self._slow_values.get("cpu_temp", "--")
+
+        try:
+            cpu_load = Utils.cpu_load()
+        except Exception:
+            pass
+
+        try:
+            cpu_temp = Utils.cpu_temp()
+        except Exception:
+            pass
+
+        if self.ssd_monitor:
+            try:
+                latest_recording_info = self.ssd_monitor.get_latest_recording_info()
+            except Exception:
+                pass
+
+        self._slow_values.update({
+            "cpu_load": cpu_load,
+            "cpu_temp": cpu_temp,
+            "latest_recording_info": latest_recording_info,
+        })
+        self._last_slow_refresh_ts = time.monotonic()
+
+    def _maybe_refresh_slow_values(self):
+        if (
+            not self._slow_values
+            or (time.monotonic() - self._last_slow_refresh_ts) >= self.slow_refresh_interval
+        ):
+            self._refresh_slow_values()
+
+    def _handle_redis_change(self, _data):
+        self._fast_dirty = True
+        self._redraw_event.set()
+
+    def _vu_active(self):
+        monitor = getattr(self.usb_monitor, "audio_monitor", None)
+        return bool(monitor and getattr(monitor, "running", False))
+
+    def _get_font(self, kind: str, size):
+        font_size = max(1, int(round(size)))
+        key = (kind, font_size)
+        font = self._font_cache.get(key)
+        if font is None:
+            path = self.bold_font_path if kind == "bold" else self.regular_font_path
+            font = ImageFont.truetype(os.path.realpath(path), font_size)
+            self._font_cache[key] = font
+        return font
+
     def populate_values(self):
         # update section headers first
-        self._update_cam_section_labels()
+        cam_list = self._get_camera_list()
+        self._update_cam_section_labels(cam_list)
+        self._maybe_refresh_slow_values()
         self.load_sensor_values_from_redis()
         resolution_value = self.estimate_resolution_in_k()
-
-        # ── read CAMERAS json ─────────────────────────────────────
-        cams_json = self.redis_controller.get_value(ParameterKey.CAMERAS.value) or "[]"
-        try:
-            cam_list = json.loads(cams_json)
-        except (ValueError, TypeError):
-            cam_list = []
 
         sensor_left  = ""   
         sensor_right = ""
@@ -460,8 +531,8 @@ class SimpleGUI(threading.Thread):
             "zoom_is_default": True,
             "anamorphic_factor": f"{self.redis_controller.get_value(ParameterKey.ANAMORPHIC_FACTOR.value)}X",
             "ram_load":       Utils.memory_usage(),
-            "cpu_load":       Utils.cpu_load(),
-            "cpu_temp":       Utils.cpu_temp(),
+            "cpu_load":       self._slow_values.get("cpu_load", "0%"),
+            "cpu_temp":       self._slow_values.get("cpu_temp", "--"),
             "disk_label":     (self.ssd_monitor.device_name or "").upper()[:4],
             "usb_connected":  bool(self.serial_handler.serial_connected),
             "mic_connected":  self.usb_monitor.usb_mic is not None,
@@ -514,10 +585,11 @@ class SimpleGUI(threading.Thread):
                     if rec_active:
                         values["mic_wav_saved"] = False
                     else:
-                        _, dng_count, wav_count = self.ssd_monitor.get_latest_recording_info()
+                        _, dng_count, wav_count = self._slow_values.get(
+                            "latest_recording_info",
+                            (None, 0, 0),
+                        )
                         values["mic_wav_saved"] = dng_count > 0 and wav_count > 0
-                    _, dng_count, wav_count = self.ssd_monitor.get_latest_recording_info()
-                    values["mic_wav_saved"] = dng_count > 0 and wav_count > 0
                 except (TypeError, ValueError):
                     values["mic_wav_saved"] = False
 
@@ -729,8 +801,8 @@ class SimpleGUI(threading.Thread):
     # LEFT-HAND COLUMN  (CAM / MON / SYS …)
     # ─────────────────────────────────────────────────────────────
     def draw_left_sections(self, draw, values):
-        label_font = ImageFont.truetype(self.regular_font_path, 26)
-        box_font   = ImageFont.truetype(self.bold_font_path,     26)
+        label_font = self._get_font("regular", 26)
+        box_font   = self._get_font("bold", 26)
 
         BOX_H, BOX_W  = 40, 60
         BOX_COLOR     = (136, 136, 136)
@@ -846,8 +918,8 @@ class SimpleGUI(threading.Thread):
     # RIGHT-HAND MIRROR COLUMN
     # ─────────────────────────────────────────────────────────────
     def draw_right_sections(self, draw, values):
-        label_font = ImageFont.truetype(self.regular_font_path, 26)
-        box_font   = ImageFont.truetype(self.bold_font_path,     24)
+        label_font = self._get_font("regular", 26)
+        box_font   = self._get_font("bold", 24)
 
         BOX_H, BOX_W  = 40, 60
         BOX_COLOR     = (136, 136, 136)
@@ -931,7 +1003,7 @@ class SimpleGUI(threading.Thread):
             draw_bar(x, bar_width, vu_levels[i], vu_peaks[i])
 
         # Optional: Draw channel labels
-        label_font = ImageFont.truetype(self.regular_font_path, 16)
+        label_font = self._get_font("regular", 16)
         labels = ["L", "R"] if n_channels == 2 else [str(i+1) for i in range(n_channels)]
         for i, label in enumerate(labels):
             text_bbox = draw.textbbox((0, 0), label, font=label_font)
@@ -1163,10 +1235,7 @@ class SimpleGUI(threading.Thread):
             position = [info["pos"][0] * shrink_x, info["pos"][1] * shrink_y]
             font_size = info.get("size", 12) * min(min(shrink_x, shrink_y), 1) 
             # 12 is the default font size, min with 1 makes sure the font stays same in bigger displays
-            font = ImageFont.truetype(
-                os.path.realpath(self.bold_font_path if info.get("font", "bold") == "bold" else self.regular_font_path),
-                font_size
-            )
+            font = self._get_font(info.get("font", "bold"), font_size)
             value = str(values.get(element, ''))
             color_mode = self.color_mode
             color = self.colors.get(element, {}).get(color_mode, "white")
@@ -1182,8 +1251,7 @@ class SimpleGUI(threading.Thread):
                 self.draw_rounded_box(draw, value, position, font_size, 5, "black", "white", image)
             else:
                 draw.text(position, value, font=font, fill=color)
-                
-        self.update_smoothed_vu_levels()
+
         self.draw_right_vu_meter(draw)
         if self.show_buffer_vu:
             self.draw_framebuffer_vu_meter(draw)
@@ -1202,7 +1270,7 @@ class SimpleGUI(threading.Thread):
         self.fb.show(image)
         
     def draw_rounded_box(self, draw, text, position, font_size, padding, text_color, fill_color, image, extra_height=-17, reduce_top=12):
-        font = ImageFont.truetype(os.path.realpath(self.font_path), font_size)
+        font = self._get_font("bold", font_size)
         bbox = draw.textbbox((0, 0), text, font=font)
         text_width = bbox[2] - bbox[0]
         text_height = bbox[3] - bbox[1] + extra_height  # Increase height by extra_height
@@ -1260,10 +1328,34 @@ class SimpleGUI(threading.Thread):
             self.vu_decay_factor = 0.2
 
             while self._running:
-                values = self.populate_values()
+                now = time.monotonic()
+                if (
+                    not self._slow_values
+                    or (now - self._last_slow_refresh_ts) >= self.slow_refresh_interval
+                ):
+                    self._slow_dirty = True
+
+                has_work = self._fast_dirty or self._slow_dirty or self._vu_active()
+                if not has_work:
+                    self._redraw_event.wait(timeout=0.1)
+                    self._redraw_event.clear()
+                    continue
+
+                due_in = max(0.0, self.min_frame_interval - (now - self._last_draw_ts))
+                if due_in > 0:
+                    self._redraw_event.wait(timeout=due_in)
+                    self._redraw_event.clear()
+                    continue
+
+                if self._slow_dirty:
+                    self._refresh_slow_values()
+
                 self.update_smoothed_vu_levels()
+                values = self.populate_values()
                 self.draw_gui(values)
-                time.sleep(0.2)
+                self._fast_dirty = False
+                self._slow_dirty = False
+                self._last_draw_ts = time.monotonic()
         finally:
             pass
  


### PR DESCRIPTION
## Summary
- make `SimpleGUI` redraws event-driven and cap them at a configurable refresh rate
- move slower system and recording-info refreshes off the hot redraw path
- add a separate SimpleGUI timing guide documenting the user-editable timing knobs

## Why
The previous GUI loop was fixed to a 200 ms polling cadence, which made framecount, buffer, timecode, and VU updates feel stepped. Raising the poll rate without other changes would also have increased unnecessary redraw and framebuffer work.

## Validation
- `python3 -m py_compile src/module/simple_gui.py`
- runtime-tested on the Pi
- Pi-side `python3 -m py_compile /tmp/cinemate-publish.bGSVbX/src/module/simple_gui.py`
- `git diff --check`

## Notes
- local and Pi working checkouts remain on `dev`
- the manual lives in `docs/simple-gui-refresh-tuning.md`