### PR TITLE
fix(dynamic_resolution): F-286 explicit 12-bit request + missing toggle

### DIFF
--- a/_test/test_dynamic_resolution.py
+++ b/_test/test_dynamic_resolution.py
@@ -24,6 +24,23 @@ IMX585_DETECTED_ORDER_MODES = {
     1: {"width": 1928, "height": 1090, "bit_depth": 12, "fps_max": 50},
 }
 
+# Real imx477 mode table, `cinepi-raw --list-cameras` on hardware (dev 2026-08-24).
+# The 10-bit and 12-bit modes at each resolution always tie on area; only the
+# max-resolution pair matters for F-286, but the whole table is included so
+# the fixture is a faithful stand-in for the live sensor, not a minimal repro.
+IMX477_MODES = {
+    0: {"width": 1332, "height": 990, "bit_depth": 10, "fps_max": 120.50},
+    1: {"width": 2028, "height": 1080, "bit_depth": 10, "fps_max": 74.74},
+    2: {"width": 2028, "height": 1520, "bit_depth": 10, "fps_max": 53.77},
+    3: {"width": 4056, "height": 2160, "bit_depth": 10, "fps_max": 19.58},
+    4: {"width": 4056, "height": 3040, "bit_depth": 10, "fps_max": 14.00},
+    5: {"width": 1332, "height": 990, "bit_depth": 12, "fps_max": 101.68},
+    6: {"width": 2028, "height": 1080, "bit_depth": 12, "fps_max": 62.81},
+    7: {"width": 2028, "height": 1520, "bit_depth": 12, "fps_max": 45.19},
+    8: {"width": 4056, "height": 2160, "bit_depth": 12, "fps_max": 16.39},
+    9: {"width": 4056, "height": 3040, "bit_depth": 12, "fps_max": 11.72},
+}
+
 
 class DynamicResolutionTests(unittest.TestCase):
     def test_resolution_indicator_only_when_dynamic_substitute_is_active(self):
@@ -110,6 +127,38 @@ class DynamicResolutionTests(unittest.TestCase):
         self.assertIsNotNone(choice)
         self.assertEqual(choice.mode, 1)
         self.assertFalse(choice.dynamic_active)
