### PR TITLE
fix(autostart): F-283 restart hang/failed (polkit prompt)

### DIFF
--- a/_test/test_console_handoff_script.py
+++ b/_test/test_console_handoff_script.py
@@ -5,12 +5,17 @@ F-283: reproduced on hardware with `timeout 10 bash -x` on the installed
 script -- as user `pi`, `systemctl start <unit>` triggers a PolicyKit
 "AUTHENTICATING FOR org.freedesktop.systemd1.manage-units" prompt with no
 tty to answer it. It blocks until systemd kills this ExecStopPost step at
-TimeoutStopSec and the unit lands failed instead of restarting. (A
-Before=/Conflicts= job-cancellation race was also considered; ruled out --
-no "Job ... was cancelled" or "contradicts existing jobs" lines appear
-anywhere in `journalctl -u cinemate-autostart -b`.) `pi` has passwordless
-sudo, so running as root skips the prompt entirely; `-n` guarantees a fast
-failure instead of a hang if that sudoers rule is ever tightened.
+TimeoutStopSec and the unit lands failed instead of restarting. `pi` has
+passwordless sudo, so running as root skips the prompt entirely; `-n`
+guarantees a fast failure instead of a hang if that sudoers rule is ever
+tightened. This closes the hang/failed symptom, verified on hardware across
+many restarts.
+
+A separate, narrower race is still open (not covered by this test):
+Conflicts=getty@tty1.service on the unit can occasionally collide with the
+start half of an in-flight `systemctl restart`, leaving the unit inactive
+instead of active (not failed/hung). See the longer comment in the script
+itself for the four mitigations tried and rejected.
 """
 
 import re

--- a/_test/test_console_handoff_script.py
+++ b/_test/test_console_handoff_script.py
@@ -1,0 +1,51 @@
+"""cinemate-console-handoff.sh: unprivileged systemctl unit-start calls must
+run under `sudo -n`.
+
+F-283: reproduced on hardware with `timeout 10 bash -x` on the installed
+script -- as user `pi`, `systemctl start <unit>` triggers a PolicyKit
+"AUTHENTICATING FOR org.freedesktop.systemd1.manage-units" prompt with no
+tty to answer it. It blocks until systemd kills this ExecStopPost step at
+TimeoutStopSec and the unit lands failed instead of restarting. (A
+Before=/Conflicts= job-cancellation race was also considered; ruled out --
+no "Job ... was cancelled" or "contradicts existing jobs" lines appear
+anywhere in `journalctl -u cinemate-autostart -b`.) `pi` has passwordless
+sudo, so running as root skips the prompt entirely; `-n` guarantees a fast
+failure instead of a hang if that sudoers rule is ever tightened.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+SCRIPT = (
+    Path(__file__).resolve().parent.parent
+    / "services"
+    / "cinemate-autostart"
+    / "cinemate-console-handoff.sh"
+)
+
+
+class ConsoleHandoffScriptTest(unittest.TestCase):
+    def setUp(self):
+        self.text = SCRIPT.read_text()
+
+    def test_every_systemctl_start_runs_under_sudo_n(self):
+        for line in self.text.splitlines():
+            if line.lstrip().startswith("#"):
+                continue
+            if re.search(r"\bsystemctl\b.*\bstart\b", line):
+                self.assertIn(
+                    "sudo -n",
+                    line,
+                    f"unprivileged 'systemctl start' hangs on a PolicyKit "
+                    f"prompt in ExecStopPost (F-283): {line!r}",
+                )
+
+    def test_no_bare_sudo_without_noninteractive_flag(self):
+        for line in self.text.splitlines():
+            if "sudo " in line and "sudo -n" not in line:
+                self.fail(f"sudo without -n can block on a password prompt: {line!r}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/services/cinemate-autostart/cinemate-console-handoff.sh
+++ b/services/cinemate-autostart/cinemate-console-handoff.sh
@@ -33,7 +33,7 @@ shutdown_job_in_progress() {
 }
 
 if systemd_manager_stopping || shutdown_job_in_progress; then
-    /bin/systemctl --no-block start plymouth-start.service >/dev/null 2>&1 || true
+    sudo -n /bin/systemctl --no-block start plymouth-start.service >/dev/null 2>&1 || true
     if command -v plymouth >/dev/null 2>&1; then
         plymouth change-mode --shutdown >/dev/null 2>&1 || true
         plymouth show-splash >/dev/null 2>&1 || true
@@ -41,4 +41,8 @@ if systemd_manager_stopping || shutdown_job_in_progress; then
     exit 0
 fi
 
-/bin/systemctl start getty@tty1.service >/dev/null 2>&1 || true
+# Unprivileged `systemctl start` triggers a PolicyKit prompt that blocks
+# forever with no tty to answer it -- systemd then kills this ExecStopPost
+# step at TimeoutStopSec and the unit lands failed instead of restarting.
+# `pi` has passwordless sudo; running as root skips the polkit prompt.
+sudo -n /bin/systemctl --no-block start getty@tty1.service >/dev/null 2>&1 || true

--- a/services/cinemate-autostart/cinemate-console-handoff.sh
+++ b/services/cinemate-autostart/cinemate-console-handoff.sh
@@ -44,5 +44,22 @@ fi
 # Unprivileged `systemctl start` triggers a PolicyKit prompt that blocks
 # forever with no tty to answer it -- systemd then kills this ExecStopPost
 # step at TimeoutStopSec and the unit lands failed instead of restarting.
-# `pi` has passwordless sudo; running as root skips the polkit prompt.
+# `pi` has passwordless sudo; running as root skips the prompt. Fixes
+# F-283's reported symptom (restart hangs, unit lands failed) -- verified
+# on hardware across many restarts, ExecStopPost now always completes in
+# well under a second.
+#
+# A separate, narrower race remains open: cinemate-autostart.service
+# declares Conflicts=getty@tty1.service, and on hardware this getty-start
+# has been observed to occasionally collide with the start half of an
+# in-flight `systemctl restart`, leaving the unit inactive instead of
+# active (not failed/hung -- a second restart recovers it). Tried and
+# rejected: --job-mode=ignore-dependencies (still collided), deferring via
+# a timer and re-checking is-active at fire time (a stale timer from a
+# prior restart can fire mid-transition of a later one and misread),
+# debouncing the timer (the cancel only runs at the end of this script,
+# after a stale timer may have already fired), and dropping Conflicts=
+# entirely (breaks worse: TTYVHangup=yes then SIGHUPs this unit's own
+# ExecStartPre if a getty is still alive on tty1, killing a fresh start,
+# not just a restart -- confirmed on hardware, reverted). Left open.
 sudo -n /bin/systemctl --no-block start getty@tty1.service >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary
- Fixes F-283's literally-reported symptom: `systemctl restart cinemate-autostart` hangs and the unit lands `failed`.
- Root cause: `cinemate-console-handoff.sh` (ExecStopPost) calls unprivileged `systemctl start <unit>`, which triggers an interactive PolicyKit prompt with no tty to answer it. Confirmed directly on hardware with `timeout 10 bash -x` — literal `AUTHENTICATING FOR org.freedesktop.systemd1.manage-units` / `Password:` hang, killed at the 10s timeout.
- Fix: both `systemctl start` calls in the script now run under `sudo -n` (pi has passwordless sudo — root skips the polkit prompt; `-n` fails fast instead of hanging if that sudoers rule is ever tightened).
- Adds a regression test (`_test/test_console_handoff_script.py`) asserting every `systemctl start` call in the script runs under `sudo -n`.

## Known residual issue (not fixed by this PR)
`cinemate-autostart.service` declares `Conflicts=getty@tty1.service`. The getty-start in this script can occasionally collide with the start half of an in-flight `systemctl restart`, leaving the unit `inactive` instead of `active` (not `failed`/hung — a second restart always recovers it, no `reset-failed` needed).

Four mitigations were tried on hardware and rejected — all documented in the script's comment so they aren't re-attempted blind:
1. `--job-mode=ignore-dependencies` on the getty-start — still collided.
2. Defer the getty-start via a timer, re-check `is-active` at fire time — a stale timer from an earlier restart can fire mid-transition of a later one and misread, still collided.
3. Debounce the timer (cancel any pending one first) — the cancel only runs at the end of the script, after a stale timer may already have fired, still collided.
4. Drop `Conflicts=getty@tty1.service` entirely — **worse**: `TTYVHangup=yes` then SIGHUPs the unit's own `ExecStartPre` if a getty is still alive on tty1, breaking a fresh start (not just a restart) — confirmed on hardware (`camera-ready.sh` killed by SIGHUP), reverted immediately.

This is left as an open, separate problem — closing it needs a different mechanism than anything tried so far (or an explicit decision to accept it as a known limitation).

## Test plan
- [x] Reproduced the original hang directly: `timeout 10 bash -x /usr/local/bin/cinemate-console-handoff.sh` as user `pi`, showed the polkit auth prompt.
- [x] With the fix deployed, ran 5 consecutive `systemctl restart cinemate-autostart` cycles: **0/5 landed `failed`** (the original bug never recurred); `ExecStopPost` always completed in well under a second.
- [x] `_test/test_console_handoff_script.py` passes locally.
- [ ] CI (this repo has no CI on cinemate-autostart's shell scripts beyond shellcheck; pytest will pick up the new test file)