### PR TITLE
fix(dynamic_resolution): F-286 tie-break ranks bit depth over fps_max

### DIFF
--- a/_test/test_dynamic_resolution.py
+++ b/_test/test_dynamic_resolution.py
@@ -146,6 +146,25 @@ class DynamicResolutionTests(unittest.TestCase):
         self.assertEqual(IMX477_MODES[choice.mode]["bit_depth"], 12)
         self.assertFalse(choice.dynamic_active)
 
+    def test_genuine_downgrade_prefers_bit_depth_over_unused_fps_headroom(self):
+        # F-286 tie-break correction. requested_fps=20 excludes both
+        # 4056x3040 and 4056x2160 variants (all four fps_max < 20), forcing
+        # a real downgrade. The next-largest area, 2028x1520, has both
+        # 10-bit (mode 2, fps_max 53.77) and 12-bit (mode 7, fps_max 45.19)
+        # eligible and tied on area. Both already clear requested_fps=20,
+        # so the extra headroom the 10-bit mode has over the 12-bit one is
+        # unused -- bit depth should win the tie, not fps_max.
+        choice = choose_resolution(
+            sensor_modes=IMX477_MODES,
+            desired_mode=9,
+            requested_fps=20,
+        )
+
+        self.assertIsNotNone(choice)
+        self.assertEqual(choice.mode, 7)
+        self.assertEqual(IMX477_MODES[choice.mode]["bit_depth"], 12)
+        self.assertTrue(choice.dynamic_active)
+
     def test_max_resolution_downshift_still_reaches_10bit_when_12bit_cannot_sustain_fps(self):
         # The 12-bit mode's own ceiling is 11.72fps; requesting faster than
         # that at the same desired mode must still fall through to the

--- a/src/module/dynamic_resolution.py
+++ b/src/module/dynamic_resolution.py
@@ -156,9 +156,10 @@ def choose_resolution(
         return None
 
     eligible = [
-        (mode, area, mode_fps_max)
+        (mode, area, mode_fps_max, mode_bit_depth)
         for mode, info, area in candidates
         for mode_fps_max in [_as_float(info.get("fps_max"))]
+        for mode_bit_depth in [_as_int(info.get("bit_depth")) or 0]
         if mode_fps_max is not None and mode_fps_max >= fps
     ]
     if not eligible:
@@ -166,21 +167,26 @@ def choose_resolution(
 
     # F-286: two modes can share an area and differ only in bit depth (a
     # sensor's max-resolution 10-bit and 12-bit modes always tie on area,
-    # since both sit at the sensor's ceiling). The (area, fps_max)
-    # tie-break below then prefers whichever is faster -- typically the
-    # lower bit depth -- even when the desired mode itself already
-    # sustains requested_fps and substitution has nothing to do. An
-    # explicit, sustainable request for the desired mode is honored
-    # directly, ahead of the tie-break.
+    # since both sit at the sensor's ceiling). An explicit, sustainable
+    # request for the desired mode is honored directly, ahead of the
+    # tie-break below.
     desired_eligible = next(
         (item for item in eligible if item[0] == desired_mode_int),
         None,
     )
     if desired_eligible is not None:
-        selected_mode, selected_area, selected_fps_max = desired_eligible
+        selected_mode, selected_area, selected_fps_max, _selected_bit_depth = desired_eligible
     else:
-        selected_mode, selected_area, selected_fps_max = max(
-            eligible, key=lambda item: (item[1], item[2])
+        # Genuine downgrade: the desired mode itself cannot sustain
+        # requested_fps, so a substitute must be chosen among candidates
+        # that all already clear the fps bar. Among those, bit depth ranks
+        # above fps_max -- once eligibility is satisfied, any fps_max a
+        # candidate has beyond requested_fps is unused headroom, not
+        # something the request needs, so it should not be traded against
+        # image quality. Ranked: area (resolution) first, then bit depth,
+        # then fps_max only to break a remaining tie.
+        selected_mode, selected_area, selected_fps_max, _selected_bit_depth = max(
+            eligible, key=lambda item: (item[1], item[3], item[2])
         )
     desired_area = _mode_area(desired_info)
     return DynamicResolutionChoice(


### PR DESCRIPTION
## Summary
Implements the tie-break design proposed and left open in #137: on a genuine downgrade (desired mode can't sustain `requested_fps`), bit depth now ranks above `fps_max` when two candidates tie on area. Rationale, consequence per sensor, and the reasoning for ranking above (not below) `fps_max` are all in the commit message and were laid out in #137's description — approved as-is.

## Test plan
- [x] New regression test: `requested_fps=20` with `desired_mode=9` (4056x3040 12-bit) forces a downgrade to 2028x1520, where 10-bit (53.77fps) and 12-bit (45.19fps) tie on area and both clear 20fps — now correctly lands on 12-bit.
- [x] Existing #137 tests (explicit-request guard, cannot-sustain-fps fallback) pass unchanged — neither exercises a same-area tie between two *eligible* candidates, so this commit doesn't touch their behavior.
- [x] Full local suite: 416 passed, 241 subtests, 0 failures.