### PR TITLE
B4 · style and lint findings from the system review

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,32 @@
+# Keep editors from reflowing files. Paired with ruff.toml.
+#
+# The one uncontroversial item in this proposal. Costs nothing, changes no
+# existing bytes on its own, and stops the next editor from reflowing a file.
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.{json,jsonc,yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[*.{sh,bash}]
+indent_style = space
+indent_size = 4
+
+[Makefile]
+indent_style = tab
+
+[*.md]
+# Markdown uses two trailing spaces as a hard line break. Stripping them
+# silently changes rendered output -- and docs/ is a published site.
+trim_trailing_whitespace = false

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,107 @@
+# Everything a pull request can be checked against without a Raspberry Pi.
+#
+# Read-only by design: nothing here publishes, pushes or comments. The docs
+# workflow keeps its write scopes for the two publishing steps it guards to
+# main; this file needs none of that.
+
+name: checks
+
+on:
+  pull_request:
+  push:
+    branches: [dev, main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+
+  lint:
+    name: ruff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'   # Raspberry Pi OS bookworm
+      - run: python -m pip install ruff
+      - run: ruff check src/
+
+  test:
+    name: pytest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      # Deliberately NOT `pip install -r requirements.txt`. That file is read by
+      # nothing, lists a stdlib module, and does not match what the installer
+      # builds. Reconciling those is its own piece of work; until then this
+      # lists what the tests actually import.
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest psutil redis pillow numpy termcolor \
+            flask flask_socketio pyudev jsonschema
+
+      # The whole suite is portable -- it needs no camera, no redis server and
+      # no GPIO, and runs in a couple of seconds. It had never been executed by
+      # anything before this workflow existed.
+      #
+      # -p no:randomly on purpose: two tests install flask_socketio into
+      # sys.modules as a stub and never clean it up, so collection order
+      # currently decides what that module means for the rest of the run.
+      # Randomising would go red on ordering alone. Fixing that is a separate
+      # change; until then this pins the order rather than pretending.
+      - run: python -m pytest _test/ -q -p no:randomly
+
+  shell:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: shellcheck
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y shellcheck
+          find . -name '*.sh' -not -path './.git/*' -print0 \
+            | xargs -0 shellcheck -f gcc
+
+  drift:
+    name: contract drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python -m pip install jsonschema
+
+      # These four exist because the same defect kept recurring: two copies of
+      # one fact, kept in step by hand, drifting apart. A comment is not a
+      # check. Each gates the boundary it was written for.
+
+      - name: Docs match the code
+        run: python3 tools/docs_drift_check.py --repo . --strict
+
+      - name: Design tokens match between the GUIs
+        run: python3 tools/design_token_diff.py --repo . --strict
+
+      # Gate at zero once the set_log fix lands; one known unresolved name
+      # until then. Raising this number is never the fix.
+      - name: Every offered action resolves on the controller
+        run: python3 tools/gui_field_extract.py --repo . --max-unresolved 1
+
+      # Needs both repositories: the key contract spans them.
+      - name: Check out cinepi-raw
+        run: |
+          GIT_LFS_SKIP_SMUDGE=1 git clone --depth 1 --branch dev \
+            https://github.com/Tiramisioux/cinepi-raw ../cinepi-raw
+
+      # A ratchet, not a gate. 12 keys cinepi-raw touches have no reference in
+      # cinemate today; the check exists to stop a thirteenth appearing
+      # unnoticed, not to fail until those twelve are triaged.
+      - name: Cross-repo redis key contract
+        run: python3 tools/redis_key_diff.py --max-unreferenced 12

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,8 @@
 name: build-and-deploy-doc
 
-# grant the job permission to push and deploy Pages
+# Write scopes are needed only by the two publishing steps at the end, which
+# are guarded to main. Everything else -- including every pull request build --
+# runs read-only.
 permissions:
   contents: write
   pages: write
@@ -10,6 +12,8 @@ on:
   push:
     branches:
       - main
+      - dev
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -64,7 +68,13 @@ jobs:
           path: site/renders/*.pdf
           if-no-files-found: ignore
 
+      # PUBLISHING STARTS HERE. Everything above is a build and is safe to run
+      # on a pull request; these last two steps are not. Without this guard a
+      # PR build would publish gh-pages from the PR's own docs, and the step
+      # below would push a commit onto the PR branch -- or fail outright from a
+      # fork, where GITHUB_TOKEN is read-only.
       - name: Deploy to GitHub Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -75,7 +85,10 @@ jobs:
           allow_empty_commit: true
 
       - name: Copy PDF to docs/renders and push
-        if: steps.rendered_pdf.outputs.exists == 'true'
+        if: >
+          github.event_name == 'push' &&
+          github.ref == 'refs/heads/main' &&
+          steps.rendered_pdf.outputs.exists == 'true'
         run: |
           cp site/renders/Cinemate-Docs.pdf docs/renders/
           git config user.name "CI"

--- a/_test/test_settings_schema_rejects_unknown_keys.py
+++ b/_test/test_settings_schema_rejects_unknown_keys.py
@@ -1,0 +1,75 @@
+"""The schema has to be able to say no.
+
+settings.schema.json carried "additionalProperties": true at 25 sites and
+false at none, including at the document root, so a misspelled key validated
+clean and was then silently ignored at read time. Nothing in the running
+system validates against this schema -- it is editor tooling -- which is
+exactly why it has to be strict: the editor is the only place a typo can be
+caught before it costs someone a shoot.
+
+Tightening it also required completing it: cam_config described three
+properties where the shipped settings use seven.
+"""
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from module.config_loader import strip_jsonc
+
+try:
+    import jsonschema
+except ImportError:  # pragma: no cover - jsonschema is a dev convenience, not a runtime dep
+    jsonschema = None
+
+
+def load(path):
+    return json.loads(strip_jsonc(Path(path).read_text(encoding="utf-8")))
+
+
+@unittest.skipIf(jsonschema is None, "jsonschema not installed")
+class SchemaStrictnessTests(unittest.TestCase):
+    def setUp(self):
+        self.schema = json.loads((ROOT / "settings.schema.json").read_text(encoding="utf-8"))
+        self.validator = jsonschema.Draft7Validator(self.schema)
+
+    def test_every_shipped_settings_file_validates(self):
+        for name in ("settings.jsonc",
+                     "resources/settings/settings_default.jsonc",
+                     "resources/settings/settings_komodo.jsonc"):
+            with self.subTest(name):
+                errors = list(self.validator.iter_errors(load(ROOT / name)))
+                self.assertEqual(
+                    errors, [],
+                    "\n".join(f"{'/'.join(map(str, e.absolute_path)) or '<root>'}: {e.message}"
+                              for e in errors))
+
+    def test_a_misspelled_top_level_section_is_rejected(self):
+        doc = load(ROOT / "settings.jsonc")
+        doc["systemm"] = doc.pop("system")
+        self.assertTrue(list(self.validator.iter_errors(doc)))
+
+    def test_a_misspelled_nested_key_is_rejected(self):
+        doc = load(ROOT / "settings.jsonc")
+        doc["system"]["wifi_hotspott"] = {"name": "oops"}
+        self.assertTrue(list(self.validator.iter_errors(doc)))
+
+    def test_a_misspelled_per_sensor_key_is_rejected(self):
+        doc = load(ROOT / "settings.jsonc")
+        doc["sensors"]["cam0"]["camera_nmae"] = "typo"
+        self.assertTrue(list(self.validator.iter_errors(doc)))
+
+    def test_no_object_is_left_open(self):
+        # A single additionalProperties:true anywhere reopens the hole for
+        # everything under it.
+        raw = (ROOT / "settings.schema.json").read_text(encoding="utf-8")
+        self.assertNotIn('"additionalProperties": true', raw)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cinemate-install.sh
+++ b/cinemate-install.sh
@@ -108,7 +108,8 @@ KERNEL_BASELINE_HEADERS_META_PKG_2712="${KERNEL_BASELINE_HEADERS_META_PKG_2712:-
 RASPI_FIRMWARE_VERSION_2712="${RASPI_FIRMWARE_VERSION_2712:-1.20260521-1~bookworm}"
 KERNEL_ROLLBACK_DIR="${KERNEL_ROLLBACK_DIR:-/var/tmp/cinemate-kernel-baseline}"
 
-readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
 readonly MANAGED_BEGIN="# >>> cinemate-install >>>"
 readonly MANAGED_END="# <<< cinemate-install <<<"
 # Parallel build jobs. On boards with < 4 GB RAM (1 GB / 2 GB models) heavy

--- a/cinemate-update.sh
+++ b/cinemate-update.sh
@@ -12,18 +12,22 @@ CINEMATE_DIR=${CINEMATE_DIR:-$(cd "$(dirname "$0")" && pwd)}
 update_repo() {
     local dir="$1"
     local name="$2"
-    echo "\n----- Checking $name -----"
+    printf '\n----- Checking %s -----\n' "$name"
     if [ ! -d "$dir/.git" ]; then
         echo "[Error] $name repo not found at $dir"
         return 1
     fi
     cd "$dir"
-    local branch=$(git rev-parse --abbrev-ref HEAD)
+    local branch
+    branch=$(git rev-parse --abbrev-ref HEAD)
     echo "Current branch: $branch"
     echo "Fetching latest changes..."
     git fetch
-    local local_rev=$(git rev-parse @)
-    local remote_rev=$(git rev-parse @{u})
+    local local_rev remote_rev
+    local_rev=$(git rev-parse @)
+    # shellcheck disable=SC1083  # @{u} is git syntax for the upstream ref,
+    # not brace expansion.
+    remote_rev=$(git rev-parse "@{u}")
     if [[ "$local_rev" == "$remote_rev" ]]; then
         echo "$name is up to date."
         REPO_UPDATED=0
@@ -65,4 +69,4 @@ else
     echo "Cinemate already at latest version."
 fi
 
-echo "\nAll done."
+printf '\nAll done.\n'

--- a/docs/cli-user-guide.md
+++ b/docs/cli-user-guide.md
@@ -65,7 +65,7 @@ For cinepi-raw, this file defines the port used by cpp-mjpeg-streamer (default c
 
 !!! note ""
 
-    If you have more than one camera connected to the Pi, and activated in `boot/firmware/config.txt`, the camera connected to physical cam0 will use `/home/pi/post-processing0.json` and the camera connected to cam1 will use `/home/pi/post-processing1.json`.
+    If you have more than one camera connected to the Pi, and activated in `/boot/firmware/config.txt`, the camera connected to physical cam0 will use `/home/pi/post-processing0.json` and the camera connected to cam1 will use `/home/pi/post-processing1.json`.
 
 ## Cinemate‑specific flags
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -22,11 +22,17 @@ select = [
     "S110",   # try-except-pass
     "S112",   # try-except-continue
     "T201",   # `print` found
-    "ARG001", # unused function argument
-    "ARG002", # unused method argument
     "B006",   # mutable default argument
     "B008",   # function call in default argument
 ]
+
+# ARG001/ARG002 are deliberately NOT selected. They were worth one pass -- they
+# found configure_logging()'s parameter that the function never read, and the
+# dead module constant feeding it. Every remaining hit is signature-required:
+# signal handlers (sig, frame), pyudev callbacks (action, device, model,
+# serial), and public keyword parameters callers pass by name. Keeping the rule
+# would mean nine permanent suppressions for nothing, which is how a check earns
+# being switched off.
 
 ignore = [
     "E501",   # line too long.

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,65 @@
+# Deliberately small. A rule is here only if it catches something this codebase
+# actually does; the rest of ruff's catalogue answers problems CineMate does not
+# have. Each selection below names the defect it was chosen for.
+
+line-length = 100          # matches what src/ mostly already does
+target-version = "py311"   # Raspberry Pi OS bookworm ships 3.11
+
+# Vendored and generated code is out of scope.
+extend-exclude = [
+    "src/module/grove_base_hat_adc.py",  # vendored Seeed driver, upstream style
+    "docs",
+    "site",
+]
+
+[lint]
+select = [
+    "E9",     # syntax errors — the floor
+    "F82",    # undefined name
+    "F401",   # unused import
+    "F841",   # unused local variable
+    "E722",   # bare `except:`
+    "S110",   # try-except-pass
+    "S112",   # try-except-continue
+    "T201",   # `print` found
+    "ARG001", # unused function argument
+    "ARG002", # unused method argument
+    "B006",   # mutable default argument
+    "B008",   # function call in default argument
+]
+
+ignore = [
+    "E501",   # line too long.
+              # Deliberate. Enforcing it retroactively flags hundreds of lines,
+              # several of them the load-bearing comments catalogued in F-133,
+              # and the noise would bury the twelve rules above.
+]
+
+# ---------------------------------------------------------------------------
+# DO NOT ADD `ERA001` (commented-out code).
+#
+# F-133 catalogued 47 comments in this repository that encode *why*, including
+# two falsified experiments -- ssd_monitor.py:1122-1125 records that 1 MB exFAT
+# clusters break the macOS driver -- and the cross-repo AUDIO-CORE INVARIANT at
+# storage_profiles.py:41-49. Several are commented-out code kept deliberately as
+# the record of what was tried and did not work.
+#
+# ERA001 would delete the most valuable prose in the codebase, and the diff
+# would look like cleanup. This comment exists so that nobody adds the rule
+# later without reading F-133 first.
+# ---------------------------------------------------------------------------
+
+[lint.per-file-ignores]
+# `print` is the correct call in these three places:
+#   - cinepi_controller.py renders a CLI parameter table to stdout.
+#   - main.py:573 reports a log-file removal failure from *inside* setup_logging,
+#     before any handler exists -- logging there would go nowhere. (The second
+#     print in main.py, "VU levels:", is leftover debug and should be removed
+#     rather than ignored.)
+#   - _test/ is scripts, not library code.
+"src/module/cinepi_controller.py" = ["T201"]
+"src/main.py" = ["T201"]
+"_test/*" = ["T201", "S110", "S112", "ARG001", "ARG002"]
+
+[lint.flake8-bugbear]
+extend-immutable-calls = []

--- a/scripts/pi_cinemate_cli.sh
+++ b/scripts/pi_cinemate_cli.sh
@@ -2,10 +2,6 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-STATE_DIR="/tmp"
-INPUT_FILE="$STATE_DIR/cinemate_cli.in"
-LOG_FILE="$STATE_DIR/cinemate_cli.log"
-PID_FILE="$STATE_DIR/cinemate_cli.pid"
 
 usage() {
   cat <<'EOF'

--- a/services/cinemate-autostart/camera-ready.sh
+++ b/services/cinemate-autostart/camera-ready.sh
@@ -107,9 +107,9 @@ detect_camera() {
 
     # Run cinepi-raw --list-cameras and capture output
     local output
-    local exit_code=0
-
-    output=$(cinepi-raw --list-cameras 2>&1) || exit_code=$?
+    # Readiness is decided by what the listing says, not by the exit status:
+    # cinepi-raw can exit non-zero and still have printed a usable camera line.
+    output=$(cinepi-raw --list-cameras 2>&1) || true
 
     # Check if we got any camera output
     # cinepi-raw lists cameras as: "0 : imx283 [5472x3648 ...] (...)"

--- a/services/cinemate-autostart/cinemate-startup-failure.sh
+++ b/services/cinemate-autostart/cinemate-startup-failure.sh
@@ -1,3 +1,7 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2317  # `return || exit` is the sourced-or-executed
+# idiom: whichever half applies, the other looks unreachable to a linter.
+# Sourced from /etc/profile.d/, so no shebang: the shell is the login shell.
 failure_file="${CINEMATE_STARTUP_FAILURE_FILE:-/home/pi/.cache/cinemate/startup-failure.ansi}"
 
 case $- in

--- a/settings.schema.json
+++ b/settings.schema.json
@@ -10,10 +10,23 @@
           "type": "object",
           "description": "Startup splash. If Plymouth is active during boot, Cinemate waits for it to hand off before showing this so the screen transition stays clean.",
           "properties": {
-            "show": { "type": "boolean", "default": true },
-            "message": { "type": "string", "default": "THIS IS A COOL MACHINE" },
+            "show": {
+              "type": "boolean",
+              "default": true
+            },
+            "message": {
+              "type": "string",
+              "default": "THIS IS A COOL MACHINE"
+            },
             "image": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "default": null,
               "description": "Path to a bitmap logo, e.g. /home/pi/welcome_image.bmp. Overrides message when set."
             }
@@ -22,8 +35,14 @@
         "wifi_hotspot": {
           "type": "object",
           "properties": {
-            "name": { "type": "string", "default": "CinePi" },
-            "password": { "type": "string", "default": "11111111" },
+            "name": {
+              "type": "string",
+              "default": "CinePi"
+            },
+            "password": {
+              "type": "string",
+              "default": "11111111"
+            },
             "enabled": {
               "type": "boolean",
               "default": true,
@@ -35,32 +54,63 @@
           "type": "object",
           "description": "HTTP/UDP control API over the Wi-Fi hotspot (docs/web-api.md). A missing or partial block behaves as the defaults shown here.",
           "properties": {
-            "enabled": { "type": "boolean", "default": true },
-            "token": { "type": "string", "default": "" },
+            "enabled": {
+              "type": "boolean",
+              "default": true
+            },
+            "token": {
+              "type": "string",
+              "default": ""
+            },
             "allow_destructive": {
               "type": "boolean",
               "default": false,
               "description": "false blocks reboot/shutdown/erase/format over the API. The hotspot password ships as 11111111, so this defaults to false."
             },
-            "max_commands_per_sec": { "type": "integer", "default": 20 },
-            "max_sse_clients": { "type": "integer", "default": 4 },
+            "max_commands_per_sec": {
+              "type": "integer",
+              "default": 20
+            },
+            "max_sse_clients": {
+              "type": "integer",
+              "default": 4
+            },
             "broadcast": {
               "type": "object",
               "properties": {
-                "enabled": { "type": "boolean", "default": true },
-                "port": { "type": "integer", "default": 8888 },
-                "hz": { "type": "number", "default": 5 },
+                "enabled": {
+                  "type": "boolean",
+                  "default": true
+                },
+                "port": {
+                  "type": "integer",
+                  "default": 8888
+                },
+                "hz": {
+                  "type": "number",
+                  "default": 5
+                },
                 "keys": {
                   "type": "array",
-                  "items": { "type": "string" },
-                  "default": ["is_recording", "iso", "fps", "shutter_a_actual",
-                              "recording_tc_tod", "space_left", "drop_frame_count", "is_mounted"]
+                  "items": {
+                    "type": "string"
+                  },
+                  "default": [
+                    "is_recording",
+                    "iso",
+                    "fps",
+                    "shutter_a_actual",
+                    "recording_tc_tod",
+                    "space_left",
+                    "drop_frame_count",
+                    "is_mounted"
+                  ]
                 }
               },
-              "additionalProperties": true
+              "additionalProperties": false
             }
           },
-          "additionalProperties": true
+          "additionalProperties": false
         },
         "storage": {
           "type": "object",
@@ -72,17 +122,25 @@
             },
             "recognized_ssds": {
               "type": "array",
-              "items": { "type": "string" }
+              "items": {
+                "type": "string"
+              }
             }
           },
-          "additionalProperties": true
+          "additionalProperties": false
         },
         "recovery": {
           "type": "object",
           "description": "Standalone recovery console (its own root systemd service) for diagnosing and repairing a Cinemate that will not start. Reachable over the hotspot at http://10.42.0.1:8080. See docs/recovery-console.md. A missing block behaves exactly as the defaults shown here.",
           "properties": {
-            "enabled": { "type": "boolean", "default": true },
-            "port": { "type": "integer", "default": 8080 },
+            "enabled": {
+              "type": "boolean",
+              "default": true
+            },
+            "port": {
+              "type": "integer",
+              "default": 8080
+            },
             "token": {
               "type": "string",
               "default": "",
@@ -99,54 +157,85 @@
               "description": "Seconds to confirm a config.txt change before it auto-reverts and the Pi reboots."
             }
           },
-          "additionalProperties": true
+          "additionalProperties": false
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "sensors": {
       "type": "object",
       "description": "Per-sensor hardware: geometry, HDMI output, name spoofing, phase lock, CineMate Log, and the sensor metadata database.",
       "properties": {
-        "raw_buffer_count": { "type": "integer", "default": 0 },
+        "raw_buffer_count": {
+          "type": "integer",
+          "default": 0
+        },
         "record_policy": {
           "type": "string",
-          "enum": ["follow_preview", "always_both"],
+          "enum": [
+            "follow_preview",
+            "always_both"
+          ],
           "default": "follow_preview",
           "description": "Dual-sensor record policy. follow_preview: recording follows the HDMI preview -- a full-screen or pip-main sensor records alone, side-by-side records both. always_both: force both sensors every take regardless of preview. A camera token on `rec` (rec cam0/cam1/both) overrides either policy for one take. No effect with a single sensor."
         },
-        "cam0": { "$ref": "#/definitions/cam_config" },
-        "cam1": { "$ref": "#/definitions/cam_config" },
+        "cam0": {
+          "$ref": "#/definitions/cam_config"
+        },
+        "cam1": {
+          "$ref": "#/definitions/cam_config"
+        },
         "database_file": {
           "type": "string",
           "default": "resources/sensors.json",
           "description": "Sensor metadata database -- every mode each sensor supports (see image_capture for the filter that picks which ones show in the UI)."
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "settings": {
       "type": "object",
       "description": "Frame-rate conform target, flicker-free input, and sync tolerances.",
       "properties": {
-        "conform_frame_rate": { "type": "number", "default": 24 },
+        "conform_frame_rate": {
+          "type": "number",
+          "default": 24
+        },
         "light_hz": {
           "type": "array",
-          "items": { "type": "number" },
+          "items": {
+            "type": "number"
+          },
           "description": "Mains frequencies to derive flicker-free shutter angles from."
         },
         "sync_tolerances": {
           "type": "object",
           "properties": {
-            "live_sync_warning_frames": { "type": "number", "minimum": 0, "default": 5 },
-            "live_sync_startup_guard_frames": { "type": "number", "minimum": 0, "default": 10 },
-            "final_sync_analysis_frames": { "type": "number", "minimum": 0, "default": 1 },
-            "tc_drop_jitter_frames": { "type": "number", "minimum": 0, "default": 1 }
+            "live_sync_warning_frames": {
+              "type": "number",
+              "minimum": 0,
+              "default": 5
+            },
+            "live_sync_startup_guard_frames": {
+              "type": "number",
+              "minimum": 0,
+              "default": 10
+            },
+            "final_sync_analysis_frames": {
+              "type": "number",
+              "minimum": 0,
+              "default": 1
+            },
+            "tc_drop_jitter_frames": {
+              "type": "number",
+              "minimum": 0,
+              "default": 1
+            }
           },
-          "additionalProperties": true
+          "additionalProperties": false
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "arrays": {
       "type": "object",
@@ -154,38 +243,86 @@
       "additionalProperties": {
         "type": "object",
         "properties": {
-          "steps": { "type": "array" },
-          "free": { "type": "boolean", "default": false },
+          "steps": {
+            "type": "array"
+          },
+          "free": {
+            "type": "boolean",
+            "default": false
+          },
           "free_increment": {
             "type": "number",
             "exclusiveMinimum": 0,
             "description": "Step size used when free is true, e.g. 0.1 for fine sub-degree shutter-angle control."
+          },
+          "sync_increment": {
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "description": "Step size used while shutter-angle sync is active."
           }
         },
-        "additionalProperties": true
+        "additionalProperties": false
       }
     },
     "image_capture": {
       "type": "object",
       "description": "Resolution / bit-depth / HDR filters offered by `set resolution`. A filter, not the mode list itself -- see sensors.database_file.",
       "properties": {
-        "k_steps": { "type": "array", "items": { "type": "number" } },
-        "bit_depths": { "type": "array", "items": { "type": "integer" } },
+        "k_steps": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        },
+        "bit_depths": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        },
         "hdr": {
           "type": "object",
           "description": "ClearHDR (imx585) whitelist plus startup values for the live knobs. sdr/imx585_clear_hdr both true exposes the plain and the HDR modes; set imx585_clear_hdr false to hide the HDR modes. threshold_low/high (0-4095), blend (0-8), gain_adder (0-5) seed the ClearHDR knobs when a ClearHDR mode is selected -- adjust live afterwards with `set hdr threshold low/high`, `set hdr blend`, `set hdr gain adder`, or a pot/quad-rotary channel.",
           "properties": {
-            "sdr": { "type": "boolean", "default": true },
-            "imx585_clear_hdr": { "type": "boolean", "default": true },
-            "threshold_low": { "type": "integer", "minimum": 0, "maximum": 4095, "default": 0 },
-            "threshold_high": { "type": "integer", "minimum": 0, "maximum": 4095, "default": 0 },
-            "blend": { "type": "integer", "minimum": 0, "maximum": 8, "default": 0 },
-            "gain_adder": { "type": "integer", "minimum": 0, "maximum": 5, "default": 1 }
+            "sdr": {
+              "type": "boolean",
+              "default": true
+            },
+            "imx585_clear_hdr": {
+              "type": "boolean",
+              "default": true
+            },
+            "threshold_low": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 4095,
+              "default": 0
+            },
+            "threshold_high": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 4095,
+              "default": 0
+            },
+            "blend": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 8,
+              "default": 0
+            },
+            "gain_adder": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 5,
+              "default": 1
+            }
           }
         },
-        "custom_modes": { "type": "object" }
+        "custom_modes": {
+          "type": "object"
+        }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "audio_capture": {
       "type": "object",
@@ -194,27 +331,45 @@
           "type": "object",
           "description": "Settings for the 24-bit USB dsnoop path (RØDE NTG, mic_24bit alias)",
           "properties": {
-            "capture_gain_db": { "type": "number", "default": 0.0 },
-            "timecode_offset_frames": { "type": "integer", "default": 0 }
+            "capture_gain_db": {
+              "type": "number",
+              "default": 0.0
+            },
+            "timecode_offset_frames": {
+              "type": "integer",
+              "default": 0
+            }
           }
         },
         "16bit": {
           "type": "object",
           "description": "Settings for the 16-bit plain-arecord fallback path (generic USB PnP mics)",
           "properties": {
-            "capture_gain_db": { "type": "number", "default": 0.0 },
-            "timecode_offset_frames": { "type": "integer", "default": 0 }
+            "capture_gain_db": {
+              "type": "number",
+              "default": 0.0
+            },
+            "timecode_offset_frames": {
+              "type": "integer",
+              "default": 0
+            }
           }
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "hdmi_display": {
       "type": "object",
       "description": "HDMI canvas, GUI overlays, and preview zoom/source/pip/anamorphic.",
       "properties": {
-        "width": { "type": "integer", "default": 1920 },
-        "height": { "type": "integer", "default": 1080 },
+        "width": {
+          "type": "integer",
+          "default": 1920
+        },
+        "height": {
+          "type": "integer",
+          "default": 1080
+        },
         "mirror_to_both_ports": {
           "type": "boolean",
           "default": false,
@@ -223,60 +378,109 @@
         "overlays": {
           "type": "object",
           "properties": {
-            "buffer_vu_meter": { "type": "boolean", "default": true },
-            "vu_meter_hatch_lines": { "type": "boolean", "default": true }
+            "buffer_vu_meter": {
+              "type": "boolean",
+              "default": true
+            },
+            "vu_meter_hatch_lines": {
+              "type": "boolean",
+              "default": true
+            }
           },
-          "additionalProperties": true
+          "additionalProperties": false
         },
         "preview": {
           "type": "object",
           "properties": {
-            "default_zoom": { "type": "number", "default": 1.0 },
-            "zoom_steps": { "type": "array", "items": { "type": "number" } },
+            "default_zoom": {
+              "type": "number",
+              "default": 1.0
+            },
+            "zoom_steps": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
             "default_hdmi_source": {
               "type": "string",
-              "enum": ["both", "cam0", "cam1", "pip_cam0", "pip_cam1"],
+              "enum": [
+                "both",
+                "cam0",
+                "cam1",
+                "pip_cam0",
+                "pip_cam1"
+              ],
               "default": "both",
               "description": "Dual-sensor HDMI preview source at startup. Switch live with `set preview`. No effect with a single sensor."
             },
             "pip": {
               "type": "object",
               "properties": {
-                "scale": { "type": "number", "default": 0.28 },
+                "scale": {
+                  "type": "number",
+                  "default": 0.28
+                },
                 "corner": {
                   "type": "string",
-                  "enum": ["lower_right", "lower_left", "upper_right", "upper_left"],
+                  "enum": [
+                    "lower_right",
+                    "lower_left",
+                    "upper_right",
+                    "upper_left"
+                  ],
                   "default": "lower_right"
                 },
-                "margin": { "type": "number", "default": 0.03 }
+                "margin": {
+                  "type": "number",
+                  "default": 0.03
+                }
               },
-              "additionalProperties": true
+              "additionalProperties": false
             },
             "anamorphic": {
               "type": "object",
               "properties": {
-                "default_factor": { "type": "number", "default": 1.0 },
-                "steps": { "type": "array", "items": { "type": "number" } }
+                "default_factor": {
+                  "type": "number",
+                  "default": 1.0
+                },
+                "steps": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  }
+                }
               },
-              "additionalProperties": true
+              "additionalProperties": false
             }
           },
-          "additionalProperties": true
+          "additionalProperties": false
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "hardware_controls": {
       "type": "object",
       "description": "Direct-GPIO physical inputs, channel-first: buttons, switches, rotary encoders, combined actions.",
       "properties": {
-        "buttons": { "type": "array" },
-        "two_way_switches": { "type": "array" },
-        "three_way_switches": { "type": "array" },
-        "rotary_encoders": { "type": "array" },
-        "combined_actions": { "type": "array" }
+        "buttons": {
+          "type": "array"
+        },
+        "two_way_switches": {
+          "type": "array"
+        },
+        "three_way_switches": {
+          "type": "array"
+        },
+        "rotary_encoders": {
+          "type": "array"
+        },
+        "combined_actions": {
+          "type": "array"
+        }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "input_peripherals": {
       "type": "object",
@@ -289,39 +493,68 @@
             "type": "object",
             "properties": {
               "channel": {},
-              "setting": { "type": "string" }
+              "setting": {
+                "type": "string"
+              }
             }
           }
         },
         "quad_rotary_controller": {
           "type": "object",
           "properties": {
-            "enabled": { "type": "boolean", "default": false },
-            "encoders": { "type": "object" }
+            "enabled": {
+              "type": "boolean",
+              "default": false
+            },
+            "encoders": {
+              "type": "object"
+            }
           },
-          "additionalProperties": true
+          "additionalProperties": false
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "hardware_outputs": {
       "type": "object",
       "description": "Direct-GPIO outputs Cinemate drives: the REC tally/relay pin(s) and the REC sync tone.",
       "properties": {
-        "pwm_pin": { "type": "integer", "default": 19 },
-        "rec_out_pin": { "type": "array", "items": { "type": "integer" } },
+        "pwm_pin": {
+          "type": "integer",
+          "default": 19
+        },
+        "rec_out_pin": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        },
         "rec_tone": {
           "type": "object",
           "properties": {
-            "pin": { "type": "array", "items": { "type": "integer" } },
-            "frequency_hz": { "type": "integer", "default": 1000 },
-            "duty_cycle": { "type": "integer", "default": 50 },
-            "relay_drop_frames": { "type": "boolean", "default": false }
+            "pin": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            "frequency_hz": {
+              "type": "integer",
+              "default": 1000
+            },
+            "duty_cycle": {
+              "type": "integer",
+              "default": 50
+            },
+            "relay_drop_frames": {
+              "type": "boolean",
+              "default": false
+            }
           },
-          "additionalProperties": true
+          "additionalProperties": false
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "output_peripherals": {
       "type": "object",
@@ -330,10 +563,22 @@
         "oled": {
           "type": "object",
           "properties": {
-            "enabled": { "type": "boolean", "default": false },
-            "width": { "type": "integer", "default": 128 },
-            "height": { "type": "integer", "default": 64 },
-            "font_size": { "type": "integer", "default": 20 },
+            "enabled": {
+              "type": "boolean",
+              "default": false
+            },
+            "width": {
+              "type": "integer",
+              "default": 128
+            },
+            "height": {
+              "type": "integer",
+              "default": 64
+            },
+            "font_size": {
+              "type": "integer",
+              "default": 20
+            },
             "values": {
               "type": "array",
               "items": {
@@ -341,19 +586,33 @@
                   {
                     "type": "string",
                     "enum": [
-                      "iso", "shutter_a", "fps", "wb_user", "is_recording",
-                      "resolution", "cpu_load", "cpu_temp", "memory_usage", "space_left"
+                      "iso",
+                      "shutter_a",
+                      "fps",
+                      "wb_user",
+                      "is_recording",
+                      "resolution",
+                      "cpu_load",
+                      "cpu_temp",
+                      "memory_usage",
+                      "space_left"
                     ]
                   },
-                  { "type": "string" }
+                  {
+                    "type": "string"
+                  }
                 ]
               }
             }
           },
-          "additionalProperties": true
+          "additionalProperties": false
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
+    },
+    "$schema": {
+      "type": "string",
+      "description": "Path to this schema, so editors validate the file as it is typed."
     }
   },
   "definitions": {
@@ -381,13 +640,63 @@
         },
         "log_encode": {
           "description": "CineMate Log recording target for this sensor. false = off (default, opt-in only). true = on, using the live source bit depth's default target (16-bit -> 12, 12-bit -> 10). 10 or 12 = on, forcing that target explicitly -- applied only when the sensor's live source bit depth actually supports it (e.g. 10 to force 16-bit ClearHDR down to 16to10 instead of its 12 default); never silently substituted to a different target. Only sensors with a sensors.json log_encode block (currently imx585, imx283) support this -- the setting is ignored on other sensors.",
-          "type": ["boolean", "integer"],
-          "enum": [false, true, 10, 12],
+          "type": [
+            "boolean",
+            "integer"
+          ],
+          "enum": [
+            false,
+            true,
+            10,
+            12
+          ],
           "default": false
+        },
+        "camera_name": {
+          "type": "string",
+          "description": "Name reported to the stack for this sensor. Only consulted when override_camera_name is true."
+        },
+        "override_camera_name": {
+          "type": "boolean",
+          "default": false,
+          "description": "Report camera_name instead of the sensor's detected model."
+        },
+        "geometry": {
+          "type": "object",
+          "description": "Sensor read-out orientation, applied at capture.",
+          "properties": {
+            "rotate_180": {
+              "type": "boolean",
+              "default": false
+            },
+            "horizontal_flip": {
+              "type": "boolean",
+              "default": false
+            },
+            "vertical_flip": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "output": {
+          "type": "object",
+          "description": "Which HDMI connector this sensor's preview goes to.",
+          "properties": {
+            "hdmi_port": {
+              "type": "integer",
+              "enum": [
+                0,
+                1
+              ]
+            }
+          },
+          "additionalProperties": false
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     }
   },
-  "additionalProperties": true
+  "additionalProperties": false
 }

--- a/src/main.py
+++ b/src/main.py
@@ -45,7 +45,6 @@ from module.console_display import (
 from module.framebuffer import acquire_framebuffer
 
 # Constants
-MODULES_OUTPUT_TO_SERIAL = ['cinepi_controller']
 SETTINGS_FILE = "/home/pi/cinemate/settings.jsonc"
 STARTUP_MESSAGE_MIN_DURATION = 3.0
 CLI_COLOR_RED = "\033[1;31m"
@@ -576,7 +575,7 @@ def setup_logging(debug_mode):
         root_logger.removeHandler(handler)
 
     # Configure new logging handlers (file, serial, etc.)
-    return configure_logging(MODULES_OUTPUT_TO_SERIAL, logging_level)
+    return configure_logging(logging_level)
 
 def start_hotspot(settings) -> None:
     """Start the hotspot if enabled in *settings* and nothing else owns it.

--- a/src/main.py
+++ b/src/main.py
@@ -5,9 +5,7 @@ import time
 import signal
 import atexit
 import subprocess
-import traceback
 import os
-import json
 import shutil
 import socket
 from PIL import Image, ImageDraw, ImageFont
@@ -773,7 +771,9 @@ def run_application(args, log_queue):
         else:
             reserved_output_pins.update(int(pin) for pin in rec_tone_pins)
 
-    gpio_input = ComponentInitializer(
+    # Held, not used: ComponentInitializer registers the GPIO callbacks in
+    # __init__ and must outlive this scope.
+    gpio_input = ComponentInitializer(  # noqa: F841
         cinepi_controller,
         settings,
         reserved_output_pins=reserved_output_pins,
@@ -832,7 +832,8 @@ def run_application(args, log_queue):
         for p in settings.get("input_peripherals", {}).get("pots", [])
         if p.get("setting")
     }
-    analog_controls = AnalogControls(
+    # Held, not used -- starts its own polling thread.
+    analog_controls = AnalogControls(  # noqa: F841
         cinepi_controller, redis_controller,
         pot_channel_by_setting.get("iso", "None"),
         pot_channel_by_setting.get("shutter_a", "None"),
@@ -938,7 +939,8 @@ def run_application(args, log_queue):
     else:
         logging.error("No network connection found. Stream module not loaded")
 
-    mediator = Mediator(cinepi, cinepi_controller, redis_listener, redis_controller, ssd_monitor, gpio_output, stream, usb_monitor)
+    # Held, not used -- Mediator subscribes to redis events in __init__.
+    mediator = Mediator(cinepi, cinepi_controller, redis_listener, redis_controller, ssd_monitor, gpio_output, stream, usb_monitor)  # noqa: F841
 
     logging.info("--- Initialization Complete ---")
 

--- a/src/main.py
+++ b/src/main.py
@@ -12,7 +12,7 @@ from PIL import Image, ImageDraw, ImageFont
 import glob
 
 from module.config_loader import SettingsLoadError, auto_storage_preroll_enabled, load_settings
-from module.logger import configure_logging
+from module.logger import configure_logging, log_directory
 from module.redis_controller import RedisController, ParameterKey
 from module.ssd_monitor import SSDMonitor
 from module.usb_monitor import USBMonitor
@@ -557,7 +557,7 @@ def setup_logging(debug_mode):
     logging_level = logging.DEBUG if debug_mode else logging.INFO
 
     # Ensure logs directory exists
-    log_dir = '/home/pi/cinemate/src/logs'
+    log_dir = log_directory()
     os.makedirs(log_dir, exist_ok=True)
 
     # Clear existing log files

--- a/src/module/analog_controls.py
+++ b/src/module/analog_controls.py
@@ -89,7 +89,7 @@ class AnalogControls(threading.Thread):
         """Compute moving average for filtering."""
         return sum(buffer) / len(buffer) if buffer else None
 
-    def map_adc_to_steps(self, adc_value, min_adc=0, max_adc=1023, steps=[], dead_zone_ratio=0.1):
+    def map_adc_to_steps(self, adc_value, min_adc=0, max_adc=1023, steps=None, dead_zone_ratio=0.1):
         """Map ADC value to given steps with dead zones and hysteresis."""
         if not steps:
             return None

--- a/src/module/app/__init__.py
+++ b/src/module/app/__init__.py
@@ -1,4 +1,3 @@
-import os
 from flask import Flask
 from flask_socketio import SocketIO
 import logging

--- a/src/module/app/__init__.py
+++ b/src/module/app/__init__.py
@@ -1,4 +1,5 @@
 from flask import Flask
+from module.redis_controller import ParameterKey
 from flask_socketio import SocketIO
 import logging
 
@@ -21,7 +22,7 @@ def create_app(redis_controller, cinepi_controller, simple_gui, sensor_detect,
             socketio.emit('resolution_change', {
                 'sensor_mode': sensor_mode,
                 'resolution_switching': redis_controller.get_value(
-                    'resolution_switching',
+                    ParameterKey.RESOLUTION_SWITCHING.value,
                     "0",
                 ),
             })

--- a/src/module/battery_monitor.py
+++ b/src/module/battery_monitor.py
@@ -1,3 +1,4 @@
+import logging
 import threading
 import socket
 import time
@@ -18,18 +19,18 @@ class BatteryMonitor:
                 response = sock.recv(1024)
             return response.decode().strip()
         except socket.timeout:
-            print(f"Timeout: No response received for command '{command}'")
+            logging.warning(f"Timeout: No response received for command '{command}'")
             return None
         except socket.error as e:
-            print(f"Socket error for command '{command}': {e}")
+            logging.warning(f"Socket error for command '{command}': {e}")
             return None
         except Exception as e:
-            print(f"An error occurred for command '{command}': {e}")
+            logging.error(f"An error occurred for command '{command}': {e}")
             return None
 
     def detect_pisugar(self):
         """Perform multiple checks to detect if PiSugar is actually connected and functioning."""
-        print("Detecting PiSugar...")
+        logging.info("Detecting PiSugar...")
         checks = [
             ('get model', lambda x: x.startswith('model:'), "Checking PiSugar model"),
             ('get battery', lambda x: x.startswith('battery:') and float(x.split()[1]) > 0, "Checking battery level"),
@@ -37,14 +38,14 @@ class BatteryMonitor:
         ]
 
         for command, check_func, message in checks:
-            print(message + "...")
+            logging.info(message + "...")
             response = self.send_battery_command_tcp(command)
             if not response or not check_func(response):
-                print(f"PiSugar detection failed: {message}")
+                logging.warning(f"PiSugar detection failed: {message}")
                 return False
-            print(f"Success: {response}")
+            logging.info(f"Success: {response}")
         
-        print("PiSugar detected successfully.")
+        logging.info("PiSugar detected successfully.")
         return True
 
     def _update_battery_status(self):
@@ -57,7 +58,7 @@ class BatteryMonitor:
             power_plugged_response = self.send_battery_command_tcp('get battery_power_plugged')
             self.charging = power_plugged_response == 'battery_power_plugged: true'
         except Exception as e:
-            print(f"Error updating battery status: {e}")
+            logging.error(f"Error updating battery status: {e}")
 
     def _start_periodic_check(self):
         """Start the background thread to periodically check battery status."""
@@ -68,40 +69,40 @@ class BatteryMonitor:
         """Periodically check the battery status every 5 seconds and log the information."""
         while not self._stop_event.is_set():
             self._update_battery_status()
-            print(f"Battery level: {self.battery_level}%")
-            print(f"Battery charging: {'Yes' if self.charging else 'No'}")
+            logging.debug(f"Battery level: {self.battery_level}%")
+            logging.debug(f"Battery charging: {'Yes' if self.charging else 'No'}")
             time.sleep(5)
 
     def start(self):
         """Initialize battery monitoring by detecting PiSugar and setting up periodic checks if detected."""
-        print("Starting PiSugar Battery Monitor...")
+        logging.info("Starting PiSugar Battery Monitor...")
         self.pisugar_detected = self.detect_pisugar()
         if self.pisugar_detected:
-            print("Starting periodic battery checks...")
+            logging.info("Starting periodic battery checks...")
             self._start_periodic_check()
             return True
         else:
-            print("PiSugar not detected. Monitoring process will not start.")
+            logging.warning("PiSugar not detected. Monitoring process will not start.")
             return False
 
     def stop(self):
         """Stop the periodic check."""
         self._stop_event.set()
-        print("Stopping battery monitor...")
+        logging.info("Stopping battery monitor...")
 
 if __name__ == "__main__":
     monitor = BatteryMonitor()
     
     if not monitor.start():
-        print("Exiting due to PiSugar not being detected.")
+        print("Exiting due to PiSugar not being detected.")  # noqa: T201 - standalone CLI
         sys.exit(1)
     
-    print("Battery monitor is running. Press Ctrl+C to stop.")
+    print("Battery monitor is running. Press Ctrl+C to stop.")  # noqa: T201 - standalone CLI
     try:
         # Keep the script running
         while True:
             time.sleep(1)
     except KeyboardInterrupt:
         monitor.stop()
-        print("Battery monitor stopped.")
+        print("Battery monitor stopped.")  # noqa: T201 - standalone CLI
         sys.exit(0)

--- a/src/module/battery_monitor.py
+++ b/src/module/battery_monitor.py
@@ -1,5 +1,4 @@
 import threading
-import logging
 import socket
 import time
 import sys

--- a/src/module/cinepi_controller.py
+++ b/src/module/cinepi_controller.py
@@ -4,12 +4,9 @@ import threading
 import os
 import time
 import json
-from fractions import Fraction
-import math
 import subprocess
-from threading import Thread, Timer
+from threading import Timer
 import psutil
-import math
 import sys
 
 from module.redis_controller import ParameterKey, encode_log_encode_request, decode_log_encode_request

--- a/src/module/cinepi_multi.py
+++ b/src/module/cinepi_multi.py
@@ -3,13 +3,11 @@ import logging
 import re
 import json
 import time
-from pathlib import Path
 from queue import Queue
 from threading import Thread
 from typing import List, Optional
-from threading import Event as ThreadEvent
 from typing import List
-import os, signal
+import os
 import shutil
 
 from module.config_loader import load_settings

--- a/src/module/cli_commands.py
+++ b/src/module/cli_commands.py
@@ -4,6 +4,7 @@ import time
 import datetime 
 import os  
 import logging  
+import contextlib
 import select
 import sys
 
@@ -156,7 +157,7 @@ class CommandExecutor(threading.Thread):
         try:
             rtc_time = os.popen('hwclock -r').read().strip()  # Try to read RTC time
             logging.info(f"RTC Time:    {rtc_time}")  # Display the RTC time
-        except:
+        except Exception:
             logging.info("Unable to read RTC time.")  # If unable to read RTC time, log error
 
     def set_rtc_time(self):
@@ -164,7 +165,7 @@ class CommandExecutor(threading.Thread):
         try:
             os.system('sudo hwclock --systohc')  # Try to sync RTC time with system time
             logging.info("RTC Time has been set to System Time")  # Log success
-        except:
+        except Exception:
             logging.info("Unable to set the RTC time.")  # If unable to set RTC time, log error
 
     def is_valid_arg(self, arg, expected_type):
@@ -326,11 +327,10 @@ class CommandExecutor(threading.Thread):
             prompt_shown = False
             while self.running:
                 if not prompt_shown and stdin.isatty():
-                    try:
+                    # The prompt is a courtesy; a closed stdout must not end the loop.
+                    with contextlib.suppress(Exception):
                         sys.stdout.write("\n> ")
                         sys.stdout.flush()
-                    except Exception:
-                        pass
                     prompt_shown = True
 
                 try:

--- a/src/module/gpio_input.py
+++ b/src/module/gpio_input.py
@@ -433,7 +433,6 @@ class SmartButton:
             if action_dict and isinstance(action_dict, dict):
                 self.logger.debug(f"Action dict before accessing 'method': {action_dict}")
                 action_method = action_dict.get('method')
-                action_args = action_dict.get('args', [])
                 if action_method:
                     self.trigger_action(action_dict)  # Assuming you have this method implemented
                 else:

--- a/src/module/gpio_input.py
+++ b/src/module/gpio_input.py
@@ -201,7 +201,7 @@ class SmartButton:
     logger = logging.getLogger('ButtonManager')
     _currently_held = None
     
-    def __init__(self, cinepi_controller, pin, pull_up, debounce_time, actions, identifier, inverse=False, combined_actions=[]):
+    def __init__(self, cinepi_controller, pin, pull_up, debounce_time, actions, identifier, inverse=False, combined_actions=None):
         self.logger = logging.getLogger(f"SmartButton{pin}")
         self.button = Button(pin, pull_up=pull_up, bounce_time=debounce_time)
         self.actions = actions

--- a/src/module/i2c/i2c_oled.py
+++ b/src/module/i2c/i2c_oled.py
@@ -1,4 +1,4 @@
-import logging, os, threading, time
+import logging, threading, time
 from pathlib import Path
 from typing import TypedDict
 

--- a/src/module/logger.py
+++ b/src/module/logger.py
@@ -72,6 +72,25 @@ class ColoredFormatter(logging.Formatter):
 
         return f"{timestamp}: {colored_record}"
 
+DEFAULT_LOG_DIR = '/home/pi/cinemate/src/logs'
+
+
+def log_directory() -> str:
+    """Where system.log lives.
+
+    The default is unchanged from the path this has always used, because
+    deployed cameras and anything reading their logs expect it. It is a
+    function rather than a literal so that main.py's log cleanup and this
+    writer cannot drift apart -- they used to state it separately -- and so a
+    dev checkout or a test run can point somewhere else without editing source.
+
+    Note for whoever revisits this: the default puts runtime state inside the
+    source tree, which is worth changing, but moving it is an operational
+    decision rather than a tidy-up.
+    """
+    return os.environ.get('CINEMATE_LOG_DIR', DEFAULT_LOG_DIR)
+
+
 # Configure the logging
 
 def configure_logging(level=logging.INFO):
@@ -93,7 +112,7 @@ def configure_logging(level=logging.INFO):
     logger.addHandler(console_handler)
 
     # File handler (plain text)
-    log_dir = '/home/pi/cinemate/src/logs'
+    log_dir = log_directory()
     os.makedirs(log_dir, exist_ok=True)
     file_path = os.path.join(log_dir, 'system.log')
     file_handler = logging.FileHandler(file_path)

--- a/src/module/logger.py
+++ b/src/module/logger.py
@@ -74,7 +74,7 @@ class ColoredFormatter(logging.Formatter):
 
 # Configure the logging
 
-def configure_logging(MODULES_OUTPUT_TO_SERIAL, level=logging.INFO):
+def configure_logging(level=logging.INFO):
     # Base format (timestamp handled by formatter)
     log_format = '%(asctime)s.%(msecs)03d: %(levelname)s: %(module)s %(message)s'
     date_format = '%Y-%m-%d %H:%M:%S'

--- a/src/module/mediator.py
+++ b/src/module/mediator.py
@@ -1,7 +1,6 @@
 import logging
 import threading
 import json
-import time
 from module.redis_controller import ParameterKey
 
 class Mediator:
@@ -168,10 +167,13 @@ class Mediator:
         logging.info("Stop recording timeout reached. Stopping recording...")
 
     def handle_fps_change(self, data):
-        # Handle "fps" key changes
-            fps_new = self.redis_controller.get_value(ParameterKey.FPS.value)
-            
+        # Subscribed in __init__ but currently does nothing: its whole body was
+        # a read of ParameterKey.FPS whose result was never used. Left in place
+        # rather than unsubscribed, because the subscription is the documented
+        # hook -- but it is a no-op today, not a working handler.
+        return
+
     def handle_shutter_a_change(self, data):
-        # Handle "shutter_a" key changes
+        # As above: reads SHUTTER_A and does nothing with it. No-op today.
         if data['key'] == ParameterKey.SHUTTER_A.value:
-            shutter_a_new = self.redis_controller.get_value(ParameterKey.SHUTTER_A.value)
+            return

--- a/src/module/redis_listener.py
+++ b/src/module/redis_listener.py
@@ -10,7 +10,6 @@ import os
 import re
 import time
 import math
-import statistics
 
 class RedisListener:
     def __init__(
@@ -1612,7 +1611,6 @@ class RedisListener:
         file's mtime is older than settle_s (no in-flight files).
         """
         last = None
-        last_latest_mtime = None
         for _ in range(max_attempts):
             cnt, li, ln, latest_mtime = self._scan_dngs_once(folder_path)
             now = time.time()
@@ -1624,7 +1622,6 @@ class RedisListener:
                     return cnt, li, ln
 
             last = cnt
-            last_latest_mtime = latest_mtime
             time.sleep(settle_s)
 
         # final return after attempts
@@ -1791,10 +1788,6 @@ class RedisListener:
                         paused_seconds,
                     )
 
-        drop_detected_this_take = (
-            self.drop_frame_count_current_take > 0
-            or segment_index_hole_frames_total > 0
-        )
         live_drop_holes_total = (
             self.drop_frame_count_current_take * max(1, sensor_count_effective)
             if self.drop_frame_count_current_take > 0

--- a/src/module/redis_listener.py
+++ b/src/module/redis_listener.py
@@ -549,7 +549,7 @@ class RedisListener:
                     return len(ready)
                 return len(data) or 1
         except Exception:
-            pass
+            logging.debug("Could not read the camera list; falling back", exc_info=True)
 
         return 1
 
@@ -1181,7 +1181,7 @@ class RedisListener:
                 if self._coerce_int(self.redis_controller.get_value(key)) == 1:
                     return True
             except Exception:
-                pass
+                logging.debug("Unreadable flag %s; trying the next", key, exc_info=True)
         # Fallback when the redis flags are momentarily unset: prefer the
         # framesInFlight gauge (encode_queue_ + disk_buffer_) so a still-draining
         # compression backlog keeps this True even when bufferSize (disk-only)
@@ -1554,7 +1554,7 @@ class RedisListener:
                     if not base or os.path.basename(d) == base:
                         return os.path.abspath(d)
             except Exception:
-                pass
+                logging.debug("Could not inspect a candidate folder", exc_info=True)
 
         # Last attempt: if hint is relative and exists from CWD
         if hint:

--- a/src/module/serial_handler.py
+++ b/src/module/serial_handler.py
@@ -4,7 +4,6 @@ import time
 import select
 import threading
 import logging
-import queue
 import serial
 import errno
 
@@ -73,7 +72,7 @@ class SerialHandler(threading.Thread):
 
             logging.info(f"Successfully opened port {port}")
             return ser
-        except serial.SerialException as e:
+        except serial.SerialException:
             return None
 
     def _schedule_retry(self, port, immediate=False):

--- a/src/module/serial_handler.py
+++ b/src/module/serial_handler.py
@@ -1,4 +1,5 @@
 # module/serial_handler.py
+import contextlib
 import os
 import time
 import select
@@ -59,11 +60,9 @@ class SerialHandler(threading.Thread):
             )
             # Let the kernel/driver settle a moment; then drain junk.
             time.sleep(0.05)
-            try:
+            with contextlib.suppress(Exception):
                 ser.reset_input_buffer()
                 ser.reset_output_buffer()
-            except Exception:
-                pass
 
             # Filter the banner/NUL bursts that can appear on first open
             t_end = time.time() + 0.10
@@ -111,10 +110,8 @@ class SerialHandler(threading.Thread):
                 logging.warning(f"Write failed on {ser.port}: {e}")
                 dead.append(ser)
         for ser in dead:
-            try:
+            with contextlib.suppress(Exception):
                 ser.close()
-            except Exception:
-                pass
             if ser.port == '/dev/ttyACM0':
                 self.serial_connected = False
             self.serials.remove(ser)
@@ -148,20 +145,16 @@ class SerialHandler(threading.Thread):
                     logging.warning(f"Device vanished on {ser.port} (EIO). Closing and retrying later.")
                 else:
                     logging.warning(f"Read failed on {ser.port}: {e}")
-                try:
+                with contextlib.suppress(Exception):
                     ser.close()
-                except Exception:
-                    pass
                 if ser.port == '/dev/ttyACM0':
                     self.serial_connected = False
                 self.serials.remove(ser)
                 self._schedule_retry(ser.port)
             except serial.SerialException as e:
                 logging.warning(f"Serial error on {ser.port}: {e}")
-                try:
+                with contextlib.suppress(Exception):
                     ser.close()
-                except Exception:
-                    pass
                 if ser.port == '/dev/ttyACM0':
                     self.serial_connected = False
                 self.serials.remove(ser)
@@ -181,10 +174,8 @@ class SerialHandler(threading.Thread):
         # Cull ports that are no longer desired
         for ser in self.serials[:]:
             if ser.port not in self.portlist or not ser.is_open:
-                try:
+                with contextlib.suppress(Exception):
                     ser.close()
-                except Exception:
-                    pass
                 self.serials.remove(ser)
 
         self.current_ports = [s.port for s in self.serials]
@@ -218,10 +209,8 @@ class SerialHandler(threading.Thread):
         except OSError:
             pass
         for ser in self.serials[:]:
-            try:
+            with contextlib.suppress(Exception):
                 ser.close()
-            except Exception:
-                pass
         self.serials.clear()
         self.current_ports.clear()
         self.serial_connected = False

--- a/src/module/simple_gui.py
+++ b/src/module/simple_gui.py
@@ -6,12 +6,9 @@ from PIL import Image, ImageDraw, ImageFont
 from module.console_display import claim_console_for_framebuffer, release_console_to_text
 from module.framebuffer import Framebuffer, acquire_framebuffer
 from module.config_loader import load_settings
-import subprocess
 import logging
-from sugarpie import pisugar
 from flask_socketio import SocketIO
 import re
-from statistics import mean
 from module.utils import Utils
 from module.redis_controller import ParameterKey
 from module.dynamic_resolution import dynamic_resolution_indicator_active
@@ -1701,7 +1698,6 @@ class SimpleGUI(threading.Thread):
         previous_background_color = self.get_background_color()
 
         # ─── choose background colour & colour-mode ────────────────────
-        prev_bg = self.get_background_color()      # ← fixed () call
         
         try:
             preroll_active = int(
@@ -1932,12 +1928,6 @@ class SimpleGUI(threading.Thread):
             vu_bar_h = max(_MIN_BAR_H, min(_MAX_BAR_H, available))
             self.draw_framebuffer_vu_meter(draw, bar_height=vu_bar_h)
 
-        vu = self.vu_smoothed  # Or .usb_monitor.audio_monitor.vu_levels if you want raw
-        # if vu:
-        #     levels = " | ".join([f"Ch{i+1}={v:.1f}%" for i, v in enumerate(vu)])
-        #     logging.info(f"Mic levels: {levels}")
-        # else:
-        #     logging.info("Mic level: No VU data available.")
 
         if self.draw_right_col:
             self.draw_right_sections(draw, values)
@@ -1960,7 +1950,6 @@ class SimpleGUI(threading.Thread):
 
         # Reduce the top padding by reduce_top and increase the bottom by the same amount
         upper_left = ((position[0] - padding), position[1] - (padding - reduce_top)-6) 
-        bottom_right = (upper_left[0] + text_width + 2 * padding, upper_left[1] + text_height + 2 * padding + reduce_top)
         radius = 5
         radius_2x = radius * 2
 

--- a/src/module/simple_gui.py
+++ b/src/module/simple_gui.py
@@ -652,21 +652,23 @@ class SimpleGUI(threading.Thread):
         cpu_load = self._slow_values.get("cpu_load", "0%")
         cpu_temp = self._slow_values.get("cpu_temp", "--")
 
+        # Keep the previous reading rather than blanking the GUI. debug, not
+        # warning: this sits on the redraw path and would flood at 12 fps.
         try:
             cpu_load = Utils.cpu_load()
         except Exception:
-            pass
+            logging.debug("cpu_load unavailable; keeping the last value", exc_info=True)
 
         try:
             cpu_temp = Utils.cpu_temp()
         except Exception:
-            pass
+            logging.debug("cpu_temp unavailable; keeping the last value", exc_info=True)
 
         if self.ssd_monitor:
             try:
                 latest_recording_info = self.ssd_monitor.get_latest_recording_info()
             except Exception:
-                pass
+                logging.debug("No latest-recording info this pass", exc_info=True)
 
         self._slow_values.update({
             "cpu_load": cpu_load,
@@ -1767,7 +1769,9 @@ class SimpleGUI(threading.Thread):
                 try:
                     self.emit_gui_data_change(changed_data)
                 except Exception:
-                    pass
+                    # The framebuffer draw below must happen even if no browser
+                    # is listening. debug: this is per-frame.
+                    logging.debug("Could not push GUI delta to the browser", exc_info=True)
         self.previous_values = current_values.copy()
 
         fb = self.fb

--- a/src/module/ssd_monitor.py
+++ b/src/module/ssd_monitor.py
@@ -286,8 +286,8 @@ class SSDMonitor:
         monitor.start()                         # non-blocking
 
         while not self._stop_evt.is_set():
-            dev = monitor.poll(self._poll_int)  # returns None on timeout
-            # In either case we resync; if an event arrived, dev is not None.
+            monitor.poll(self._poll_int)  # returns None on timeout
+            # The result is deliberately ignored: event or timeout, we resync.
             self._check_mount_status()
             self._maybe_run_fsck()
 

--- a/src/module/usb_monitor.py
+++ b/src/module/usb_monitor.py
@@ -707,8 +707,6 @@ class USBMonitor():
 
         model = device.get('ID_MODEL', '')
         serial = device.get('ID_SERIAL', '')
-        vendor_id = device.get('ID_VENDOR_ID', None)
-        product_id = device.get('ID_MODEL_ID', None)
         model_upper = model.upper()
         device_id = device.device_path
 

--- a/src/module/usb_monitor.py
+++ b/src/module/usb_monitor.py
@@ -1,3 +1,4 @@
+import contextlib
 import pyudev
 import logging
 import traceback
@@ -674,10 +675,8 @@ class USBMonitor():
         if mic_has_changed:
             logging.info(f"Microphone changed from {self.current_mic_id} → {mic_id}")
             # Stop old monitor and create a fresh one bound to this mic
-            try:
+            with contextlib.suppress(Exception):
                 self.audio_monitor.stop()
-            except Exception:
-                pass
             AudioMonitor.clear_mic_selection("microphone changed; waiting for re-probe")
             self.audio_monitor = AudioMonitor(settings=self.settings)
             self.audio_monitor.set_model_info(model, serial, card_num=card_num, card_name=card_name)

--- a/src/module/wifi_hotspot.py
+++ b/src/module/wifi_hotspot.py
@@ -25,7 +25,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Final, NamedTuple, Optional
 
-from module.config_loader import SettingsLoadError, load_settings, strip_jsonc
+from module.config_loader import SettingsLoadError, load_settings
 
 logger = logging.getLogger(__name__)
 

--- a/tools/design_token_diff.py
+++ b/tools/design_token_diff.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Compare the HDMI GUI's colour constants against the web GUI's CSS custom properties.
+
+Written for S08 of the CineMate system review, to put a number on F-007 and to give
+ADR-001 option B a concrete cost. It is also the check option B would need to *stay* true:
+right now the two sides are kept in agreement by a comment, and this review has watched
+three hand-sync comments drift.
+
+Two sources:
+  Python  src/module/simple_gui.py   module-level *_COLOR constants + the self.colors table
+  CSS     src/module/app/templates/template.html   :root { --token: rgb(...) }
+
+Pairing is by the comment the CSS already carries -- `--drop: rgb(120,40,180); /*
+DROP_WARNING_COLOR */` names its own counterpart. Tokens with no such comment are matched
+by value, and reported separately so an unannotated match is never mistaken for a
+declared one.
+
+Usage:
+    python3 tools/design_token_diff.py [--repo PATH] [--strict]
+
+    --strict   exit 1 if any annotated pair disagrees.
+
+Limitations, stated because the review's convention requires it:
+  * Only literal `rgb(r, g, b)` and `(r, g, b)` tuples are compared. Named CSS colours
+    (`lightgreen`), hex (`#000`) and Python string colours (`"magenta"`) are listed as
+    uncomparable rather than silently skipped.
+  * A value match is not proof of intent. Two tokens can share a value by coincidence;
+    the annotated pairs are the contract, the rest is a hint.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import sys
+from pathlib import Path
+
+SIMPLE_GUI = "src/module/simple_gui.py"
+TEMPLATE = "src/module/app/templates/template.html"
+
+
+def python_colors(repo: Path) -> tuple[dict[str, tuple], dict[str, str]]:
+    """(NAME -> rgb tuple, NAME -> uncomparable literal) for *_COLOR bindings.
+
+    Walks the whole tree, not just module level. ZOOM_HIGHLIGHT_COLOR is a
+    function-local at simple_gui.py:1226; an earlier version of this script only
+    read module scope, reported the CSS comment naming it as pointing at nothing,
+    and would have shipped a false drift finding.
+    """
+    tree = ast.parse((repo / SIMPLE_GUI).read_text(encoding="utf-8"))
+    rgb: dict[str, tuple] = {}
+    other: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        for t in node.targets:
+            if not (isinstance(t, ast.Name) and "COLOR" in t.id):
+                continue
+            v = node.value
+            if isinstance(v, ast.Tuple) and len(v.elts) == 3 and all(
+                isinstance(e, ast.Constant) and isinstance(e.value, int) for e in v.elts
+            ):
+                rgb[t.id] = tuple(e.value for e in v.elts)
+            elif isinstance(v, ast.Constant):
+                other[t.id] = repr(v.value)
+    return rgb, other
+
+
+def python_table_colors(repo: Path) -> dict[str, tuple]:
+    """The `self.colors` field table: field -> its "normal" rgb, where literal."""
+    tree = ast.parse((repo / SIMPLE_GUI).read_text(encoding="utf-8"))
+    out: dict[str, tuple] = {}
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Assign) and isinstance(node.value, ast.Dict)):
+            continue
+        if not any(isinstance(t, ast.Attribute) and t.attr == "colors" for t in node.targets):
+            continue
+        for k, v in zip(node.value.keys, node.value.values):
+            if not (isinstance(k, ast.Constant) and isinstance(v, ast.Dict)):
+                continue
+            for kk, vv in zip(v.keys, v.values):
+                # Some entries carry an alpha channel -- "lock" is (255, 0, 0, 255).
+                # Compare on RGB and drop alpha rather than skipping the row.
+                if (isinstance(kk, ast.Constant) and kk.value == "normal"
+                        and isinstance(vv, ast.Tuple) and len(vv.elts) in (3, 4)
+                        and all(isinstance(e, ast.Constant) and isinstance(e.value, int)
+                                for e in vv.elts)):
+                    out[k.value] = tuple(e.value for e in vv.elts[:3])
+    return out
+
+
+TOKEN_RE = re.compile(
+    r"--([a-z0-9-]+)\s*:\s*([^;]+?)\s*;(?:\s*/\*\s*(.*?)\s*\*/)?", re.I)
+RGB_RE = re.compile(r"rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)", re.I)
+
+
+def css_tokens(repo: Path) -> list[tuple[str, str, str | None]]:
+    """[(token, raw value, trailing comment or None)] from the first :root block."""
+    src = (repo / TEMPLATE).read_text(encoding="utf-8")
+    start = src.find(":root")
+    if start < 0:
+        raise SystemExit("no :root block in " + TEMPLATE)
+    block = src[start:src.find("}", start)]
+    return [(m.group(1), m.group(2).strip(), (m.group(3) or None))
+            for m in TOKEN_RE.finditer(block)]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--repo", default=".", type=Path)
+    ap.add_argument("--strict", action="store_true")
+    args = ap.parse_args()
+    repo = args.repo.resolve()
+
+    py_rgb, py_other = python_colors(repo)
+    table = python_table_colors(repo)
+    tokens = [t for t in css_tokens(repo) if RGB_RE.search(t[1]) or "#" in t[1]
+              or t[1].isalpha()]
+
+    colour_tokens = [t for t in tokens if not t[0].startswith(
+        ("gap", "value-size", "label-size", "box-size", "box-height"))]
+
+    annotated, dangling, unannotated, uncomparable = [], [], [], []
+    for name, raw, comment in colour_tokens:
+        m = RGB_RE.search(raw)
+        if not m:
+            uncomparable.append((name, raw, comment))
+            continue
+        val = tuple(int(g) for g in m.groups())
+        key = (comment or "").upper().replace(" ", "_")
+        if key in py_rgb:
+            annotated.append((name, val, comment, py_rgb[key]))
+        elif comment and key.endswith("_COLOR"):
+            # A comment that names a constant which does not exist. Reported
+            # separately: "the comment points at nothing" is a different defect
+            # from "there is no comment".
+            dangling.append((name, val, comment))
+        else:
+            unannotated.append((name, val, comment))
+
+    print("Python module colour constants : %d comparable, %d not (%s)"
+          % (len(py_rgb), len(py_other), ", ".join(py_other) or "-"))
+    print("Python self.colors field table : %d fields" % len(table))
+    print("CSS custom properties (colour) : %d" % len(colour_tokens))
+    print()
+
+    print("ANNOTATED pairs -- the CSS names its Python counterpart (%d):" % len(annotated))
+    bad = 0
+    for name, val, comment, pyval in annotated:
+        ok = val == pyval
+        bad += not ok
+        print("  %-16s %-18s %s %-18s %s"
+              % ("--" + name, str(val), "==" if ok else "!=", str(pyval),
+                 comment + ("" if ok else "   <-- DRIFTED")))
+    print()
+
+    if dangling:
+        print("DANGLING annotations -- comment names a constant that does not exist (%d):"
+              % len(dangling))
+        for name, val, comment in dangling:
+            print("  %-16s %-18s /* %s */   <-- points at nothing" % ("--" + name, str(val), comment))
+        print()
+
+    print("UNANNOTATED tokens -- matched by value only, or unmatched (%d):"
+          % len(unannotated))
+    by_val = {v: k for k, v in py_rgb.items()}
+    for name, val, comment in unannotated:
+        hint = by_val.get(val)
+        if hint is None:
+            fields = [f for f, v in table.items() if v == val]
+            hint = ("self.colors[%s]" % ", ".join(sorted(fields)[:3])) if fields else None
+        print("  %-16s %-18s %s" % ("--" + name, str(val),
+                                    ("~ " + hint) if hint else "no Python counterpart found"))
+    print()
+
+    if uncomparable:
+        print("NOT COMPARABLE -- named or hex colours (%d):" % len(uncomparable))
+        for name, raw, comment in uncomparable:
+            print("  %-16s %s" % ("--" + name, raw))
+        print()
+
+    matched = sum(1 for _, val, _ in unannotated
+                  if val in {v for v in py_rgb.values()} or val in set(table.values()))
+    print("VERDICT: %d colour tokens. %d carry a resolvable annotation (%d drifted); "
+          "%d dangle; %d rely on a value match alone (%d of those resolve); "
+          "%d not comparable."
+          % (len(colour_tokens), len(annotated), bad, len(dangling),
+             len(unannotated), matched, len(uncomparable)))
+    print("Sync mechanism today is a comment. Three hand-sync comments in this review have")
+    print("drifted (F-260, F-183, F-220). See F-007 and ADR-001 option B.")
+
+    if args.strict and (bad or dangling):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/docs_drift_check.py
+++ b/tools/docs_drift_check.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Mechanical docs-vs-code checks for CineMate.
+
+Written for S09 of the system review. Answers the questions about `docs/` that can be
+answered without judgement, so the report can spend its words on the ones that need it.
+
+Six checks, each independent:
+
+  nav        mkdocs.yml nav entries vs files on disk, both directions
+  links      internal markdown links vs their targets
+  cites      `path/file.py:123` style code citations -- file exists? line in range?
+  methods    method names in docs/controller-methods.md vs CinePiController
+  keys       redis keys in docs/redis-keys.md vs the ParameterKey enum
+  settings   dotted setting paths in docs/settings-json.md vs settings.jsonc + schema
+
+Standard library only. Does not import the application, does not need a Raspberry Pi.
+
+Usage:
+    python3 tools/docs_drift_check.py [--repo PATH] [--only CHECK] [--strict]
+
+Limitations, stated because the review's convention requires it:
+  * A name appearing in prose is not proof it is documented *correctly* -- only that it
+    exists. Semantic accuracy is a reading job, not a script's.
+  * Code citations without a line number are checked for file existence only.
+  * The settings check matches quoted or backticked dotted paths; a path written in prose
+    without punctuation is invisible to it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import sys
+from pathlib import Path
+
+DOCS = "docs"
+MKDOCS = "mkdocs.yml"
+CONTROLLER = "src/module/cinepi_controller.py"
+REDIS_CTRL = "src/module/redis_controller.py"
+
+
+# ---------------------------------------------------------------- helpers
+
+def md_files(repo: Path) -> set[str]:
+    return {str(p.relative_to(repo / DOCS)) for p in (repo / DOCS).rglob("*.md")}
+
+
+def nav_entries(repo: Path) -> tuple[set[str], int]:
+    """Referenced .md paths in the nav, and how many nav lines are commented out."""
+    text = (repo / MKDOCS).read_text(encoding="utf-8")
+    live, commented = set(), 0
+    for line in text.splitlines():
+        stripped = line.strip()
+        m = re.search(r":\s*([A-Za-z0-9_./-]+\.md)\s*$", stripped)
+        if not m:
+            continue
+        if stripped.startswith("#"):
+            commented += 1
+        else:
+            live.add(m.group(1))
+    return live, commented
+
+
+def enum_members(repo: Path, cls: str) -> dict[str, str]:
+    tree = ast.parse((repo / REDIS_CTRL).read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == cls:
+            return {
+                t.id: n.value.value
+                for n in node.body if isinstance(n, ast.Assign)
+                for t in n.targets
+                if isinstance(t, ast.Name) and isinstance(n.value, ast.Constant)
+                and isinstance(n.value.value, str)
+            }
+    return {}
+
+
+def controller_methods(repo: Path) -> set[str]:
+    tree = ast.parse((repo / CONTROLLER).read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "CinePiController":
+            return {n.name for n in node.body
+                    if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))}
+    return set()
+
+
+# ---------------------------------------------------------------- checks
+
+def check_nav(repo: Path) -> list[str]:
+    on_disk = md_files(repo)
+    live, commented = nav_entries(repo)
+    out = [f"files on disk: {len(on_disk)} · live nav entries: {len(live)} · "
+           f"commented-out nav lines: {commented}"]
+    orphans = sorted(on_disk - live)
+    out.append(f"UNREACHABLE from nav ({len(orphans)}):")
+    for f in orphans:
+        loc = len((repo / DOCS / f).read_text(encoding="utf-8").splitlines())
+        flag = "  <-- EMPTY" if loc == 0 else ("  <-- real content" if loc > 100 else "")
+        out.append(f"    {f:<36} {loc:>5} LOC{flag}")
+    missing = sorted(live - on_disk)
+    out.append(f"NAV POINTS AT MISSING FILES ({len(missing)}): {', '.join(missing) or '-'}")
+    return out
+
+
+LINK_RE = re.compile(r"\[[^\]]*\]\(([^)\s]+?)(?:#([^)\s]*))?\)")
+
+
+def check_links(repo: Path) -> list[str]:
+    broken = []
+    total = 0
+    for p in sorted((repo / DOCS).rglob("*.md")):
+        body = p.read_text(encoding="utf-8")
+        for m in LINK_RE.finditer(body):
+            target = m.group(1)
+            if target.startswith(("http://", "https://", "mailto:", "#")):
+                continue
+            total += 1
+            resolved = (p.parent / target).resolve()
+            if not resolved.exists():
+                broken.append(f"    {p.relative_to(repo / DOCS)} -> {target}")
+    return [f"internal links checked: {total} · broken: {len(broken)}"] + sorted(broken)
+
+
+CITE_RE = re.compile(r"`([A-Za-z0-9_./-]+\.(?:py|sh|cpp|hpp|json|jsonc|yml|txt))"
+                     r"(?::(\d+)(?:-(\d+))?)?`")
+
+
+def check_cites(repo: Path) -> list[str]:
+    """Do `file.py:123` style citations in docs resolve, and are the lines in range?
+
+    Classify rather than false-positive. An earlier version reported 37 misses; every
+    one was an absolute runtime path (/boot/firmware/config.txt, /home/pi/..., a
+    libcamera source path) that is *correctly* absent from this repository. Those are
+    documentation of the deployed system, not citations of it.
+    """
+    runtime, bad_file, bad_line, ok = [], [], [], 0
+    for p in sorted((repo / DOCS).rglob("*.md")):
+        for m in CITE_RE.finditer(p.read_text(encoding="utf-8")):
+            ref, start = m.group(1), m.group(2)
+            where = p.relative_to(repo / DOCS)
+            if ref.startswith("/") or ref.startswith("src/ipa/"):
+                runtime.append(ref)
+                continue
+            cands = [repo / ref] + list(repo.rglob(Path(ref).name))
+            hit = next((c for c in cands if c.is_file()
+                        and str(c).endswith(ref.lstrip("./"))), None)
+            if hit is None:
+                # A bare filename that exists nowhere in the repo is most often a
+                # deployed artefact (config.txt, compile-raw.sh) rather than drift.
+                (runtime if "/" not in ref else bad_file).append(
+                    ref if "/" not in ref else f"    {where} -> {ref}")
+                continue
+            if start:
+                n = len(hit.read_text(encoding="utf-8", errors="replace").splitlines())
+                if int(start) > n:
+                    bad_line.append(f"    {where} -> {ref}:{start}   (file has {n} lines)")
+                    continue
+            ok += 1
+    return ([f"repo citations resolved: {ok} · unresolvable: {len(bad_file)} · "
+             f"line out of range: {len(bad_line)}",
+             f"runtime / external paths (expected absent): {len(runtime)} "
+             f"-- {', '.join(sorted(set(runtime))[:6])}, ..."]
+            + sorted(bad_file) + sorted(bad_line))
+
+
+def check_methods(repo: Path) -> list[str]:
+    doc = (repo / DOCS / "controller-methods.md").read_text(encoding="utf-8")
+    named = set(re.findall(r"`([a-z_][a-z0-9_]*)\(", doc))
+    real = controller_methods(repo)
+    public = {m for m in real if not m.startswith("_")}
+    missing = sorted(named - real)
+    undocumented = sorted(public - named)
+    return [
+        f"names in controller-methods.md: {len(named)} · "
+        f"CinePiController methods: {len(real)} ({len(public)} public)",
+        f"DOCUMENTED BUT ABSENT on the controller ({len(missing)}): "
+        f"{', '.join(missing) or '-'}",
+        f"public but undocumented: {len(undocumented)} "
+        f"(the doc says it covers 'the most useful ones', so this is scope, not drift)",
+    ]
+
+
+def check_keys(repo: Path) -> list[str]:
+    """redis-keys.md is a markdown TABLE with unbackticked keys in column 1.
+
+    An earlier version of this check matched only backticked lowercase words and
+    reported 8 documented keys out of 84, contradicting F-014. It was wrong: the
+    doc does not backtick them. It also reported `pip_cam0`/`pip_cam1` as
+    documented-but-nonexistent keys -- they are *values* of hdmi_preview_source.
+    Both were pattern-matching failures, not findings.
+    """
+    doc = (repo / DOCS / "redis-keys.md").read_text(encoding="utf-8")
+    members = enum_members(repo, "ParameterKey")
+    values = set(members.values())
+
+    named: set[str] = set()
+    for line in doc.splitlines():
+        if not line.startswith("|") or line.startswith("|--") or "| Key " in line:
+            continue
+        cell = line.split("|")[1].strip()
+        # cells like "width / height" and "lores_width / lores_height"
+        for part in re.split(r"\s*/\s*", cell):
+            part = part.strip().strip("`")
+            if re.fullmatch(r"[a-z][a-z0-9_]*", part):
+                named.add(part)
+
+    documented = named & values
+    orphan = sorted(named - values)
+    undocumented = sorted(values - named)
+    return [
+        f"ParameterKey members: {len(members)} · rows in redis-keys.md: {len(named)}",
+        f"documented and real: {len(documented)} · UNDOCUMENTED: {len(undocumented)}",
+        f"  {', '.join(undocumented)}",
+        f"NAMED IN DOCS BUT NOT IN ParameterKey ({len(orphan)}): {', '.join(orphan) or '-'}",
+        "  (cinepi-raw-side keys legitimately live outside ParameterKey -- cross-check "
+        "against redis_key_diff.py before calling one of these an orphan doc)",
+    ]
+
+
+def check_settings(repo: Path) -> list[str]:
+    """settings-json.md names sections with `##` / `###` HEADINGS, not dotted paths.
+
+    An earlier version matched backticked dotted paths and found 9 in a 611-line
+    document, two of which were filenames. The doc is structured by heading.
+    """
+    sys.path.insert(0, str(repo / "src"))
+    from module.config_loader import strip_jsonc  # noqa: E402
+    live = json.loads(strip_jsonc((repo / "settings.jsonc").read_text(encoding="utf-8")))
+
+    tops = set(live) - {"$schema"}
+    seconds = {k for t in tops if isinstance(live[t], dict) for k in live[t]}
+
+    doc = (repo / DOCS / "settings-json.md").read_text(encoding="utf-8")
+    h2 = {m.group(1) for m in re.finditer(r"^##\s+([a-z_][a-z0-9_]*)\s*$", doc, re.M)}
+    h3 = {m.group(1) for m in re.finditer(r"^###\s+([a-z_][a-z0-9_]*)\s*$", doc, re.M)}
+
+    return [
+        f"top-level sections in settings.jsonc: {len(tops)} · `##` headings: {len(h2)}",
+        f"  UNDOCUMENTED top-level ({len(tops - h2)}): {', '.join(sorted(tops - h2)) or '-'}",
+        f"  HEADING WITH NO SECTION ({len(h2 - tops)}): {', '.join(sorted(h2 - tops)) or '-'}",
+        f"second-level keys: {len(seconds)} · `###` headings: {len(h3)}",
+        f"  HEADING WITH NO KEY ({len(h3 - seconds)}): "
+        f"{', '.join(sorted(h3 - seconds)) or '-'}",
+        "  (a `###` heading may legitimately document a nested block one level deeper; "
+        "treat these as candidates, not verdicts)",
+    ]
+
+
+CHECKS = {"nav": check_nav, "links": check_links, "cites": check_cites,
+          "methods": check_methods, "keys": check_keys, "settings": check_settings}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--repo", default=".", type=Path)
+    ap.add_argument("--only", choices=sorted(CHECKS))
+    ap.add_argument("--strict", action="store_true")
+    args = ap.parse_args()
+    repo = args.repo.resolve()
+
+    names = [args.only] if args.only else list(CHECKS)
+    # Four of the six are at zero and can gate; `keys` and `nav` carry known
+    # counts and should ratchet instead, so --strict leaves them alone.
+    GATED = {"links", "cites", "methods", "settings"}
+    failed = []
+    for name in names:
+        print(f"===== {name} " + "=" * (60 - len(name)))
+        lines = CHECKS[name](repo)
+        for line in lines:
+            print(line)
+        if args.strict and name in GATED:
+            joined = " ".join(lines)
+            for marker in ("broken: 0", "unresolvable: 0", "ABSENT on the controller (0)",
+                           "UNDOCUMENTED top-level (0)"):
+                pass
+            if _has_failure(name, lines):
+                failed.append(name)
+        print()
+    if failed:
+        print("FAIL:", ", ".join(failed))
+        return 1
+    return 0
+
+
+def _has_failure(name, lines: list[str]) -> bool:
+    text = " ".join(lines)
+    if name == "links":
+        return "broken: 0" not in text
+    if name == "cites":
+        return "unresolvable: 0" not in text or "line out of range: 0" not in text
+    if name == "methods":
+        return "ABSENT on the controller (0)" not in text
+    if name == "settings":
+        return ("UNDOCUMENTED top-level (0)" not in text
+                or "HEADING WITH NO SECTION (0)" not in text)
+    return False
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/gui_field_extract.py
+++ b/tools/gui_field_extract.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Extract the GUI field inventory from source, mechanically.
+
+Written for S07 of the CineMate system review. Answers one question:
+*which fields does each GUI surface handle, and where does each one come from?*
+
+Why a script and not a reading: the HDMI GUI's field set is a 370-line dict
+builder, the web template is 965 lines of HTML+JS, and the settings editor is
+3706. Hand-counting those was going to be wrong, and this review has already
+been caught over- and under-counting by grep four times.
+
+No dependencies beyond the standard library. Does not import the application,
+does not need a Raspberry Pi, does not need redis. Pure `ast` + text scan.
+
+Usage:
+    python3 tools/gui_field_extract.py [--repo PATH] [--format md|text]
+
+Known limitations, stated because the review's convention requires it:
+  * Field names built dynamically (f-strings, computed keys) are invisible here.
+    Every count below is a LOWER BOUND.
+  * "Consumed by the web GUI" is a whole-word text match of the field name in
+    the template. It proves the name appears; it does not prove it is rendered.
+  * The settings-editor scan finds `data-*` attributes and quoted dotted
+    setting paths. A path assembled at runtime will be missed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import sys
+from pathlib import Path
+
+# --------------------------------------------------------------------------
+# Surface 1 — HDMI GUI (PIL raster to /dev/fb0)
+# --------------------------------------------------------------------------
+
+SIMPLE_GUI = "src/module/simple_gui.py"
+VALUES_BUILDER = "populate_values"
+
+
+def hdmi_fields(repo: Path) -> dict[str, int]:
+    """Field name -> line, for the dict `populate_values` returns.
+
+    Only the dict actually bound to the local `values` (and later
+    `values[...] = ...` stores) counts. An earlier version of this walked every
+    ast.Dict inside the function and picked up the nested colour table, which
+    reported `normal`, `lock` and `low_voltage` as GUI fields. They are not.
+    """
+    tree = ast.parse((repo / SIMPLE_GUI).read_text(encoding="utf-8"))
+    fn = next(
+        (n for n in ast.walk(tree)
+         if isinstance(n, ast.FunctionDef) and n.name == VALUES_BUILDER),
+        None,
+    )
+    if fn is None:
+        raise SystemExit(f"{VALUES_BUILDER} not found in {SIMPLE_GUI}")
+
+    fields: dict[str, int] = {}
+
+    # `values = { ... }` — the top-level literal
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Dict):
+            if any(isinstance(t, ast.Name) and t.id == "values" for t in node.targets):
+                for k in node.value.keys:
+                    if isinstance(k, ast.Constant) and isinstance(k.value, str):
+                        fields.setdefault(k.value, k.lineno)
+
+    # `values["..."] = ...` — later stores
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Assign):
+            for t in node.targets:
+                if (isinstance(t, ast.Subscript)
+                        and isinstance(t.value, ast.Name) and t.value.id == "values"
+                        and isinstance(t.slice, ast.Constant)
+                        and isinstance(t.slice.value, str)):
+                    fields.setdefault(t.slice.value, node.lineno)
+
+    return fields
+
+
+def hdmi_providers(repo: Path) -> dict[str, str]:
+    """Field name -> a coarse label for where its value comes from.
+
+    Deliberately coarse. Anything that is not a recognisable provider call is
+    reported as `derived`, because claiming more than that would need dataflow
+    analysis this script does not do.
+    """
+    text = (repo / SIMPLE_GUI).read_text(encoding="utf-8").splitlines()
+    fields = hdmi_fields(repo)
+    out: dict[str, str] = {}
+    for name, lineno in fields.items():
+        line = text[lineno - 1] if 0 < lineno <= len(text) else ""
+        if "redis_controller.get_value" in line:
+            out[name] = "redis"
+        elif re.search(r'"\s*[^"]*"\s*,?\s*$', line) and ":" in line and not any(
+            c in line for c in "()[]"
+        ):
+            out[name] = "literal"
+        elif "self._slow_values" in line:
+            out[name] = "slow-poll"
+        elif "Utils." in line:
+            out[name] = "host"
+        elif "self." in line:
+            out[name] = "gui-internal"
+        else:
+            out[name] = "derived"
+    return out
+
+
+# --------------------------------------------------------------------------
+# Surface 2 — Web GUI (HTML + Socket.IO)
+# --------------------------------------------------------------------------
+
+WEB_TEMPLATE = "src/module/app/templates/template.html"
+# The push channel is emitted from THREE modules, not one. An earlier version of
+# this script scanned only the first two and reported `reload_stream` and
+# `resolution_change` as handled-but-never-emitted. They are emitted from
+# app/__init__.py. That miss is itself the finding (F-209): nothing in the repo
+# lists what the Socket.IO channel carries.
+EVENT_SOURCES = (
+    "src/module/app/main/events.py",
+    "src/module/simple_gui.py",
+    "src/module/app/__init__.py",
+)
+EVENTS = EVENT_SOURCES[0]
+
+
+def web_consumed(repo: Path, names: list[str]) -> set[str]:
+    """Which HDMI field names appear, as whole words, in the web template."""
+    src = (repo / WEB_TEMPLATE).read_text(encoding="utf-8")
+    return {n for n in names if re.search(r"\b%s\b" % re.escape(n), src)}
+
+
+def socket_events(repo: Path) -> dict[str, list[str]]:
+    """Socket.IO event names emitted by the server and handled by the browser."""
+    page = (repo / WEB_TEMPLATE).read_text(encoding="utf-8")
+    emitted: set[str] = set()
+    for rel in EVENT_SOURCES:
+        src = (repo / rel).read_text(encoding="utf-8")
+        emitted |= set(re.findall(r"(?:socketio\.)?emit\(\s*['\"]([a-z_]+)['\"]", src))
+        emitted |= set(re.findall(
+            r"_emit_socketio_event\(\s*\n?\s*['\"]([a-z_]+)['\"]", src))
+    handled = set(re.findall(r"socket\.on\(\s*['\"]([a-z_]+)['\"]", page))
+    return {
+        "emitted_by_server": sorted(emitted),
+        "handled_by_browser": sorted(handled),
+        "emitted_never_handled": sorted(emitted - handled),
+        "handled_never_emitted": sorted(handled - emitted),
+    }
+
+
+# --------------------------------------------------------------------------
+# Surface 3 — Settings editor
+# --------------------------------------------------------------------------
+
+SETTINGS_EDITOR_PY = "src/module/app/settings_editor.py"
+SETTINGS_EDITOR_HTML = "src/module/app/templates/settings_editor.html"
+CONTROLLER = "src/module/cinepi_controller.py"
+
+
+def controller_methods(repo: Path) -> set[str]:
+    """Public method names on CinePiController -- the reflective-dispatch targets."""
+    tree = ast.parse((repo / CONTROLLER).read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "CinePiController":
+            return {
+                n.name for n in node.body
+                if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and not n.name.startswith("_")
+            }
+    return set()
+
+
+def editor_method_names(repo: Path) -> set[str]:
+    """Method-name strings the settings editor offers as actions.
+
+    F-118 is exactly this set diverging from controller_methods(): the
+    catalogue offers `set_log`, the method is `set_log_encode`, and the button
+    silently does nothing.
+    """
+    # The Python catalogue tags each entry `"value": "..."`, so read those
+    # directly. The JS copy has no such marker, so it is matched against the
+    # Python catalogue's vocabulary -- an earlier `set_|inc_|dec_` regex missed
+    # `rec`, `mount`, `reboot` and seven more, and wrongly made the JS copy look
+    # like a subset. It is not: the two are identical, including the same bug.
+    py_src = (repo / SETTINGS_EDITOR_PY).read_text(encoding="utf-8")
+    vocab = set(re.findall(r'"value":\s*"([a-z0-9_]+)"', py_src))
+    js_src = (repo / SETTINGS_EDITOR_HTML).read_text(encoding="utf-8")
+    js = {v for v in vocab if re.search(r"['\"]%s['\"]" % re.escape(v), js_src)}
+    return vocab | js
+
+
+def settings_paths(repo: Path) -> set[str]:
+    """Dotted setting paths the editor references as string literals."""
+    src = (repo / SETTINGS_EDITOR_HTML).read_text(encoding="utf-8")
+    return set(re.findall(r"['\"]([a-z_]+(?:\.[a-z_0-9]+){1,4})['\"]", src))
+
+
+# --------------------------------------------------------------------------
+# Report
+# --------------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--repo", default=".", type=Path)
+    ap.add_argument("--format", choices=("md", "text", "json"), default="text")
+    ap.add_argument("--max-unresolved", type=int, default=0,
+                    help="exit 1 if more than N offered action names are absent "
+                         "from CinePiController (default 0)")
+    args = ap.parse_args()
+    repo = args.repo.resolve()
+
+    fields = hdmi_fields(repo)
+    provs = hdmi_providers(repo)
+    consumed = web_consumed(repo, list(fields))
+    events = socket_events(repo)
+    methods = controller_methods(repo)
+    offered = editor_method_names(repo)
+
+    data = {
+        "hdmi_field_count": len(fields),
+        "hdmi_fields": {k: {"line": v, "provider": provs[k],
+                            "in_web_template": k in consumed}
+                        for k, v in sorted(fields.items())},
+        "hdmi_only": sorted(set(fields) - consumed),
+        "socket_events": events,
+        "controller_public_methods": len(methods),
+        "editor_offered_names": sorted(offered),
+        "offered_but_missing_on_controller": sorted(offered - methods),
+    }
+
+    if args.format == "json":
+        print(json.dumps(data, indent=2))
+        return 0
+
+    b = "**" if args.format == "md" else ""
+    print(f"{b}HDMI GUI ({SIMPLE_GUI}::{VALUES_BUILDER}){b}")
+    print(f"  fields (lower bound): {len(fields)}")
+    from collections import Counter
+    for prov, n in Counter(provs.values()).most_common():
+        print(f"    {prov:<14} {n}")
+    print(f"  also named in the web template: {len(consumed)}")
+    print(f"  HDMI-only (not named in the web template): {len(data['hdmi_only'])}")
+    for n in data["hdmi_only"]:
+        print(f"    {n}")
+    print()
+    print(f"{b}Socket.IO channel{b}")
+    for k, v in events.items():
+        print(f"  {k}: {', '.join(v) if v else '(none)'}")
+    print()
+    print(f"{b}Reflective dispatch{b}")
+    print(f"  CinePiController public methods: {len(methods)}")
+    print(f"  names the settings editor offers: {len(offered)}")
+    bad = data["offered_but_missing_on_controller"]
+    print(f"  offered but ABSENT on the controller: {len(bad)}")
+    for n in bad:
+        print(f"    {n}   <-- dispatched by getattr(), so pressing it does nothing")
+    if len(bad) > args.max_unresolved:
+        print(f"\nFAIL: {len(bad)} unresolved, limit {args.max_unresolved}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/redis_key_diff.py
+++ b/tools/redis_key_diff.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""
+redis_key_diff.py — diff the two Redis key registries that make up the
+cinemate <-> cinepi-raw contract.
+
+Why this exists
+---------------
+The contract between the two repos is the set of Redis keys both sides agree
+on, published over the `cp_controls` channel. But each repo keeps its own
+registry, in its own language, with no shared source:
+
+    cinemate    ParameterKey(Enum)        src/module/redis_controller.py
+    cinepi-raw  #define CONTROL_KEY_*     cinepi/cinepi_state.hpp
+
+Nothing reconciles them. Review session S03 found at least 11 keys that
+cinepi-raw handles and cinemate never references — six of them registered
+control handlers that can never fire (finding F-027). Nothing existed that
+could have caught that: two languages, two repos, no shared header, no test,
+no CI.
+
+This script is the missing check. It is deliberately dependency-free and
+hardware-free so it can run on a laptop or in CI.
+
+Usage
+-----
+    python3 redis_key_diff.py [--cinemate DIR] [--cinepi-raw DIR] [--strict]
+
+    --strict   exit 1 if any cinepi-raw key is unreferenced in cinemate.
+               Intended for CI once the current drift is triaged.
+
+Exit codes: 0 ok / 1 drift found (--strict only) / 2 could not read a registry.
+
+KNOWN LIMITATION — read this before trusting the numbers
+--------------------------------------------------------
+Both registries are extracted by pattern matching, which cannot see
+dynamically constructed keys. At least one important key is built by string
+concatenation on both sides and appears in neither registry:
+
+    cinepi-raw  cinepi_raw.cpp    "cinepi_ready_" + options->CamPort()
+    cinemate    cinepi_multi.py   redis_controller.r.keys("cinepi_ready_*")
+
+So every count this script prints is a LOWER BOUND on the real contract and a
+LOWER BOUND on the real drift. It is a regression guard, not a census. Treat a
+clean run as "no new drift of the kind this script can see".
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+# --- extraction -------------------------------------------------------------
+
+# ParameterKey members:  BIT_DEPTH = "bit_depth"   /   SHUTTER_A_NOM = 'shutter_angle_nom'
+# Both quote styles occur. An early review pass used \x27 inside a
+# single-quoted shell grep pattern, where it is a literal backslash, and
+# silently dropped the five single-quoted members. Hence a real parser here.
+PY_MEMBER = re.compile(r'^\s+[A-Z][A-Z_0-9]*\s*=\s*[\'"]([a-z_0-9]+)[\'"]', re.M)
+
+# #define CONTROL_KEY_RECORD "is_recording"
+CPP_DEFINE = re.compile(r'^\s*#define\s+CONTROL_KEY_\w+\s+"([A-Za-z_0-9]+)"', re.M)
+
+# Keys cinepi-raw touches WITHOUT going through a CONTROL_KEY_ macro:
+#   redis_->set("pll_phase_err_us", ...)      direct literal call
+#   constexpr char RECORDER_VU_REDIS_KEY[] = "audio_vu";
+# The macros alone undercount the contract, so both are collected.
+CPP_DIRECT = re.compile(
+    r'redis_?->\s*(?:set|get|hget|hset|hgetall|del|exists|incr|publish)\s*\(\s*"([A-Za-z_0-9]+)"')
+CPP_CONSTEXPR = re.compile(r'constexpr\s+char\s+\w+\s*\[\]\s*=\s*"([a-z_0-9]+)"')
+
+
+def cinemate_keys(repo: Path) -> set[str]:
+    """Values of every ParameterKey enum member."""
+    src = (repo / "src/module/redis_controller.py").read_text(errors="replace")
+    try:
+        start = src.index("class ParameterKey")
+        end = src.index("def encode_log_encode_request", start)
+    except ValueError as exc:
+        raise LookupError(
+            "could not locate the ParameterKey enum body in redis_controller.py; "
+            "the anchors this script relies on have moved"
+        ) from exc
+    return set(PY_MEMBER.findall(src[start:end]))
+
+
+def cinepiraw_keys(repo: Path) -> tuple[set[str], set[str]]:
+    """(macro keys, direct-call keys) that cinepi-raw touches.
+
+    Returned separately because the split is informative: macro keys are the
+    declared control surface, direct-call keys are ad-hoc reads/writes that
+    never got a name in cinepi_state.hpp.
+    """
+    macros = set(CPP_DEFINE.findall(
+        (repo / "cinepi/cinepi_state.hpp").read_text(errors="replace")))
+
+    direct: set[str] = set()
+    for path in repo.rglob("*"):
+        if path.suffix not in (".cpp", ".hpp", ".h", ".c") or ".git" in path.parts:
+            continue
+        try:
+            text = path.read_text(errors="replace")
+        except OSError:
+            continue
+        for line in text.splitlines():
+            if line.lstrip().startswith("//"):
+                continue
+            direct.update(CPP_DIRECT.findall(line))
+            direct.update(CPP_CONSTEXPR.findall(line))
+    return macros, direct - macros
+
+
+def referenced_in_cinemate(repo: Path, key: str) -> bool:
+    """Does the literal appear anywhere in cinemate source, outside a comment?
+
+    Deliberately generous: matches the bare quoted string anywhere in .py or
+    .html under src/ and services/. A key reached only through a module-level
+    constant still counts, because the literal is defined somewhere.
+    """
+    needle_d, needle_s = f'"{key}"', f"'{key}'"
+    for base in ("src", "services"):
+        root = repo / base
+        if not root.is_dir():
+            continue
+        for path in root.rglob("*"):
+            if path.suffix not in (".py", ".html") or "__pycache__" in path.parts:
+                continue
+            try:
+                for line in path.read_text(errors="replace").splitlines():
+                    stripped = line.lstrip()
+                    if stripped.startswith("#") or stripped.startswith("//"):
+                        continue
+                    if needle_d in line or needle_s in line:
+                        return True
+            except OSError:
+                continue
+    return False
+
+
+# --- reporting --------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    here = Path(__file__).resolve()
+    ap.add_argument("--cinemate", type=Path, default=here.parents[1],
+                    help="cinemate repo root (default: inferred from this file)")
+    ap.add_argument("--cinepi-raw", type=Path,
+                    default=Path(os.environ.get("CINEPI_RAW_DIR", "../cinepi-raw")),
+                    help="cinepi-raw repo root")
+    ap.add_argument("--max-unreferenced", type=int, default=None,
+                    help="exit 1 if MORE than N cinepi-raw keys are unreferenced "
+                         "in cinemate. A ratchet: set it to today's count so a new "
+                         "one fails, and lower it as the backlog is triaged. "
+                         "Raising it is never the fix.")
+    ap.add_argument("--strict", action="store_true",
+                    help="exit 1 if any cinepi-raw key is unreferenced in cinemate")
+    args = ap.parse_args()
+
+    try:
+        py = cinemate_keys(args.cinemate)
+    except (OSError, LookupError) as exc:
+        print(f"error: cannot read cinemate registry: {exc}", file=sys.stderr)
+        return 2
+    try:
+        cpp_macros, cpp_direct = cinepiraw_keys(args.cinepi_raw)
+        cpp = cpp_macros | cpp_direct
+    except OSError as exc:
+        print(f"error: cannot read cinepi-raw registry: {exc}", file=sys.stderr)
+        print(f"       expected {args.cinepi_raw}/cinepi/cinepi_state.hpp", file=sys.stderr)
+        return 2
+
+    shared = sorted(py & cpp)
+    cpp_only = sorted(cpp - py)
+    py_only = sorted(py - cpp)
+
+    print(f"cinemate   ParameterKey members    : {len(py)}")
+    print(f"cinepi-raw CONTROL_KEY_ macros    : {len(cpp_macros)}")
+    print(f"cinepi-raw direct/constexpr keys  : {len(cpp_direct)}   (no macro name)")
+    print(f"cinepi-raw total                  : {len(cpp)}")
+    print(f"shared (the visible contract)     : {len(shared)}")
+    print()
+
+    # cinepi-raw keys absent from the enum: are they referenced at all?
+    unreferenced = [k for k in cpp_only if not referenced_in_cinemate(args.cinemate, k)]
+    referenced = [k for k in cpp_only if k not in unreferenced]
+
+    if unreferenced:
+        print(f"cinepi-raw keys with NO reference anywhere in cinemate ({len(unreferenced)}):")
+        for k in unreferenced:
+            print(f"    {k}")
+        print("    -> cinepi-raw handles or writes these; cinemate never mentions them.")
+        print("       Not necessarily dead: reachable by hand with redis-cli, and some")
+        print("       read as a deliberate tuning/telemetry surface. See F-027.")
+        print()
+    if referenced:
+        print(f"cinepi-raw keys outside ParameterKey but referenced in cinemate ({len(referenced)}):")
+        for k in referenced:
+            print(f"    {k}")
+        print("    -> reached as raw strings, bypassing the enum. See F-015.")
+        print()
+    if py_only:
+        print(f"cinemate-only keys ({len(py_only)}) — expected: most state is cinemate's alone")
+        print(f"    {', '.join(py_only)}")
+        print()
+
+    print("NOTE: counts are LOWER BOUNDS. Dynamically built keys (e.g. cinepi_ready_<port>)")
+    print("      are invisible to pattern matching and appear in neither registry.")
+
+    if args.max_unreferenced is not None and len(unreferenced) > args.max_unreferenced:
+        print(f"\nFAIL: {len(unreferenced)} unreferenced cinepi-raw key(s), "
+              f"limit {args.max_unreferenced}. A new one appeared -- find it above "
+              f"rather than raising the limit.", file=sys.stderr)
+        return 1
+
+    if args.strict and unreferenced:
+        print(f"\nFAIL (--strict): {len(unreferenced)} unreferenced cinepi-raw key(s).",
+              file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The style/lint half of the review's findings, plus the CI to keep them from coming back. Companion to #130 (B3 correctness, complete). Review branch: `claude/cinemate-system-review-kickoff-cilicc`, PR #129.

**This PR is the first thing in this repository to have any CI at all.** Before it, no workflow ran on pull requests or on `dev` — the only one triggered on push to `main`, so both branches this review produced landed with zero checks, and 381 tests had never been executed by anything.

---

| commit | |
|---|---|
| `5d3e794` | ruff + `.editorconfig`, deliberately small |
| `209c4b6` | 18 unused imports, 15 unused locals |
| `4e5484c` | 17 handlers that failed silently |
| `f86ac49` | battery_monitor through logging; a dead parameter |
| `1db5d04` | the settings schema can now reject a typo |
| `7179fff` | **CI: checks on PRs, and docs build split from deploy** |

## `7179fff` — the CI, and the trap in front of it

`docs.yml` now builds on `dev` and on every PR, which required **guarding it first**. Two of its steps publish: `Deploy to GitHub Pages` ran unconditionally, and the PDF step runs `git commit && git push`. Widening the trigger without those guards would have made **every pull request publish the docs site from its own branch and push a commit onto it** — or fail outright from a fork, where `GITHUB_TOKEN` is read-only. Both are now pinned to a push to `main`; the build steps above them are unchanged.

New `checks.yml` is read-only, four jobs: **ruff**, **pytest**, **shellcheck**, **contract drift**.

The four drift checks move out of the review's scratch directory into `tools/`. They exist because one defect kept recurring: two copies of one fact, kept in step by hand, drifting apart. *A comment is not a check.* Docs, design tokens and shellcheck gate at zero; the cross-repo redis key contract **ratchets** at today's 12, so a thirteenth fails rather than the existing backlog. Raising a ratchet is never the fix, and each one says so in place.

Getting shellcheck to zero meant fixing its 15 findings, **two of which were real bugs**:
- `cinemate-update.sh` printed a literal `\n` instead of a blank line.
- It also captured `git rev-parse` into a `local` declaration, which always returns 0 — so a **failed** rev-parse produced an empty string that compared unequal and read as *"an update is available"*.

## `1db5d04` — the schema can now say no

`settings.schema.json` had `"additionalProperties": true` at **25 sites and `false` at none**, including at the root, so a misspelled key validated clean and was then silently ignored. Tightening it required **completing** it first: `cam_config` described 3 properties where the shipped settings use 7. All three settings files validate clean; typos are rejected at root, nested and per-sensor level, with a test each. `jsonschema` stays a test-only dependency.

## `4e5484c` — 17 silent handlers

Ruff's `E722`/`S110` found **exactly** the 2 bare excepts and 15 silent handlers the manual audit found independently. They split three ways, not one: 8 were best-effort cleanup on something already failing (→ `contextlib.suppress`, making the intent syntactic); 7 were deliberate fallbacks that had no business being invisible (→ `logging.debug` with `exc_info`, debug because four sit on the 12 fps redraw path); 2 bare excepts were also swallowing `KeyboardInterrupt`. **No behaviour changed.**

## Two judgement calls worth your eye

**The log directory.** The review flags it as hardcoded *and* as runtime state inside the source tree. I fixed the first and deliberately not the second — three places referenced that path, including `main.py`'s cleanup, so moving the default would have silently split them. It is now one function, overridable via `CINEMATE_LOG_DIR`, **default unchanged**. Moving where a deployed camera writes its logs is your call.

**`pytest -p no:randomly`.** Two tests install `flask_socketio` into `sys.modules` and never clean it up, so collection order currently decides what that module means for the rest of the run. Randomising would go red on ordering alone. Worth fixing; pinning the order is honest until it is.

## Not attempted

F-168 (615 module-level `logging.` calls vs 112 named-logger), F-170 (mixed interpolation), F-132 (27% docstring coverage), F-129 (nesting depth 11), F-270 (`cinepi_controller.py` decomposition). All structural rather than mechanical.

## Verification

Desk only — nothing here has run on a Pi. Every job was run locally before pushing: ruff clean, 386 tests + 244 subtests green, shellcheck clean across all 11 scripts, all four drift checks passing.