### PR TITLE
B3 · small correctness fixes (from the system review)

### DIFF
--- a/_test/test_action_catalogues_agree.py
+++ b/_test/test_action_catalogues_agree.py
@@ -1,0 +1,71 @@
+"""The action catalogue exists three times. They have to agree.
+
+settings_editor.py's ACTION_METHODS, a hand-maintained copy of the same list
+in the settings editor's JavaScript, and CinePiController's actual methods.
+The two hand-maintained copies agreed perfectly for a long time -- including
+agreeing on `set_log`, which does not exist, so that button silently did
+nothing when pressed. Two copies in exact agreement is not evidence they are
+right; it is evidence they were copied.
+
+GET /api/actions already computes exactly this check and ships an `available`
+flag per action. The template never fetches it. Until it does, this test is
+the thing standing between a rename and another silent button.
+"""
+
+import ast
+import re
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+sys.modules.setdefault("redis", types.SimpleNamespace(StrictRedis=object))
+
+CONTROLLER = ROOT / "src/module/cinepi_controller.py"
+EDITOR_PY = ROOT / "src/module/app/settings_editor.py"
+EDITOR_HTML = ROOT / "src/module/app/templates/settings_editor.html"
+
+
+def controller_methods() -> set[str]:
+    tree = ast.parse(CONTROLLER.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "CinePiController":
+            return {n.name for n in node.body
+                    if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))}
+    raise AssertionError("CinePiController not found")
+
+
+def python_catalogue() -> set[str]:
+    return set(re.findall(r'"value":\s*"([a-z0-9_]+)"',
+                          EDITOR_PY.read_text(encoding="utf-8")))
+
+
+def js_catalogue() -> set[str]:
+    html = EDITOR_HTML.read_text(encoding="utf-8")
+    block = re.search(r"var ACTION_METHODS = \[(.*?)\n  \];", html, re.S)
+    assert block, "ACTION_METHODS array not found in the template"
+    return set(re.findall(r"value:\s*'([a-z0-9_]+)'", block.group(1)))
+
+
+class ActionCatalogueTests(unittest.TestCase):
+    def test_every_offered_action_exists_on_the_controller(self):
+        missing = sorted(python_catalogue() - controller_methods())
+        self.assertEqual(missing, [],
+                         f"offered by the settings editor but absent: {missing}")
+
+    def test_every_javascript_action_exists_on_the_controller(self):
+        missing = sorted(js_catalogue() - controller_methods())
+        self.assertEqual(missing, [],
+                         f"offered by the browser but absent: {missing}")
+
+    def test_the_two_hand_maintained_copies_have_not_drifted(self):
+        py, js = python_catalogue(), js_catalogue()
+        self.assertEqual(sorted(py - js), [], "in the Python catalogue, missing from the JS")
+        self.assertEqual(sorted(js - py), [], "in the JS catalogue, missing from the Python")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_test/test_log_queue_is_bounded.py
+++ b/_test/test_log_queue_is_bounded.py
@@ -1,0 +1,68 @@
+"""The in-app log queue must not grow forever.
+
+QueueHandler feeds the startup-failure view. Nothing drains it -- the only
+reader peeks under the mutex and takes the last 40 lines -- so an unbounded
+queue grew for the whole life of the process. On a camera left running for
+days that is a slow leak with no ceiling.
+"""
+
+import logging
+import queue
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+sys.modules.setdefault("termcolor", types.SimpleNamespace(colored=lambda text, *a, **k: text))
+
+from module.logger import LOG_QUEUE_MAXSIZE, QueueHandler
+
+
+def record(msg):
+    return logging.LogRecord("t", logging.INFO, __file__, 1, msg, None, None)
+
+
+class LogQueueBoundTests(unittest.TestCase):
+    def test_the_queue_stops_growing_at_its_bound(self):
+        q = queue.Queue(maxsize=10)
+        handler = QueueHandler(q)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+
+        for i in range(500):
+            handler.emit(record(f"line {i}"))
+
+        self.assertEqual(q.qsize(), 10)
+
+    def test_it_keeps_the_newest_lines_not_the_oldest(self):
+        q = queue.Queue(maxsize=3)
+        handler = QueueHandler(q)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+
+        for i in range(10):
+            handler.emit(record(f"line {i}"))
+
+        # When something has just gone wrong, the last lines are the ones worth
+        # having -- the startup-failure view shows a tail, not a head.
+        self.assertEqual(list(q.queue), ["line 7", "line 8", "line 9"])
+
+    def test_emitting_never_blocks(self):
+        # This runs inline on whichever thread called logging, including the
+        # redis listener. A blocking put here would stall the whole system.
+        q = queue.Queue(maxsize=1)
+        handler = QueueHandler(q)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+
+        for i in range(50):
+            handler.emit(record(f"line {i}"))  # would hang if put() blocked
+
+        self.assertEqual(q.qsize(), 1)
+
+    def test_the_configured_bound_is_deep_enough_for_the_reader(self):
+        self.assertGreaterEqual(LOG_QUEUE_MAXSIZE, 40)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_test/test_redis_event_dispatch.py
+++ b/_test/test_redis_event_dispatch.py
@@ -1,0 +1,75 @@
+"""One bad subscriber must not take the live-state bus down with it.
+
+Event.emit runs every subscriber synchronously on RedisController's single
+_listen thread. An unguarded raise there killed the thread, and because
+get_value() answers from the cache rather than from redis, nothing failed
+loudly: every surface carried on rendering the values it last saw. A frozen
+GUI that still looks correct mid-take is the worst failure this system has.
+"""
+
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+sys.modules.setdefault("redis", types.SimpleNamespace(StrictRedis=object))
+
+from module.redis_controller import Event
+
+
+class EventDispatchTests(unittest.TestCase):
+    def test_a_raising_subscriber_does_not_stop_the_others(self):
+        seen = []
+
+        event = Event()
+        event.subscribe(lambda data: seen.append(("first", data)))
+        event.subscribe(lambda data: (_ for _ in ()).throw(RuntimeError("boom")))
+        event.subscribe(lambda data: seen.append(("third", data)))
+
+        with self.assertLogs(level="ERROR"):
+            event.emit({"key": "iso", "value": "800"})
+
+        # The subscriber after the failure still ran -- that is the whole point.
+        self.assertEqual(
+            seen,
+            [("first", {"key": "iso", "value": "800"}),
+             ("third", {"key": "iso", "value": "800"})],
+        )
+
+    def test_the_failure_is_logged_not_swallowed(self):
+        event = Event()
+        event.subscribe(lambda data: (_ for _ in ()).throw(ValueError("nope")))
+
+        with self.assertLogs(level="ERROR") as captured:
+            event.emit(None)
+
+        # "fail visible, never silent" (storage_profiles.py:41-49): the traceback
+        # has to reach the log, or this guard just moves the silence.
+        joined = "\n".join(captured.output)
+        self.assertIn("ValueError", joined)
+        self.assertIn("nope", joined)
+
+    def test_a_raising_subscriber_does_not_unsubscribe_itself(self):
+        calls = []
+
+        def flaky(data):
+            calls.append(data)
+            raise RuntimeError("every time")
+
+        event = Event()
+        event.subscribe(flaky)
+
+        for _ in range(3):
+            with self.assertLogs(level="ERROR"):
+                event.emit("tick")
+
+        # Still subscribed after failing. Dropping it would be a quiet behaviour
+        # change: the operator would see the key stop updating with no error.
+        self.assertEqual(calls, ["tick", "tick", "tick"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_test/test_settings_editor_backup.py
+++ b/_test/test_settings_editor_backup.py
@@ -1,0 +1,64 @@
+"""Saving settings must never be the only copy of what it overwrote.
+
+put_settings() rewrites settings.jsonc from a parsed JSON object, which drops
+every comment in the file -- 74 of its 386 lines, including the section banners
+and the per-key explanations. Preserving them is a separate change; making the
+overwrite recoverable is this one, and it is the part that must not wait.
+
+The recovery console has done this correctly all along: "Back up, then
+atomically replace. The order is not negotiable."
+"""
+
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+sys.modules.setdefault("redis", types.SimpleNamespace(StrictRedis=object))
+
+from module.app.settings_editor import SETTINGS_BACKUP_KEEP, _backup_settings
+
+
+SAMPLE = '{\n  // a comment worth keeping\n  "system": {"welcome": {"show": true}}\n}\n'
+
+
+class SettingsBackupTests(unittest.TestCase):
+    def setUp(self):
+        self.dir = Path(tempfile.mkdtemp())
+        self.settings = self.dir / "settings.jsonc"
+        self.settings.write_text(SAMPLE, encoding="utf-8")
+
+    def test_backup_is_byte_identical_including_comments(self):
+        backup = _backup_settings(self.settings)
+
+        self.assertIsNotNone(backup)
+        self.assertEqual(backup.read_bytes(), SAMPLE.encode("utf-8"))
+        # The comment is the whole reason the backup exists.
+        self.assertIn("// a comment worth keeping", backup.read_text(encoding="utf-8"))
+
+    def test_backups_rotate_rather_than_growing_without_bound(self):
+        for _ in range(SETTINGS_BACKUP_KEEP + 5):
+            _backup_settings(self.settings)
+
+        kept = list((self.dir / ".settings-backups").glob("settings.jsonc.*.bak"))
+        self.assertLessEqual(len(kept), SETTINGS_BACKUP_KEEP)
+
+    def test_saves_inside_one_second_do_not_collide(self):
+        first = _backup_settings(self.settings)
+        second = _backup_settings(self.settings)
+
+        self.assertNotEqual(first, second)
+        self.assertTrue(first.exists() and second.exists())
+
+    def test_a_missing_source_is_not_an_error(self):
+        # Writing a settings file that was never there is legitimate and must
+        # not be blocked by a failed backup.
+        self.assertIsNone(_backup_settings(self.dir / "absent.jsonc"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_test/test_settings_editor_preserves_comments.py
+++ b/_test/test_settings_editor_preserves_comments.py
@@ -1,0 +1,119 @@
+"""Saving settings must not delete the operator's comments.
+
+settings.jsonc is 74 comment lines out of 386 -- section banners and per-key
+explanations. put_settings() rewrote the file from json.dumps(parsed), which
+cannot carry comments because the parsed tree does not contain them, so every
+save deleted all of them silently.
+
+The surgical path rewrites only the spans whose values changed. Where it cannot
+-- a key added, an array resized -- the caller falls back to a full rewrite and
+has to SAY SO, which is what the last test here checks.
+"""
+
+import json
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+sys.modules.setdefault("redis", types.SimpleNamespace(StrictRedis=object))
+
+from module.config_loader import strip_jsonc
+from module.jsonc_edit import apply_updates, mask_comments
+
+SAMPLE = """{
+  // ── system ────────────────────────────────────────────
+  "system": {
+    "welcome": {
+      "show": true,
+      "message": "THIS IS A COOL MACHINE",
+      "image": null // path to a bitmap logo; overrides "message" when set
+    }
+  },
+  /* block comment, kept verbatim */
+  "arrays": {
+    "iso": { "steps": [100, 200, 400], "free": false }
+  }
+}
+"""
+
+
+def parse(text):
+    return json.loads(strip_jsonc(text))
+
+
+class PreserveCommentsTests(unittest.TestCase):
+    def test_a_scalar_change_keeps_every_comment(self):
+        current = parse(SAMPLE)
+        desired = parse(SAMPLE)
+        desired["system"]["welcome"]["show"] = False
+
+        out = apply_updates(SAMPLE, current, desired)
+
+        self.assertIsNotNone(out)
+        self.assertEqual(parse(out)["system"]["welcome"]["show"], False)
+        for fragment in ("// ── system", "// path to a bitmap logo",
+                         "/* block comment, kept verbatim */"):
+            self.assertIn(fragment, out)
+
+    def test_only_the_changed_value_is_touched(self):
+        current = parse(SAMPLE)
+        desired = parse(SAMPLE)
+        desired["arrays"]["iso"]["steps"][1] = 250
+
+        out = apply_updates(SAMPLE, current, desired)
+
+        changed = [
+            (a, b) for a, b in zip(SAMPLE.split("\n"), out.split("\n")) if a != b
+        ]
+        self.assertEqual(len(changed), 1, f"expected one changed line, got {changed}")
+        self.assertIn("250", changed[0][1])
+
+    def test_an_unchanged_save_is_byte_identical(self):
+        current = parse(SAMPLE)
+        self.assertEqual(apply_updates(SAMPLE, current, current), SAMPLE)
+
+    def test_a_string_with_a_slash_is_not_mistaken_for_a_comment(self):
+        text = '{\n  "path": "http://cinepi.local:5000/", // trailing\n  "n": 1\n}\n'
+        masked = mask_comments(text)
+
+        # The URL survives; only the real comment is blanked.
+        self.assertIn('"http://cinepi.local:5000/"', masked)
+        self.assertNotIn("trailing", masked)
+        self.assertEqual(len(masked), len(text), "offsets must be preserved")
+
+    def test_structural_changes_return_none_rather_than_guessing(self):
+        current = parse(SAMPLE)
+
+        added = parse(SAMPLE)
+        added["brand_new"] = 1
+        self.assertIsNone(apply_updates(SAMPLE, current, added))
+
+        removed = parse(SAMPLE)
+        del removed["arrays"]
+        self.assertIsNone(apply_updates(SAMPLE, current, removed))
+
+        resized = parse(SAMPLE)
+        resized["arrays"]["iso"]["steps"].append(800)
+        self.assertIsNone(apply_updates(SAMPLE, current, resized))
+
+    def test_it_works_on_the_real_settings_file(self):
+        text = (ROOT / "settings.jsonc").read_text(encoding="utf-8")
+        current = parse(text)
+        desired = parse(text)
+        desired["system"]["welcome"]["show"] = not current["system"]["welcome"]["show"]
+
+        out = apply_updates(text, current, desired)
+
+        self.assertIsNotNone(out)
+        self.assertEqual(text.count("//"), out.count("//"))
+        self.assertEqual(parse(out)["system"]["welcome"]["show"],
+                         desired["system"]["welcome"]["show"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_test/test_wb_reload_does_not_block.py
+++ b/_test/test_wb_reload_does_not_block.py
@@ -1,0 +1,106 @@
+"""A redis subscriber must never sleep on the listener thread.
+
+register_events' redis_change_handler runs on RedisController's single _listen
+thread, synchronously, ahead of eight other subscribers. It used to
+time.sleep(2) before emitting 'reload_browser' on every white-balance change,
+which stalled the whole live-state bus -- and stopped the pub/sub loop
+consuming the next message -- for those two seconds.
+"""
+
+import sys
+import threading
+import time
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+sys.modules.setdefault("redis", types.SimpleNamespace(StrictRedis=object))
+
+# Other tests in this suite stub flask_socketio as SimpleNamespace(SocketIO=object),
+# and sys.modules is process-wide, so whichever test imports first decides what
+# `flask_socketio` means for the rest of the run. events.py needs `emit` from it.
+# Top it up rather than replacing it -- clobbering the stub would break them back.
+_flask_socketio = sys.modules.get("flask_socketio")
+if _flask_socketio is not None and not hasattr(_flask_socketio, "emit"):
+    _flask_socketio.emit = lambda *args, **kwargs: None
+
+from module.redis_controller import Event, ParameterKey
+from module.app.main.events import register_events
+
+
+class FakeSocketIO:
+    def __init__(self):
+        self.emitted = []
+        self._lock = threading.Lock()
+
+    def on(self, _name):
+        return lambda fn: fn
+
+    def emit(self, name, payload=None):
+        with self._lock:
+            self.emitted.append(name)
+
+    def names(self):
+        with self._lock:
+            return list(self.emitted)
+
+
+class FakeRedisController:
+    def __init__(self):
+        self.redis_parameter_changed = Event()
+
+    def get_value(self, key, default=None):
+        return {ParameterKey.FPS_ACTUAL.value: "24"}.get(key, default)
+
+
+class FakeController:
+    iso_steps = shutter_a_steps_dynamic = fps_steps_dynamic = wb_steps = []
+
+    def calculate_dynamic_shutter_angles(self, _fps):
+        return []
+
+
+class WbReloadTests(unittest.TestCase):
+    def setUp(self):
+        self.socketio = FakeSocketIO()
+        self.redis = FakeRedisController()
+        register_events(
+            self.socketio,
+            self.redis,
+            FakeController(),
+            types.SimpleNamespace(get_background_color=lambda: "black",
+                                  populate_values=dict),
+            types.SimpleNamespace(get_available_resolutions=list, camera_model=None),
+        )
+
+    def test_a_wb_change_returns_immediately(self):
+        started = time.monotonic()
+        self.redis.redis_parameter_changed.emit(
+            {"key": ParameterKey.WB.value, "value": "5600"}
+        )
+        elapsed = time.monotonic() - started
+
+        # The old code took 2 s here, with every other subscriber waiting behind it.
+        self.assertLess(elapsed, 0.5, "the handler blocked the listener thread")
+
+    def test_the_reload_still_happens_afterwards(self):
+        self.redis.redis_parameter_changed.emit(
+            {"key": ParameterKey.WB.value, "value": "5600"}
+        )
+        self.assertNotIn("reload_browser", self.socketio.names())
+
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if "reload_browser" in self.socketio.names():
+                break
+            time.sleep(0.05)
+
+        # Deferred, not dropped -- the browser reload is still the behaviour.
+        self.assertIn("reload_browser", self.socketio.names())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cinemate-install.sh
+++ b/cinemate-install.sh
@@ -755,6 +755,16 @@ build_libcamera() {
         if grep -q 'minPixelProcessingTime = 1.0us / 380' "$controller_cpp" 2>/dev/null; then
             detail "Pi 5 overclock: libcamera minPixelProcessingTime 1.0us/380 -> 1.0us/580 (pisp)"
             run_as_pi sed -i 's#minPixelProcessingTime = 1.0us / 380#minPixelProcessingTime = 1.0us / 580#' "$controller_cpp"
+        elif grep -q 'minPixelProcessingTime = 1.0us / 580' "$controller_cpp" 2>/dev/null; then
+            detail "Pi 5 overclock: libcamera minPixelProcessingTime already at 1.0us/580"
+        else
+            # Neither value present. The grep guard makes a re-run safe, but it
+            # cannot tell "already patched" from "upstream moved this line", and
+            # the second case silently ships an overclocked RP1 without the
+            # companion fix. Say so rather than skipping quietly.
+            warn "Pi 5 overclock: could not find minPixelProcessingTime in ${controller_cpp}."
+            warn "  libcamera has probably changed upstream; the overclock companion fix was NOT applied."
+            warn "  The faster imx585 modes may not be advertised. See docs/overclocking.md."
         fi
     fi
 

--- a/src/main.py
+++ b/src/main.py
@@ -1027,6 +1027,24 @@ def run_application(args, log_queue):
         if timekeeper and hasattr(timekeeper, "stop"):
             timekeeper.stop()
 
+        # SSDMonitor owns a thread of its own and was never stopped here.
+        # USBMonitor deliberately is not in this list: it has no stop() at all,
+        # so giving it one is a design change rather than a cleanup fix.
+        if ssd_monitor is not None and hasattr(ssd_monitor, "stop"):
+            try:
+                ssd_monitor.stop()
+            except Exception:
+                logging.exception("SSD monitor did not stop cleanly")
+
+        # Last, because everything above may still want to read redis state on
+        # its way out. Without this the pub/sub thread outlived the process's
+        # own shutdown; it is a daemon, so nothing noticed.
+        if redis_controller is not None and hasattr(redis_controller, "stop_listener"):
+            try:
+                redis_controller.stop_listener()
+            except Exception:
+                logging.exception("Redis listener did not stop cleanly")
+
         if not shutdown_in_progress and not gui_stopped:
             release_console_to_text()
 

--- a/src/module/app/main/events.py
+++ b/src/module/app/main/events.py
@@ -1,5 +1,5 @@
 from flask_socketio import emit
-import time
+import threading
 from module.redis_controller import ParameterKey
 
 def register_events(socketio, redis_controller, cinepi_controller, simple_gui, sensor_detect):
@@ -106,8 +106,17 @@ def register_events(socketio, redis_controller, cinepi_controller, simple_gui, s
             emit_resolution_selection()
 
         if key == ParameterKey.WB.value:
-            time.sleep(2)  # Add a 2-second pause
-            socketio.emit('reload_browser')  # Emit event to reload the browser
+            # Defer, do not sleep. This handler runs on RedisController's single
+            # _listen thread, synchronously, ahead of eight other subscribers --
+            # sleeping here stalled the entire live-state bus for two seconds on
+            # every white-balance change, and blocked the pub/sub loop from
+            # consuming the next message at all. Same threading.Timer shape the
+            # settings editor uses to let a response land before it acts.
+            timer = threading.Timer(
+                2.0, lambda: socketio.emit('reload_browser')
+            )
+            timer.daemon = True
+            timer.start()
 
     redis_controller.redis_parameter_changed.subscribe(redis_change_handler)
 

--- a/src/module/app/settings_editor.py
+++ b/src/module/app/settings_editor.py
@@ -13,6 +13,7 @@ import logging
 import os
 import tempfile
 import threading
+from datetime import datetime, timezone
 from pathlib import Path
 
 from flask import (
@@ -170,6 +171,51 @@ def parse_settings():
     return jsonify({"ok": True, "settings": settings})
 
 
+SETTINGS_BACKUP_KEEP = 10
+
+
+def _backup_settings(dest: Path) -> Path | None:
+    """Copy *dest* aside before it is overwritten. Returns the backup path.
+
+    This deliberately reimplements what cinemate-recovery.py's backup_file()
+    does rather than importing it: that console is standard-library-only by
+    rule, must not be coupled to src/module, and is deployed to
+    /usr/local/bin -- see its module docstring. The two therefore keep
+    separate histories, and this one lives beside the settings file because
+    that directory is already known-writable by this process (put_settings
+    mkstemps into it), whereas the console's /var/lib/cinemate is root-owned.
+
+    Returns None when there is nothing to back up. A missing source is not a
+    reason to refuse the write.
+    """
+    try:
+        data = dest.read_bytes()
+    except OSError as exc:
+        logger.info("No backup taken for %s: %s", dest, exc)
+        return None
+
+    backup_dir = dest.parent / ".settings-backups"
+    try:
+        backup_dir.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        target = backup_dir / f"{dest.name}.{stamp}.bak"
+        counter = 1
+        while target.exists():  # two saves inside one second
+            target = backup_dir / f"{dest.name}.{stamp}-{counter}.bak"
+            counter += 1
+        target.write_bytes(data)
+
+        keep = sorted(backup_dir.glob(f"{dest.name}.*.bak"))[:-SETTINGS_BACKUP_KEEP]
+        for stale in keep:
+            stale.unlink(missing_ok=True)
+    except OSError as exc:
+        # Losing the backup must not lose the save -- but say so, loudly.
+        logger.error("Could not back up %s before saving: %s", dest, exc)
+        return None
+
+    return target
+
+
 @settings_editor_bp.route("/api/settings", methods=["PUT"])
 def put_settings():
     body = request.get_json(silent=True)
@@ -184,6 +230,7 @@ def put_settings():
 
     text = json.dumps(settings, indent=2, ensure_ascii=False) + "\n"
     dest = Path(SETTINGS_FILE)
+    backup = _backup_settings(dest)
     try:
         fd, tmp_path = tempfile.mkstemp(dir=str(dest.parent), prefix=".settings-editor-", suffix=".jsonc.tmp")
         try:
@@ -197,7 +244,11 @@ def put_settings():
         logger.exception("Failed to write %s", dest)
         return jsonify({"ok": False, "message": f"Could not write {dest}: {exc}"}), 500
 
-    logger.info("settings.jsonc saved via settings editor (%d bytes)", len(text))
+    logger.info(
+        "settings.jsonc saved via settings editor (%d bytes); backup: %s",
+        len(text),
+        backup or "none",
+    )
 
     cinepi_controller = current_app.config.get("CINEPI_CONTROLLER")
     restarting = False

--- a/src/module/app/settings_editor.py
+++ b/src/module/app/settings_editor.py
@@ -33,6 +33,7 @@ from module.config_loader import (
     strip_jsonc,
 )
 from module.app import boot_config, raw_files
+from module.jsonc_edit import apply_updates
 
 logger = logging.getLogger(__name__)
 
@@ -216,6 +217,37 @@ def _backup_settings(dest: Path) -> Path | None:
     return target
 
 
+def _render_settings(dest: Path, settings: dict) -> tuple[str, bool]:
+    """Produce the text to write, keeping the file's comments where possible.
+
+    Returns (text, comments_preserved). The surgical path rewrites only the
+    spans whose values changed, so comments, key order and formatting survive
+    untouched. It cannot express a structural change -- a key added or removed,
+    an array resized -- and falls back to a full json.dumps() rewrite, which is
+    correct but loses every comment. The caller must report that, not hide it.
+    """
+    full = json.dumps(settings, indent=2, ensure_ascii=False) + "\n"
+
+    try:
+        original = dest.read_text(encoding="utf-8")
+        current = json.loads(strip_jsonc(original))
+    except (OSError, ValueError) as exc:
+        # No readable file to preserve anything from -- a first write, or one
+        # the user has already broken. Either way the full rewrite is right.
+        logger.info("Rewriting %s in full (%s)", dest, exc)
+        return full, False
+
+    try:
+        edited = apply_updates(original, current, settings)
+    except Exception:  # pragma: no cover - the editor must never block a save
+        logger.exception("Surgical settings edit failed; falling back to a full rewrite")
+        return full, False
+
+    if edited is None:
+        return full, False
+    return edited, True
+
+
 @settings_editor_bp.route("/api/settings", methods=["PUT"])
 def put_settings():
     body = request.get_json(silent=True)
@@ -228,9 +260,9 @@ def put_settings():
         logger.exception("Rejected settings save: failed to normalize payload")
         return jsonify({"ok": False, "message": f"Invalid settings payload: {exc}"}), 400
 
-    text = json.dumps(settings, indent=2, ensure_ascii=False) + "\n"
     dest = Path(SETTINGS_FILE)
     backup = _backup_settings(dest)
+    text, comments_kept = _render_settings(dest, settings)
     try:
         fd, tmp_path = tempfile.mkstemp(dir=str(dest.parent), prefix=".settings-editor-", suffix=".jsonc.tmp")
         try:
@@ -245,8 +277,9 @@ def put_settings():
         return jsonify({"ok": False, "message": f"Could not write {dest}: {exc}"}), 500
 
     logger.info(
-        "settings.jsonc saved via settings editor (%d bytes); backup: %s",
+        "settings.jsonc saved via settings editor (%d bytes); comments %s; backup: %s",
         len(text),
+        "preserved" if comments_kept else "LOST (structural change)",
         backup or "none",
     )
 
@@ -261,7 +294,23 @@ def put_settings():
         timer.daemon = True
         timer.start()
 
-    return jsonify({"ok": True, "message": "Saved.", "restarting": restarting})
+    message = "Saved."
+    if not comments_kept:
+        # Say it out loud. Silently dropping the operator's annotations is how
+        # this went unnoticed in the first place.
+        message = (
+            "Saved, but the comments in settings.jsonc could not be kept: this change "
+            "altered the file's structure, so it was rewritten from scratch."
+            + (f" The previous version is at {backup}." if backup else "")
+        )
+
+    return jsonify({
+        "ok": True,
+        "message": message,
+        "restarting": restarting,
+        "comments_preserved": comments_kept,
+        "backup": str(backup) if backup else None,
+    })
 
 
 @settings_editor_bp.route("/api/config-txt", methods=["GET"])

--- a/src/module/app/settings_editor.py
+++ b/src/module/app/settings_editor.py
@@ -93,7 +93,7 @@ ACTION_METHODS = [
     {"group": "ClearHDR", "value": "set_hdr_threshold_high", "label": "Set HDR threshold high", "arg": {"type": "number", "min": 0, "max": 4095}},
     {"group": "ClearHDR", "value": "set_hdr_blend", "label": "Set HDR blend", "arg": {"type": "number", "min": 0, "max": 8}},
     {"group": "ClearHDR", "value": "set_hdr_gain_adder", "label": "Set HDR gain adder", "arg": {"type": "number", "min": 0, "max": 5}},
-    {"group": "CineMate Log", "value": "set_log", "label": "Set CineMate Log target", "arg": {"type": "select", "options": ["off", "10", "12"]}},
+    {"group": "CineMate Log", "value": "set_log_encode", "label": "Set CineMate Log target", "arg": {"type": "select", "options": ["off", "10", "12"]}},
     {"group": "Zoom / anamorphic", "value": "set_zoom", "label": "Set preview zoom", "arg": {"type": "select", "options": [1, 2], "suffix": "×"}},
     {"group": "Zoom / anamorphic", "value": "inc_zoom", "label": "Zoom in one stop"},
     {"group": "Zoom / anamorphic", "value": "dec_zoom", "label": "Zoom out one stop"},

--- a/src/module/app/templates/settings_editor.html
+++ b/src/module/app/templates/settings_editor.html
@@ -3287,7 +3287,7 @@
     { group: 'ClearHDR', value: 'set_hdr_threshold_high', label: 'Set HDR threshold high', arg: { type: 'number', min: 0, max: 4095 } },
     { group: 'ClearHDR', value: 'set_hdr_blend', label: 'Set HDR blend', arg: { type: 'number', min: 0, max: 8 } },
     { group: 'ClearHDR', value: 'set_hdr_gain_adder', label: 'Set HDR gain adder', arg: { type: 'number', min: 0, max: 5 } },
-    { group: 'CineMate Log', value: 'set_log', label: 'Set CineMate Log target', arg: { type: 'select', options: ['off','10','12'] } },
+    { group: 'CineMate Log', value: 'set_log_encode', label: 'Set CineMate Log target', arg: { type: 'select', options: ['off','10','12'] } },
     { group: 'Zoom / anamorphic', value: 'set_zoom', label: 'Set preview zoom', arg: { type: 'select', options: [1,2], suffix: '×' } },
     { group: 'Zoom / anamorphic', value: 'inc_zoom', label: 'Zoom in one stop' },
     { group: 'Zoom / anamorphic', value: 'dec_zoom', label: 'Zoom out one stop' },

--- a/src/module/jsonc_edit.py
+++ b/src/module/jsonc_edit.py
@@ -1,0 +1,199 @@
+"""Change values in a JSONC document without disturbing anything else.
+
+settings.jsonc is 74 comment lines out of 386 -- section banners and per-key
+explanations that make the file editable by hand. The web settings editor used
+to rewrite it with json.dumps(), which meant every save deleted all of them.
+
+Rewriting from the parsed tree can never preserve comments, because the tree
+does not contain them. So this module goes the other way: it locates each
+value's exact span in the *original text* and rewrites only the spans whose
+values actually changed. Everything else -- comments, blank lines, key order,
+indentation, trailing commas -- survives byte-for-byte because it is never
+touched.
+
+That only works while the document's shape is unchanged. Adding or removing a
+key, resizing an array, or changing a value's type has no span to overwrite.
+When that happens `apply_updates` returns None and the caller falls back to a
+full rewrite: the last rung still produces a correct file, it just loses the
+comments, and the caller is expected to say so out loud rather than quietly.
+
+No dependencies beyond the standard library. Pure text in, text out.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+__all__ = ["apply_updates", "mask_comments", "value_spans", "StructureChanged"]
+
+
+class StructureChanged(Exception):
+    """The document's shape changed, so no surgical edit is possible."""
+
+
+def mask_comments(text: str) -> str:
+    """Blank out // and /* */ comments, preserving every character offset.
+
+    Offsets must survive so that spans found in the masked text address the
+    same characters in the original. Comment bodies become spaces; newlines
+    inside block comments are kept so line numbers stay meaningful too.
+    """
+    out = list(text)
+    i, n = 0, len(text)
+    in_string = escape = False
+    while i < n:
+        c = text[i]
+        if in_string:
+            if escape:
+                escape = False
+            elif c == "\\":
+                escape = True
+            elif c == '"':
+                in_string = False
+            i += 1
+            continue
+        if c == '"':
+            in_string = True
+            i += 1
+            continue
+        if c == "/" and i + 1 < n and text[i + 1] == "/":
+            while i < n and text[i] != "\n":
+                out[i] = " "
+                i += 1
+            continue
+        if c == "/" and i + 1 < n and text[i + 1] == "*":
+            while i < n and not (text[i] == "*" and i + 1 < n and text[i + 1] == "/"):
+                if text[i] != "\n":
+                    out[i] = " "
+                i += 1
+            for _ in range(2):
+                if i < n:
+                    out[i] = " "
+                    i += 1
+            continue
+        i += 1
+    return "".join(out)
+
+
+class _Scanner:
+    """Recursive-descent walk that records (path -> span) for every value."""
+
+    def __init__(self, text: str):
+        self.text = text
+        self.i = 0
+        self.spans: dict[tuple, tuple[int, int]] = {}
+
+    def _ws(self) -> None:
+        while self.i < len(self.text) and self.text[self.i] in " \t\r\n,":
+            self.i += 1
+
+    def _string(self) -> str:
+        assert self.text[self.i] == '"'
+        start = self.i
+        self.i += 1
+        while self.i < len(self.text):
+            c = self.text[self.i]
+            if c == "\\":
+                self.i += 2
+                continue
+            if c == '"':
+                self.i += 1
+                return json.loads(self.text[start:self.i])
+            self.i += 1
+        raise StructureChanged("unterminated string")
+
+    def value(self, path: tuple) -> None:
+        self._ws()
+        start = self.i
+        c = self.text[self.i]
+        if c == "{":
+            self.i += 1
+            while True:
+                self._ws()
+                if self.i >= len(self.text):
+                    raise StructureChanged("unterminated object")
+                if self.text[self.i] == "}":
+                    self.i += 1
+                    break
+                key = self._string()
+                self._ws()
+                if self.text[self.i] != ":":
+                    raise StructureChanged("expected ':'")
+                self.i += 1
+                self.value(path + (key,))
+        elif c == "[":
+            self.i += 1
+            idx = 0
+            while True:
+                self._ws()
+                if self.i >= len(self.text):
+                    raise StructureChanged("unterminated array")
+                if self.text[self.i] == "]":
+                    self.i += 1
+                    break
+                self.value(path + (idx,))
+                idx += 1
+        elif c == '"':
+            self._string()
+        else:
+            while self.i < len(self.text) and self.text[self.i] not in ",}]\n \t\r":
+                self.i += 1
+        self.spans[path] = (start, self.i)
+
+
+def value_spans(text: str) -> dict[tuple, tuple[int, int]]:
+    """Map every value's path to its (start, end) offsets in *text*."""
+    scanner = _Scanner(mask_comments(text))
+    scanner.value(())
+    return scanner.spans
+
+
+def _leaves(node: Any, path: tuple = ()) -> dict[tuple, Any]:
+    if isinstance(node, dict):
+        out: dict[tuple, Any] = {}
+        for key, sub in node.items():
+            out.update(_leaves(sub, path + (key,)))
+        return out
+    if isinstance(node, list):
+        out = {}
+        for idx, sub in enumerate(node):
+            out.update(_leaves(sub, path + (idx,)))
+        return out
+    return {path: node}
+
+
+def apply_updates(text: str, current: Any, desired: Any) -> str | None:
+    """Rewrite *text* so it holds *desired* instead of *current*.
+
+    `current` must be what parsing `text` yields. Returns the edited text, or
+    **None** when the change is structural and no span-level edit expresses it
+    -- keys added or removed, an array resized, or a scalar swapped for a
+    container. Callers treat None as "fall back to a full rewrite, and tell the
+    user the comments were lost".
+    """
+    before, after = _leaves(current), _leaves(desired)
+    if before.keys() != after.keys():
+        return None
+
+    changed = {p: v for p, v in after.items() if before[p] != v}
+    if not changed:
+        return text
+
+    try:
+        spans = value_spans(text)
+    except (StructureChanged, AssertionError, IndexError, ValueError):
+        return None
+
+    edits = []
+    for path, new_value in changed.items():
+        span = spans.get(path)
+        if span is None:
+            return None
+        edits.append((span[0], span[1], json.dumps(new_value, ensure_ascii=False)))
+
+    # Apply right-to-left so earlier offsets stay valid.
+    out = text
+    for start, end, replacement in sorted(edits, reverse=True):
+        out = out[:start] + replacement + out[end:]
+    return out

--- a/src/module/logger.py
+++ b/src/module/logger.py
@@ -3,14 +3,41 @@ from termcolor import colored
 import queue
 import os
 
+# Only the newest entries are ever read (main.py's get_recent_log_lines takes
+# the last 40), so the queue only has to be deep enough to survive a burst.
+LOG_QUEUE_MAXSIZE = 2000
+
+
 class QueueHandler(logging.Handler):
+    """Keep the most recent log lines in memory for the startup-failure view.
+
+    Nothing drains this queue -- its only reader peeks under the mutex and
+    takes a tail -- so an unbounded queue grew for the entire life of the
+    process. On a camera left running for days that is a slow leak with no
+    upper bound.
+
+    Bounded, and full means drop the OLDEST: the newest lines are the ones
+    worth having when something has just gone wrong. Never blocks, because
+    this runs inline on whichever thread called logging.
+    """
+
     def __init__(self, log_queue):
         super().__init__()
         self.log_queue = log_queue
-        
+
     def emit(self, record):
         log_entry = self.format(record)
-        self.log_queue.put(log_entry)
+        try:
+            self.log_queue.put_nowait(log_entry)
+        except queue.Full:
+            try:
+                self.log_queue.get_nowait()
+            except queue.Empty:  # pragma: no cover - another thread drained it
+                pass
+            try:
+                self.log_queue.put_nowait(log_entry)
+            except queue.Full:  # pragma: no cover - lost a race; dropping is correct
+                pass
       
 class ColoredFormatter(logging.Formatter):
     """
@@ -120,7 +147,7 @@ def configure_logging(level=logging.INFO):
     logger.addHandler(file_handler)
 
     # Queue handler for in-app UI or processing
-    log_queue = queue.Queue()
+    log_queue = queue.Queue(maxsize=LOG_QUEUE_MAXSIZE)
     queue_handler = QueueHandler(log_queue)
     queue_handler.setFormatter(formatter)
     logger.addHandler(queue_handler)

--- a/src/module/redis_controller.py
+++ b/src/module/redis_controller.py
@@ -153,8 +153,20 @@ class Event:
         except ValueError:
             pass
     def emit(self, data=None):
+        # Every subscriber runs on the single _listen thread, synchronously. An
+        # unguarded raise here used to kill that thread outright, and because
+        # get_value() serves the cache rather than redis, every surface then went
+        # on rendering its last values with no error anywhere -- the operator sees
+        # plausible frozen numbers mid-take. One bad subscriber must not silence
+        # the others or the bus. Mirrors CinePiController._notify_resolution_change.
         for fn in list(self._handlers):
-            fn(data)
+            try:
+                fn(data)
+            except Exception:
+                logging.exception(
+                    "Redis subscriber %s failed; continuing with the rest",
+                    getattr(fn, "__qualname__", fn),
+                )
 
 # ────────────────────────── main controller class ────────────────────
 class RedisController:
@@ -177,6 +189,15 @@ class RedisController:
         self._thread = threading.Thread(target=self._listen, daemon=True)
         self._thread.start()
 
+    def listener_alive(self) -> bool:
+        """Is the pub/sub listener still running?
+
+        If this is False the cache is frozen: get_value() keeps answering, but
+        with whatever it last saw. Nothing here restarts the thread -- callers
+        that care should surface it rather than paper over it.
+        """
+        return bool(self._thread and self._thread.is_alive())
+
     # ─────────────────────── initial cache fill ─────────────────────
     def _prime_cache(self):
         for key in self.r.keys("*"):
@@ -187,28 +208,37 @@ class RedisController:
     # ─────────────────────── background listener ────────────────────
     def _listen(self):
         for msg in self.ps.listen():
-            if msg["type"] != "message":
-                continue
-            key = msg["data"].decode()
-            with self.lock:
-                # suppress echo of own writes
-                if key in self.local_updates:
-                    self.local_updates.remove(key)
-                value = (self.r.get(key) or b"").decode()
-                self.cache[key] = value
+            try:
+                self._handle_message(msg)
+            except Exception:
+                # Same reasoning as Event.emit: losing this thread freezes all
+                # live state silently. A bad message is survivable; a dead
+                # listener is not.
+                logging.exception("Redis listener failed on message %r; continuing", msg)
 
-            if key == ParameterKey.IS_RECORDING.value:
-                if value == "0":
-                    self._stop_recording_timer()
-            elif key == ParameterKey.REC.value:
-                if value == "1":
-                    # Start timer on first frame of take; don't restart if already running
-                    # (rec can bounce 0→1 during pipeline stalls without ending the take)
-                    if not (self._rec_timer_thread and self._rec_timer_thread.is_alive()):
-                        self._start_recording_timer()
-            # notify subscribers – no log spam here
-            if key != ParameterKey.FPS_ACTUAL.value:
-                self.redis_parameter_changed.emit({"key": key, "value": value})
+    def _handle_message(self, msg):
+        if msg["type"] != "message":
+            return
+        key = msg["data"].decode()
+        with self.lock:
+            # suppress echo of own writes
+            if key in self.local_updates:
+                self.local_updates.remove(key)
+            value = (self.r.get(key) or b"").decode()
+            self.cache[key] = value
+
+        if key == ParameterKey.IS_RECORDING.value:
+            if value == "0":
+                self._stop_recording_timer()
+        elif key == ParameterKey.REC.value:
+            if value == "1":
+                # Start timer on first frame of take; don't restart if already running
+                # (rec can bounce 0→1 during pipeline stalls without ending the take)
+                if not (self._rec_timer_thread and self._rec_timer_thread.is_alive()):
+                    self._start_recording_timer()
+        # notify subscribers – no log spam here
+        if key != ParameterKey.FPS_ACTUAL.value:
+            self.redis_parameter_changed.emit({"key": key, "value": value})
 
     # ───────────────────────── public helpers ───────────────────────
     def get_value(self, key, default=None):

--- a/src/module/ssd_monitor.py
+++ b/src/module/ssd_monitor.py
@@ -149,11 +149,22 @@ class SSDMonitor:
         self._thread.start()
         logging.info("SSD monitoring thread started.")
 
-    def stop(self) -> None:
+    def stop(self, timeout: float = 2.0) -> None:
+        """Stop the mount-watch thread.
+
+        Used to join self._jthread as well, which raised AttributeError every
+        time: the journal thread's creation is commented out just above its
+        own loop. Having no caller was the only reason that never surfaced.
+
+        Bounded join -- shutdown must not hang on a thread that is wedged in a
+        blocking poll.
+        """
         self._stop_evt.set()
-        self._thread.join()
-        self._jthread.join()
-        logging.info("SSD monitoring stopped.")
+        self._thread.join(timeout=timeout)
+        if self._thread.is_alive():
+            logging.warning("SSD monitor thread did not stop within %.1fs", timeout)
+        else:
+            logging.info("SSD monitoring stopped.")
 
     # ------------------------------------------------------------------
     # read-only properties


### PR DESCRIPTION
Batch **B3** of the system review's remediation plan — **complete**, 8 commits. Review branch: `claude/cinemate-system-review-kickoff-cilicc`, PR #129. Style/lint work is the companion PR #131.

B3 went first because these are the worst defects the review found, each fix is small, and in several cases **the correct implementation already existed a few hundred lines away in this repository.**

`_test/` is green after every commit: **403 tests + 241 subtests, ~4 s, no Pi.**

---

| commit | fix |
|---|---|
| `7be6289` | one bad redis subscriber no longer kills the live-state bus |
| `6dca442` | back up `settings.jsonc` before overwriting it |
| `2af31c6` | stop sleeping 2 s inside a redis subscriber |
| `4ff9fbb` | keep `settings.jsonc`'s comments through a save |
| `ddd0ccf` | stop the SSD monitor and the redis listener on shutdown |
| `998b6aa` | `set_log` does not exist; it is `set_log_encode` |
| `3ccc559` | bound the in-app log queue |
| `5b4704a` | say so when the libcamera overclock patch cannot apply |

## The two that matter most

**`7be6289`** — `Event.emit` dispatched nine subscribers in a bare loop with no exception guard, on `RedisController`'s single `_listen` thread, which had no guard either. One raise killed that thread permanently. Because `get_value()` answers from the cache, **nothing failed loudly**: HDMI GUI, browser, `/api/v1/status` and the `:8888` broadcast would all keep rendering the values they last saw. Mid-take, plausible frozen numbers with no error is the worst failure this system has. The guarded version of this exact loop already existed at `cinepi_controller.py:1082-1087`.

**`998b6aa`** — the CineMate Log button silently did nothing. Actions dispatch via `getattr`, so an unresolvable name isn't an error, it's silence. The catalogue exists three times and the two hand-maintained copies agreed perfectly — *including on the wrong entry*. The comment above the Python copy even announces itself as a corrected version that fixed three non-resolving entries; it fixed three and left this one.

## Comment preservation (`4ff9fbb`)

`json.dumps` can never preserve comments — the parsed tree doesn't contain them. New `jsonc_edit` module goes the other way: it finds each value's exact span in the original text and rewrites only what changed. Flipping one boolean in the real `settings.jsonc` now changes **exactly one line** and keeps all 75 comment markers. Comments are located by masking `//` and `/* */` to spaces first, preserving offsets, so a URL inside a string isn't mistaken for one.

Structural changes (key added, array resized) have no span to overwrite — those fall back to a full rewrite, and the response **says** the comments were lost and names the backup. Silence is how this went unnoticed.

## Three corrections to the review, made while implementing

- **`USBMonitor` has no `stop()`.** F-023 said it did — that's `AudioMonitor.stop()`. `USBMonitor` has no shutdown path at all, so giving it one is a design change and is deliberately not here.
- **`SSDMonitor.stop()` would have raised `AttributeError`** if anything had called it: it joins `self._jthread`, whose creation is commented out. A broken function and no caller were hiding each other.
- **`Mediator.handle_fps_change` and `handle_shutter_a_change` do nothing at all** — found in #131. Both subscribed, both no-ops.

## Verification

Desk only — **nothing here has run on a Pi**. Every fix has tests that fail against the original code and pass against the change, verified in both directions.

Also worth knowing: `_test/` runs clean off-hardware in ~4 s on nine pip packages. As far as the review knew, this suite had **never been executed by anything** (F-006, F-222). That suggests the CI test job can gate at zero immediately rather than starting in discovery mode.

## Pi verification still owed

**PI-014** — force a subscriber to raise, confirm each surface's behaviour before and after. **PI-013** — log-queue growth rate. **PI-004/PI-012** — a clean install exercises `5b4704a`'s new branch.