### PR TITLE
fix(ssd_monitor): F-284 unmount/mount cannot find RAW volume

### DIFF
--- a/_test/test_ssd_monitor_format.py
+++ b/_test/test_ssd_monitor_format.py
@@ -86,6 +86,52 @@ class SSDMonitorFormatTests(unittest.TestCase):
         self.assertEqual(calls[0], ["blkid", "-p", "-s", "TYPE", "-o", "value", "/dev/sda2"])
         self.assertEqual(calls[1], ["blkid", "-c", "/dev/null", "-s", "TYPE", "-o", "value", "/dev/sda2"])
 
+    def test_fresh_probe_skips_a_successful_but_empty_result(self):
+        """F-284. Unprivileged (User=pi): `blkid -p` raises on a raw device it
+        cannot open, correctly falls through. `-c /dev/null` needs the same
+        raw access and does not have it either, but on this hardware it
+        exits 0 with empty stdout instead of raising -- reproduced 10/10 on
+        a whole-disk (no partition table) NVMe volume. An empty-but-
+        successful result must not be treated as final; the cache-backed
+        query one step further, which actually has the label, must still
+        run.
+        """
+        calls = []
+
+        def fake_check_output(cmd, **_kwargs):
+            calls.append(cmd)
+            if "-p" in cmd:
+                raise CalledProcessError(2, cmd)
+            if "-c" in cmd:
+                return ""
+            return "RAW\n"
+
+        with patch.object(ssd_monitor.subprocess, "check_output", side_effect=fake_check_output):
+            value = ssd_monitor.SSDMonitor._blkid_value("/dev/nvme0n1", "LABEL", fresh=True)
+
+        self.assertEqual(value, "RAW")
+        self.assertEqual(len(calls), 3)
+        self.assertEqual(calls[2], ["blkid", "-s", "LABEL", "-o", "value", "/dev/nvme0n1"])
+
+    def test_find_raw_device_logs_when_blkid_enumeration_fails(self):
+        monitor = self._monitor()
+
+        with (
+            patch.object(
+                ssd_monitor.subprocess,
+                "check_output",
+                side_effect=CalledProcessError(2, ["blkid"]),
+            ),
+            self.assertLogs(level="WARNING") as logs,
+        ):
+            result = monitor._find_raw_device()
+
+        self.assertIsNone(result)
+        self.assertTrue(
+            any("blkid enumeration failed" in message for message in logs.output),
+            logs.output,
+        )
+
 
 class SSDMonitorStorageErrorTests(unittest.TestCase):
     """A corrupt clip dir on a dirty NTFS volume must not unmount a healthy drive.

--- a/src/module/ssd_monitor.py
+++ b/src/module/ssd_monitor.py
@@ -559,6 +559,20 @@ class SSDMonitor:
         The normal blkid path can briefly report cached pre-format metadata.
         Fresh probes first ask blkid to read the device directly and then fall
         back to the cache-backed query used elsewhere.
+
+        F-284: this process runs unprivileged (User=pi). `blkid -p` (true raw
+        probe) then always raises CalledProcessError ("Permission denied"),
+        which is caught and skipped correctly -- but its `-c /dev/null`
+        fallback needs the same raw device access and does not have it
+        either; on this hardware it exits 0 with empty stdout instead of
+        raising, since it isn't a low-level probe. A bare `return` on any
+        successful-but-empty command short-circuited before ever reaching
+        the cache-backed query that actually works (confirmed instant and
+        correct by hand, and matching stage 1's own cache-based
+        enumeration) -- so a device with an unprivileged-unreadable raw
+        node, e.g. a whole-disk filesystem with no partition table, always
+        failed LABEL lookup with `fresh=True`. Reproduced 10/10 on
+        hardware. A command must return a non-empty value to count.
         """
         commands = []
         if fresh:
@@ -570,7 +584,7 @@ class SSDMonitor:
 
         for cmd in commands:
             try:
-                return subprocess.check_output(
+                value = subprocess.check_output(
                     cmd,
                     text=True,
                     stderr=subprocess.DEVNULL,
@@ -582,6 +596,8 @@ class SSDMonitor:
                 subprocess.TimeoutExpired,
             ):
                 continue
+            if value:
+                return value
         return ""
 
     @staticmethod
@@ -632,7 +648,12 @@ class SSDMonitor:
                 FileNotFoundError,
                 subprocess.CalledProcessError,
                 subprocess.TimeoutExpired,
-            ):
+            ) as exc:
+                logging.warning(
+                    "_find_raw_device(): blkid enumeration failed (%s): %s",
+                    type(exc).__name__,
+                    exc,
+                )
                 return []
 
         candidates = [d for d in _blkid_lines() if Path(d).exists()]


### PR DESCRIPTION
## Summary
- Fixes F-284: `unmount` then `mount` reported "no partition labelled RAW found" while `blkid`/`lsblk` see the device instantly by hand.
- Root cause, one level down from `mount_drive()`: `_blkid_value(fresh=True)`'s fallback chain is `blkid -p` (raw probe) → `blkid -c /dev/null` → cache-backed `blkid`. Running unprivileged (`User=pi`), `-p` correctly raises `Permission denied` and falls through — but `-c /dev/null` needs the same raw device access it doesn't have either, and on this hardware exits `0` with **empty** stdout instead of raising. The loop treated that as a final result and never reached the cache-backed query that actually has the label.
- Affects any device whose raw block node this unprivileged process can't open for a true `-p` probe — concretely, this NVMe has no partition table (`LABEL=RAW` lives directly on `/dev/nvme0n1`, no `/dev/nvme0n1p1` exists).
- Fix: a blkid command must return a non-empty value to count; empty-but-successful results now fall through to the next fallback.
- Also logs blkid enumeration failures in `_find_raw_device()` (previously a bare `return []` with no trace).

## Test plan
- [x] Reproduced on hardware: 10 consecutive CLI `unmount`/`mount` cycles on unfixed code — **10/10 failed** (`no partition labelled RAW found` every time), confirmed with timing/exception diagnostics (ruled out the 1s timeout — enumeration took ~5-18ms every time; confirmed empty-but-successful `-c /dev/null` result via direct manual testing).
- [x] Same 10-cycle test with the fix deployed — **10/10 succeeded**, `is_mounted=1` throughout, zero "no partition labelled RAW found" warnings.
- [x] Two new regression tests (`_test/test_ssd_monitor_format.py`), subprocess stubbed, no hardware needed: the empty-`-c`-fallback case falls through correctly, and `_find_raw_device()` logs on enumeration failure.
- [x] Full local suite: 405 passed + 241 subtests, 0 failures.