### PR TITLE
B6 · one dependency list, read by the installer, and a pairing manifest

### DIFF
--- a/cinemate-install.sh
+++ b/cinemate-install.sh
@@ -71,6 +71,14 @@ PYTHON_BIN="${PYTHON_BIN:-/usr/bin/python3}"
 PIP_BIN="${PIP_BIN:-/usr/bin/pip3}"
 
 CINEMATE_REPO_URL="${CINEMATE_REPO_URL:-https://github.com/Tiramisioux/cinemate.git}"
+# Optional pairing manifest: records which cinepi-raw revision goes with which
+# cinemate revision. Sourced before the defaults below so anything it sets
+# wins, and an environment variable still wins over both. Absent is fine --
+# that is the historical behaviour of tracking each default branch.
+_versions_env="$(dirname "${BASH_SOURCE[0]}")/versions.env"
+# shellcheck source=/dev/null
+[[ -f "$_versions_env" ]] && source "$_versions_env"
+
 CINEMATE_REPO_REF="${CINEMATE_REPO_REF:-}"
 CINEPI_RAW_REPO_URL="${CINEPI_RAW_REPO_URL:-https://github.com/Tiramisioux/cinepi-raw.git}"
 CINEPI_RAW_REPO_REF="${CINEPI_RAW_REPO_REF:-}"