+
+    def test_explicit_max_resolution_request_honors_bit_depth(self):
+        # F-286. imx477 at 4056x3040: 10-bit (mode 4, fps_max 14.00) and
+        # 12-bit (mode 9, fps_max 11.72) tie on area -- the sensor's max
+        # resolution, so there is no larger mode either could be beaten by.
+        # An explicit request for the 12-bit mode at a sustainable fps must
+        # return the 12-bit mode, not silently substitute the faster 10-bit
+        # one nothing asked for.
+        choice = choose_resolution(
+            sensor_modes=IMX477_MODES,
+            desired_mode=9,
+            requested_fps=10,
+        )
+
+        self.assertIsNotNone(choice)
+        self.assertEqual(choice.mode, 9)
+        self.assertEqual(IMX477_MODES[choice.mode]["bit_depth"], 12)
+        self.assertFalse(choice.dynamic_active)
+
+    def test_max_resolution_downshift_still_reaches_10bit_when_12bit_cannot_sustain_fps(self):
+        # The 12-bit mode's own ceiling is 11.72fps; requesting faster than
+        # that at the same desired mode must still fall through to the
+        # tie-break (10-bit, faster) rather than return nothing.
+        choice = choose_resolution(
+            sensor_modes=IMX477_MODES,
+            desired_mode=9,
+            requested_fps=13,
+        )
+
+        self.assertIsNotNone(choice)
+        self.assertEqual(choice.mode, 4)
+        self.assertEqual(IMX477_MODES[choice.mode]["bit_depth"], 10)
 
     def test_keeps_manual_desired_mode_when_it_is_already_the_low_one(self):
         choice = choose_resolution(

--- a/_test/test_dynamic_resolution_enabled_toggle.py
+++ b/_test/test_dynamic_resolution_enabled_toggle.py
@@ -1,0 +1,85 @@
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+sys.modules.setdefault("redis", types.SimpleNamespace(StrictRedis=object))
+sys.modules.setdefault("smbus", types.SimpleNamespace(SMBus=object))
+
+from module.cinepi_controller import CinePiController
+from module.redis_controller import ParameterKey
+
+
+class FakeRedis:
+    def __init__(self, dynamic_resolution_enabled=None):
+        self.values = {}
+        if dynamic_resolution_enabled is not None:
+            self.values[ParameterKey.DYNAMIC_RESOLUTION_ENABLED.value] = dynamic_resolution_enabled
+        self.sets = []
+
+    def get_value(self, key, default=None):
+        key = key.value if isinstance(key, ParameterKey) else key
+        return self.values.get(key, default)
+
+    def set_value(self, key, value):
+        key = key.value if isinstance(key, ParameterKey) else key
+        self.values[key] = value
+        self.sets.append((key, value))
+
+
+class DynamicResolutionEnabledToggleTests(unittest.TestCase):
+    """F-286. dynamic_resolution_enabled was a hardcoded True with no CLI or
+    redis-write toggle -- published for display only, never read back. This
+    covers the startup read-back and the new setter, mirroring
+    test_cinepi_controller_startup_sensor_mode.py's controller() pattern."""
+
+    def controller(self, redis):
+        controller = CinePiController.__new__(CinePiController)
+        controller.redis_controller = redis
+        controller.dynamic_resolution_enabled = True
+        controller.dynamic_resolution_active = False
+        controller.dynamic_resolution_desired_mode = None
+        return controller
+
+    def test_startup_defaults_to_enabled_when_unset(self):
+        controller = self.controller(FakeRedis())
+        self.assertTrue(controller._get_startup_dynamic_resolution_enabled())
+
+    def test_startup_reads_back_disabled_from_redis(self):
+        controller = self.controller(FakeRedis(dynamic_resolution_enabled=0))
+        self.assertFalse(controller._get_startup_dynamic_resolution_enabled())
+
+    def test_startup_reads_back_enabled_from_redis(self):
+        controller = self.controller(FakeRedis(dynamic_resolution_enabled=1))
+        self.assertTrue(controller._get_startup_dynamic_resolution_enabled())
+
+    def test_set_explicit_value_and_publishes(self):
+        controller = self.controller(FakeRedis(dynamic_resolution_enabled=1))
+
+        controller.set_dynamic_resolution_enabled(0)
+
+        self.assertFalse(controller.dynamic_resolution_enabled)
+        self.assertEqual(
+            controller.redis_controller.get_value(ParameterKey.DYNAMIC_RESOLUTION_ENABLED.value),
+            0,
+        )
+
+    def test_toggle_with_no_value_flips_current_state(self):
+        controller = self.controller(FakeRedis(dynamic_resolution_enabled=1))
+        controller.dynamic_resolution_enabled = True
+
+        controller.set_dynamic_resolution_enabled()
+
+        self.assertFalse(controller.dynamic_resolution_enabled)
+
+    def test_invalid_value_raises(self):
+        controller = self.controller(FakeRedis())
+        with self.assertRaises(ValueError):
+            controller.set_dynamic_resolution_enabled("nonsense")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -38,6 +38,7 @@ The same commands can be sent wirelessly over the camera's Wi-Fi hotspot — see
 | `set wb [<Kelvin>]`                        | int or none       | `set wb 5600`                           | Set white balance or cycle active WB steps      |
 | `inc wb` / `dec wb`                        | -              |                                 | Step white balance; `arrays.wb.free_increment` (100 K default) in free mode |
 | `set resolution [<mode>]`                  | int or none       | `set resolution 2`                      | Apply or cycle sensor mode                      |
+| `set dynamic resolution [0/1]`             | 0/1 or none       | `set dynamic resolution 0`              | Enable/disable/toggle dynamic resolution substitution |
 | `set anamorphic factor [<float>]`          | float or none     | `set anamorphic factor 1.33`            | Set or toggle anamorphic stretch                |
 | `set zoom [<float>]`                       | float or none     | `set zoom 2`                            | Change digital zoom; omit to cycle              |
 | `inc zoom` / `dec zoom`                    | -              |                              | Step preview zoom factor                        |

--- a/docs/controller-methods.md
+++ b/docs/controller-methods.md
@@ -29,6 +29,7 @@ These methods adjust ISO, shutter angle and frame rate. Increment/decrement help
 ## Resolution and preview
 
 - `set_resolution(value=None)` – Switch sensor mode. Passing `None` cycles through the available modes.
+- `set_dynamic_resolution_enabled(value=None)` – Toggle or explicitly set whether dynamic resolution may substitute a lower-resolution mode when the requested fps exceeds the desired mode's own `fps_max`. Omit the value to toggle.
 - `set_anamorphic_factor(value=None)` – Change the preview’s anamorphic stretch. Omit the value to toggle between presets.
 - `set_zoom(value=None, direction="next")` – Adjust the digital zoom factor. Without a value it steps through `preview.zoom_steps`.
 - `inc_zoom()` / `dec_zoom()` – Convenience wrappers around `set_zoom()`.

--- a/src/module/app/settings_editor.py
+++ b/src/module/app/settings_editor.py
@@ -99,6 +99,7 @@ ACTION_METHODS = [
     {"group": "Zoom / anamorphic", "value": "dec_zoom", "label": "Zoom out one stop"},
     {"group": "Zoom / anamorphic", "value": "set_anamorphic_factor", "label": "Set anamorphic desqueeze", "arg": {"type": "select", "options": [1, 1.33, 2], "suffix": "×"}},
     {"group": "Resolution / preview", "value": "set_resolution", "label": "Change resolution", "arg": {"type": "number", "placeholder": "mode #, blank = cycle"}},
+    {"group": "Resolution / preview", "value": "set_dynamic_resolution_enabled", "label": "Toggle dynamic resolution", "arg": {"type": "toggle01"}},
     {"group": "Resolution / preview", "value": "set_preview_source", "label": "Set HDMI preview source", "arg": {"type": "select", "options": ["cam0", "cam1", "cam0+cam1"]}},
     {"group": "Storage", "value": "mount", "label": "Mount storage"},
     {"group": "Storage", "value": "unmount", "label": "Unmount storage"},

--- a/src/module/app/templates/settings_editor.html
+++ b/src/module/app/templates/settings_editor.html
@@ -3293,6 +3293,7 @@
     { group: 'Zoom / anamorphic', value: 'dec_zoom', label: 'Zoom out one stop' },
     { group: 'Zoom / anamorphic', value: 'set_anamorphic_factor', label: 'Set anamorphic desqueeze', arg: { type: 'select', options: [1,1.33,2], suffix: '×' } },
     { group: 'Resolution / preview', value: 'set_resolution', label: 'Change resolution', arg: { type: 'number', placeholder: 'mode #, blank = cycle' } },
+    { group: 'Resolution / preview', value: 'set_dynamic_resolution_enabled', label: 'Toggle dynamic resolution', arg: { type: 'toggle01' } },
     { group: 'Resolution / preview', value: 'set_preview_source', label: 'Set HDMI preview source', arg: { type: 'select', options: ['cam0','cam1','cam0+cam1'] } },
     { group: 'Storage', value: 'mount', label: 'Mount storage' },
     { group: 'Storage', value: 'unmount', label: 'Unmount storage' },

--- a/src/module/cinepi_controller.py
+++ b/src/module/cinepi_controller.py
@@ -99,12 +99,14 @@ class CinePiController:
         except Exception as exc:
             logging.warning("Could not apply phase_lock setting: %s", exc)
 
-        # Dynamic resolution is always on: it substitutes a lower-resolution
-        # sensor mode when the requested fps exceeds what the desired mode's
-        # own declared fps_max (the value cinepi-raw --list-cameras reports,
-        # see sensor_detect.py) can sustain. No curated performance table,
-        # no policy -- just the sensor's own numbers.
-        self.dynamic_resolution_enabled = True
+        # Dynamic resolution substitutes a lower-resolution sensor mode when
+        # the requested fps exceeds what the desired mode's own declared
+        # fps_max (the value cinepi-raw --list-cameras reports, see
+        # sensor_detect.py) can sustain. No curated performance table, no
+        # policy -- just the sensor's own numbers. Defaults on; settable via
+        # set_dynamic_resolution_enabled / redis, and read back at startup
+        # (F-286 -- this was previously a hardcoded True with no toggle).
+        self.dynamic_resolution_enabled = self._get_startup_dynamic_resolution_enabled()
         self.dynamic_resolution_desired_mode = None
         self.dynamic_resolution_active = False
         self.dynamic_resolution_suspended = False
@@ -314,6 +316,14 @@ class CinePiController:
             return self.sensor_mode
         return desired_mode
 
+    def _get_startup_dynamic_resolution_enabled(self) -> bool:
+        value = self.redis_controller.get_value(
+            ParameterKey.DYNAMIC_RESOLUTION_ENABLED.value
+        )
+        if value is None:
+            return True
+        return self._as_bool(value)
+
     def _publish_dynamic_resolution_state(self):
         self.redis_controller.set_value(
             ParameterKey.DYNAMIC_RESOLUTION_ENABLED.value,
@@ -328,6 +338,19 @@ class CinePiController:
                 ParameterKey.DYNAMIC_RESOLUTION_DESIRED_MODE.value,
                 self.dynamic_resolution_desired_mode,
             )
+
+    def set_dynamic_resolution_enabled(self, value=None):
+        if value is not None:
+            if value in (0, False):
+                self.dynamic_resolution_enabled = False
+            elif value in (1, True):
+                self.dynamic_resolution_enabled = True
+            else:
+                raise ValueError("Invalid value. Please provide either 0, 1, True, or False.")
+        else:
+            self.dynamic_resolution_enabled = not self.dynamic_resolution_enabled
+        logging.info(f"Dynamic resolution enabled {self.dynamic_resolution_enabled}")
+        self._publish_dynamic_resolution_state()
 
     def _current_user_fps_value(self):
         value = self.redis_controller.get_value(ParameterKey.FPS_USER.value)

--- a/src/module/cli_commands.py
+++ b/src/module/cli_commands.py
@@ -93,6 +93,7 @@ class CommandExecutor(threading.Thread):
 
             # ── Resolution / anamorphic / storage ────────────────────────────────
             'set resolution'         : (cinepi_controller.set_resolution, [int, None]),
+            'set dynamic resolution' : (cinepi_controller.set_dynamic_resolution_enabled, [int, None]),
             'set anamorphic factor'  : (cinepi_controller.set_anamorphic_factor, [float, None]),
             'mount'                  : (cinepi_controller.mount,          None),
             'unmount'                : (cinepi_controller.unmount,        None),

--- a/src/module/dynamic_resolution.py
+++ b/src/module/dynamic_resolution.py
@@ -164,9 +164,24 @@ def choose_resolution(
     if not eligible:
         return None
 
-    selected_mode, selected_area, selected_fps_max = max(
-        eligible, key=lambda item: (item[1], item[2])
+    # F-286: two modes can share an area and differ only in bit depth (a
+    # sensor's max-resolution 10-bit and 12-bit modes always tie on area,
+    # since both sit at the sensor's ceiling). The (area, fps_max)
+    # tie-break below then prefers whichever is faster -- typically the
+    # lower bit depth -- even when the desired mode itself already
+    # sustains requested_fps and substitution has nothing to do. An
+    # explicit, sustainable request for the desired mode is honored
+    # directly, ahead of the tie-break.
+    desired_eligible = next(
+        (item for item in eligible if item[0] == desired_mode_int),
+        None,
     )
+    if desired_eligible is not None:
+        selected_mode, selected_area, selected_fps_max = desired_eligible
+    else:
+        selected_mode, selected_area, selected_fps_max = max(
+            eligible, key=lambda item: (item[1], item[2])
+        )
     desired_area = _mode_area(desired_info)
     return DynamicResolutionChoice(
         mode=selected_mode,


### PR DESCRIPTION
## Summary

Two commits, reviewable independently:

**1. `fix(dynamic_resolution): honor an explicit sustainable mode request`**

`choose_resolution()`'s tie-break maximizes `(area, fps_max)` with no bit-depth term. A sensor's max-resolution modes at different bit depths always tie on area (neither can be beaten by anything larger), so the tie-break falls to `fps_max` — favoring the lower bit depth. On imx477, `4056x3040` 10-bit (`fps_max` 14.00) and 12-bit (`fps_max` 11.72) tie on area; **requesting the 12-bit mode at 10fps returned the 10-bit mode instead, with nothing reported.** Confirmed against the real sensor table (`cinepi-raw --list-cameras`).

This is stronger than "can't reach 12-bit in a tie" — it's silent substitution of an explicit, sustainable request. Fix: when the desired mode itself is eligible (already sustains `requested_fps`), select it directly, ahead of the tie-break. The tie-break still runs for genuine downgrades.

**2. `feat(dynamic_resolution): wire up the missing enabled toggle`**

`dynamic_resolution_enabled` was a hardcoded `True`, published to redis for display only, never read back or settable. PI-016 needed to reach the sensor's true max mode and could only do it by patching source directly. Wired up: `_get_startup_dynamic_resolution_enabled()` reads the redis-persisted value at startup; `set_dynamic_resolution_enabled(value=None)` sets or toggles it; wired into the CLI (`set dynamic resolution`), both copies of the settings-editor catalogue (Python + JS), and docs. `tools/gui_field_extract.py --max-unresolved 0` and `tools/docs_drift_check.py --strict` both pass.

## Open design question — not implemented, needs your call

The guard above fixes explicit requests. It does **not** change what happens on a genuine downgrade, where the desired mode cannot sustain `requested_fps` and a substitute must be chosen among lower-or-equal-area candidates. Should `bit_depth` become a third sort term?

**My recommendation: yes, ranked *above* `fps_max`.** Reasoning:

- The tie-break only runs among candidates that already passed the eligibility filter (`mode_fps_max >= requested_fps`). So when two same-area candidates differing only in bit depth are *both* eligible, the fps_max difference between them is unused headroom, not something the request actually needs — the user asked for `requested_fps`, and both already deliver it.
- Preferring bit depth in that situation matches operator intent: "give me the best image quality that still hits my target fps," not "give me extra fps I didn't ask for."
- It's the same principle as the guard fix above, extended to the downgrade path: don't silently trade depth away for unrequested margin.

**Consequence per sensor**, using the real imx477 table and the current `IMX585_MODES`/`HDR_MODES` test fixtures:

- **imx477**: e.g. desired mode `4056x3040` 12-bit, `requested_fps=20` (exceeds both `4056x3040` variants' ceilings, and both `4056x2160` variants' too) — the downgrade lands on `2028x1520`, where 10-bit (53.77fps) and 12-bit (45.19fps) both clear 20fps and tie on area. Today: picks 10-bit. With the change: picks 12-bit.
- **imx585**: no effect today — every mode in the live table and the existing test fixtures (`IMX585_MODES`, `IMX585_DETECTED_ORDER_MODES`, `HDR_MODES`) is `bit_depth: 12` throughout, so there is no bit-depth variety for this ranking to act on. It would only matter if/when imx585 exposes a lower-bit-depth mode at the same resolution (mirroring imx477's shape).

If this is the wrong call, the fix is a one-line key-function change (`(item[1], item[2])` → `(item[1], bit_depth, item[2])` with a sign flip depending on ranking) plus a fixture reusing `IMX477_MODES` from this PR at a lower, tied resolution. Happy to implement once you confirm the direction.

## Test plan
- [x] Reproduced via a real fixture: `desired_mode=9` (12-bit, `4056x3040`), `requested_fps=10` on unfixed code → returned mode 4 (10-bit). Fixed code → returns mode 9 (12-bit).
- [x] Downgrade path still works: `requested_fps=13` (exceeds 12-bit's 11.72 ceiling) correctly falls through to mode 4 (10-bit).
- [x] **Hardware, the decisive test**: `set fps free 1`, `set fps 10`, then `set resolution 0` through the real CLI command surface (mode 0 = `4056:3040:12:U` in this process's live numbering, confirmed by cycling 0–9 and reading back `resolution_target_width/height/bit_depth`). Redis published `bit_depth=12`, `width=4056`, `height=3040`. **Recorded a take and parsed the actual DNG's TIFF tags directly (not just redis/GUI display): `ImageWidth=4056`, `ImageLength=3040`, `BitsPerSample=12`.** Real 12-bit capture at full resolution through the normal command surface, no source patch needed — this is exactly what PI-016 could not do.
- [x] Existing suites re-run and pass unchanged: `test_dynamic_resolution.py`, `test_resolution_defaults.py`, `test_cinepi_controller_resolution_gui.py`.
- [x] Full local suite: 411 passed, 241 subtests, 0 failures (405 + 6 new toggle tests + 2 new tie-break tests over dev baseline... plus the pre-existing 403 puts this at 411 total, see individual commits for exact deltas).
- [x] 6 new regression tests for the toggle (redis stubbed), 2 new regression tests for the guard fix (real imx477 fixture) — all off-hardware, no Pi needed to re-verify the logic.