### PR TITLE
ci: tighten unresolved-action ratchet to zero

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -89,10 +89,10 @@ jobs:
       - name: Design tokens match between the GUIs
         run: python3 tools/design_token_diff.py --repo . --strict
 
-      # Gate at zero once the set_log fix lands; one known unresolved name
-      # until then. Raising this number is never the fix.
+      # Gated at zero: the set_log fix landed in #130. Raising this number
+      # is never the fix.
       - name: Every offered action resolves on the controller
-        run: python3 tools/gui_field_extract.py --repo . --max-unresolved 1
+        run: python3 tools/gui_field_extract.py --repo . --max-unresolved 0
 
       # Needs both repositories: the key contract spans them.
       - name: Check out cinepi-raw


### PR DESCRIPTION
## Summary
- The contract-drift job's \`gui_field_extract\` check allowed 1 unresolved name with a comment saying to gate at zero once the \`set_log\` fix landed.
- That fix landed in #130. \`gui_field_extract --repo . --max-unresolved 999\` on the current \`dev\` tip (\`7e05bb5a\`) reports 0 unresolved names.
- \`redis_key_diff --max-unreferenced 12\` still reports exactly 12 on the current \`dev\` tip after #132's deletions, so that limit is unchanged.

Part of the batch merge tracked in \`system-review/PI-VERIFICATION-QUEUE.md\` (Phase B, cinemate-dev skill run).

## Test plan
- [x] Ran \`python3 tools/gui_field_extract.py --repo . --max-unresolved 999\` on dev tip \`7e05bb5a\` → 0 unresolved
- [x] Ran \`python3 tools/redis_key_diff.py --max-unreferenced 999\` (with cinepi-raw dev cloned alongside) → 12 unreferenced, unchanged
- [ ] CI (this PR triggers the real gate at the new threshold)