@@ -947,18 +955,20 @@ install_python_environment() {
     detail "Upgrading pip tooling"
     run_as_pi "${pip_cmd[@]}" --upgrade pip setuptools wheel
     run_as_pi "$PIP_BIN" uninstall -y --break-system-packages board >/dev/null 2>&1 || true
-    detail "Installing Cinemate Python packages"
-    run_as_pi "${pip_cmd[@]}" \
-        gpiozero \
-        adafruit-blinka adafruit-circuitpython-ssd1306 adafruit-circuitpython-seesaw \
-        luma.oled grove.py pigpio-encoder smbus2 rpi_hardware_pwm \
-        watchdog psutil pillow redis keyboard pyudev numpy termcolor sounddevice \
-        evdev inotify_simple sysv_ipc flask_socketio sugarpie
-
-    if is_true "$INSTALL_ALT_GPIO_BACKEND"; then
-        detail "Installing lgpio Python package"
-        run_as_pi "${pip_cmd[@]}" lgpio
+    # Read the package list from the repo rather than restating it here. The
+    # two lists used to disagree: requirements.txt was read by nothing, and the
+    # literal that lived here had drifted from it in both directions. lgpio is
+    # in requirements-hardware.txt unconditionally -- rpi_gpio_wrapper imports
+    # it at the top of main.py's own import chain, so it is not optional
+    # whatever INSTALL_ALT_GPIO_BACKEND says about the C library below.
+    local req_dir="${CINEMATE_SOURCE_DIR:-$CINEMATE_DIR}"
+    local req="$req_dir/requirements.txt"
+    local req_hw="$req_dir/requirements-hardware.txt"
+    if [[ ! -f "$req" || ! -f "$req_hw" ]]; then
+        die "Missing $req or $req_hw -- cannot install the Python environment."
     fi
+    detail "Installing Cinemate Python packages from requirements files"
+    run_as_pi "${pip_cmd[@]}" -r "$req" -r "$req_hw"
 }
 
 configure_loader_paths() {

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,0 +1,11 @@
+# Documentation build only, used by .github/workflows/docs.yml.
+# Kept out of the runtime requirements: a camera does not build its own docs.
+
+mkdocs
+mkdocs-material
+mkdocs-pdf-export-plugin
+mkdocs-git-revision-date-localized-plugin
+mkdocs-macros-plugin
+mkdocs-with-pdf==0.9.3
+schemdraw<0.18
+schemdraw-markdown

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+# Development and CI only. Not installed on a camera.
+
+pytest         # _test/ -- the whole suite is portable and needs no Pi
+jsonschema     # settings.schema.json strictness test
+ruff           # lint, see ruff.toml

--- a/requirements-hardware.txt
+++ b/requirements-hardware.txt
@@ -1,0 +1,21 @@
+# Raspberry Pi-only runtime dependencies.
+#
+# These need real hardware, kernel interfaces or ARM-specific wheels, so they
+# are kept out of requirements.txt: that file has to stay installable on a
+# developer machine and in CI. The installer installs both files.
+#
+# See the note in requirements.txt about pinning.
+
+adafruit-blinka                   # provides board, busio, digitalio
+adafruit-circuitpython-seesaw     # quad rotary encoder
+adafruit-circuitpython-ssd1306    # OLED
+evdev                             # keyboard/input devices
+gpiozero                          # GPIO
+grove.py                          # Grove Base HAT ADC
+lgpio                             # rpi_gpio_wrapper imports this unguarded, so
+                                  # it is NOT optional despite the installer's
+                                  # INSTALL_ALT_GPIO_BACKEND flag calling it so
+smbus2                            # I2C
+
+# Also required, but not a pip package:
+#   python3-systemd   (apt) -- `from systemd import journal` in ssd_monitor

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,22 +1,24 @@
-rpi-lgpio
-flask
-flask_socketio
-wave
-pyaudio
-sugarpie
-redis
-pyudev
-Pillow
-psutil
-gpiozero
-numpy
-sugarpie
-flask_socketio
-termcolor
-adafruit-blinka
-adafruit-circuitpython-seesaw
-adafruit-circuitpython-ssd1306
-mkdocs-with-pdf==0.9.3
-schemdraw<0.18
-schemdraw-markdown
-pillow
+# Portable runtime dependencies.
+#
+# Everything here installs and imports on any Linux or macOS, which is what
+# makes `pytest _test/` runnable off-hardware. Pi-only packages live in
+# requirements-hardware.txt; the installer installs both.
+#
+# Derived from the actual top-level imports in src/, not maintained by hand:
+#   python3 -c "import ast,pathlib,sys; ..."   (see tools/ and the CI drift job)
+#
+# NOT PINNED YET, deliberately. Reproducible installs need exact versions, but
+# they have to come from `pip freeze` on a verified Raspberry Pi install --
+# pinning to whatever a developer machine happens to resolve risks naming
+# versions with no aarch64 wheel, which would turn a fast install into a long
+# source build or a failure. Structure first, pins when hardware confirms them.
+
+flask                 # module.app, api, settings_editor, main.routes
+flask_socketio        # the browser push channel
+numpy                 # simple_gui VU maths
+pillow                # PIL -- the HDMI GUI's raster path
+psutil                # host stats
+pyserial              # `import serial` in serial_handler
+pyudev                # USB/storage hotplug
+redis                 # the live-state bus
+termcolor             # logger's coloured console formatter

--- a/versions.env
+++ b/versions.env
@@ -1,0 +1,47 @@
+# Which cinepi-raw goes with which cinemate.
+#
+# These two programs talk to each other over a redis key contract, and nothing
+# anywhere has ever recorded which revisions were tested together. The
+# installer pins the sensor drivers (6.12.y) and libcamera (the cinemate
+# branch), but left the two repositories that move most tracking whatever their
+# default branch happened to hold that day -- so an install performed on two
+# different days is not necessarily the same system.
+#
+# For scale: cinepi-raw's main and dev currently differ by 45 files and +7164
+# lines, including four CONTROL_KEY_ macros of that shared contract.
+#
+# ---------------------------------------------------------------------------
+# HOW TO USE THIS
+#
+# Both values are EMPTY by default, which reproduces exactly today's
+# behaviour: clone the default branch of each. Nothing changes until you fill
+# them in.
+#
+# Fill them in once you have an install you trust:
+#
+#   1. Do a clean install and verify the camera reaches ready and records.
+#   2. On that machine:
+#        git -C ~/cinemate    rev-parse HEAD
+#        git -C ~/cinepi-raw  rev-parse HEAD
+#   3. Put those two values below, with the date and what you verified.
+#   4. Commit it. That is now a pairing someone else can reproduce.
+#
+# Update it whenever a change to one repo needs a matching change in the other
+# -- a new CONTROL_KEY_, a changed command-line flag, a new sensor mode.
+#
+# Any value here can still be overridden from the environment, as before:
+#   CINEPI_RAW_REPO_REF=some-branch ./cinemate-install.sh
+# ---------------------------------------------------------------------------
+
+# Last verified pairing: (none recorded yet)
+# Verified on:           --
+# Verified by:           --
+
+CINEMATE_REPO_REF="${CINEMATE_REPO_REF:-}"
+CINEPI_RAW_REPO_REF="${CINEPI_RAW_REPO_REF:-}"
+
+# For reference, the revisions this remediation work was written against:
+#   cinemate    dev  02b5a395922f8ed63d35498562142fe1ac08abb3
+#   cinepi-raw  dev  ea96f2d3da98511df3a2ba001fb54433445017d4
+# Neither has been validated on hardware, so they are recorded here as a
+# starting point rather than set above as a known-good pairing.


### PR DESCRIPTION
Batch **B6** of the review's remediation plan. Sibling of #132 — both based on #131 so they land with CI running. Merge order: #131 → then #132 and this in either order.

---

## The problem, measured

`requirements.txt` was read by nothing. The installer restated the package list as a 23-name literal, and the two had drifted **in both directions**:

| | count | |
|---|---|---|
| imported by live code, installed by neither | **3** | `flask`, `pyserial`, `lgpio` |
| installed on every camera, imported nowhere | **9** | `inotify-simple`, `keyboard`, `luma.oled`, `pigpio-encoder`, `rpi-hardware-pwm`, `sounddevice`, `sugarpie`, `sysv-ipc`, `watchdog` |

Derived from an AST pass over every top-level import in `src/`, then cross-checked against `services/`, `scripts/` and `_test/` — not from reading the list.

**`pyserial` is the one worth pausing on.** `serial_handler.py` does `import serial`, `main.py` starts it unconditionally, and the package appears in **no pip list and no apt list anywhere in the repo**. It presumably arrives as a transitive dependency of `adafruit-blinka`, the same way `flask` arrives via `flask_socketio`. Neither is declared, so neither is guaranteed.

## The split, verified rather than assumed

| file | what belongs there |
|---|---|
| `requirements.txt` | portable — installs and imports on any Linux or macOS |
| `requirements-hardware.txt` | needs real hardware, kernel interfaces, or ARM wheels |
| `requirements-dev.txt` | pytest, ruff, jsonschema — not on a camera |
| `docs/requirements-docs.txt` | the mkdocs set |

**A clean venv built from `requirements.txt` + `requirements-dev.txt` runs the whole suite** — 386 tests, 244 subtests, no Pi, nothing else installed. That's the evidence the line is in the right place, and it's why the review's PI-002 ("discover which tests need hardware") turned out to have the answer *none*.

Also dropped: `wave`, which is a **standard-library module** that was listed as a pip requirement, and three duplicate lines.

## `lgpio` moves to hardware unconditionally

It was installed only when `INSTALL_ALT_GPIO_BACKEND` was true, while `rpi_gpio_wrapper` imports it at the top of `main.py`'s own import chain — `main.py:21` → `gpio_output` → `rpi_gpio_wrapper`. So a feature the installer prints under **"Optional features"** decided whether the program could start at all. The flag now controls only the `lg` C library build, which is genuinely optional.

## `versions.env` — the thing that never existed

These two programs talk over a redis key contract, and **nothing has ever recorded which revisions were tested together**. cinepi-raw's `main` and `dev` currently differ by 45 files and +7164 lines, including four `CONTROL_KEY_` macros of that contract.

The manifest is now there and the installer sources it. **Both values are empty by default**, so behaviour is unchanged until someone completes a verified install and fills them in — the file carries the procedure. Environment variables still override, as before.

I did not invent a pairing. Recording two SHAs as "known-good" when nothing has been run on hardware would be worse than the gap it replaces; the revisions this work was written against are noted as a reference point instead.

## Not pinned yet, deliberately

The files say why. Reproducible installs need exact versions from `pip freeze` on a **verified Pi install** — pinning to whatever a developer machine resolves risks naming versions with no aarch64 wheel, turning a fast install into a long source build or a failure. Structure now, pins when hardware confirms them.

## Verification

⚠️ **This changes the installer's pip invocation, which is a boot-path change.** It is not verified until a clean install on a blank SD card reaches camera-ready — **PI-004**, and **PI-012** covers the `lgpio` move specifically.

What *was* verified here: clean-venv install and full suite pass, `bash -n` and shellcheck clean on the installer, `versions.env` sources correctly under `set -u`, and environment-variable precedence still works.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBku1dDuju5t762UogsJRq)_