### PR TITLE
B11.1 + B11.2 · config.txt saves, and cinepi.local resolves

### DIFF
--- a/_test/test_boot_config_write.py
+++ b/_test/test_boot_config_write.py
@@ -1,0 +1,109 @@
+"""config.txt saves must not silently fail as User=pi (F-288).
+
+/boot/firmware is root-owned; the settings editor runs unprivileged, so a
+direct write there raises PermissionError before a byte is written. That
+case must fall back to staging the text somewhere pi-writable and handing
+it to the privileged helper cinemate-install.sh's configure_sudoers()
+grants -- and a failure in that fallback must not leave a staged file
+behind.
+"""
+
+import os
+import stat
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+sys.modules.setdefault("redis", types.SimpleNamespace(StrictRedis=object))
+
+from module.app import boot_config
+
+
+class WriteConfigTxtDirectTests(unittest.TestCase):
+    def setUp(self):
+        self.dir = Path(tempfile.mkdtemp())
+        self.dest = self.dir / "config.txt"
+        self.dest.write_text("original\n", encoding="utf-8")
+        self.patched = mock.patch.object(boot_config, "CONFIG_TXT_PATH", str(self.dest))
+        self.patched.start()
+        self.addCleanup(self.patched.stop)
+
+    def test_writes_directly_when_the_destination_is_writable(self):
+        boot_config.write_config_txt("new content\n")
+        self.assertEqual(self.dest.read_text(encoding="utf-8"), "new content\n")
+
+    def test_direct_write_leaves_no_temp_file_behind(self):
+        boot_config.write_config_txt("new content\n")
+        leftovers = list(self.dir.glob(".settings-editor-*"))
+        self.assertEqual(leftovers, [])
+
+
+class WriteConfigTxtFallbackTests(unittest.TestCase):
+    """Simulates the real /boot/firmware permission wall with a read-only
+    directory, so the fallback path exercises a genuine PermissionError
+    rather than a mocked one."""
+
+    def setUp(self):
+        self.root_dir = Path(tempfile.mkdtemp())
+        self.readonly_dir = self.root_dir / "firmware"
+        self.readonly_dir.mkdir()
+        self.dest = self.readonly_dir / "config.txt"
+        self.dest.write_text("original\n", encoding="utf-8")
+        self.readonly_dir.chmod(0o555)
+        self.addCleanup(self.readonly_dir.chmod, 0o755)
+
+        self.staging_dir = Path(tempfile.mkdtemp())
+        self.staged = self.staging_dir / "config.txt.staged"
+
+        self.patches = [
+            mock.patch.object(boot_config, "CONFIG_TXT_PATH", str(self.dest)),
+            mock.patch.object(boot_config, "STAGED_CONFIG_TXT_PATH", str(self.staged)),
+        ]
+        for p in self.patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+        if os.geteuid() == 0:
+            self.skipTest("root bypasses the read-only directory this test relies on")
+
+    def test_falls_back_to_the_helper_on_permission_denied(self):
+        def fake_helper(cmd, **kwargs):
+            # Stands in for cinemate-apply-config-txt: read the staged file,
+            # write it to dest (which the real helper can because it runs
+            # as root; here we bypass the chmod ourselves for the same
+            # effect).
+            self.readonly_dir.chmod(0o755)
+            self.dest.write_text(self.staged.read_text(encoding="utf-8"), encoding="utf-8")
+            self.readonly_dir.chmod(0o555)
+            return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        with mock.patch("subprocess.run", side_effect=fake_helper) as run:
+            boot_config.write_config_txt("staged via helper\n")
+
+        run.assert_called_once()
+        called_cmd = run.call_args.args[0]
+        self.assertEqual(called_cmd, ["sudo", "-n", boot_config.APPLY_CONFIG_TXT_HELPER])
+        self.readonly_dir.chmod(0o755)
+        self.assertEqual(self.dest.read_text(encoding="utf-8"), "staged via helper\n")
+
+    def test_a_failed_helper_raises_and_cleans_up_the_staged_file(self):
+        with mock.patch(
+            "subprocess.run",
+            return_value=types.SimpleNamespace(returncode=1, stdout="", stderr="sudo: a password is required"),
+        ):
+            with self.assertRaises(PermissionError):
+                boot_config.write_config_txt("should not land\n")
+
+        self.assertFalse(self.staged.exists())
+        self.readonly_dir.chmod(0o755)
+        self.assertEqual(self.dest.read_text(encoding="utf-8"), "original\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cinemate-install.sh
+++ b/cinemate-install.sh
@@ -1323,6 +1323,41 @@ configure_hostname_and_i2c() {
     sudo usermod -aG i2c "$PI_USER"
     sudo modprobe i2c-dev || true
     ensure_line_in_root_file /etc/modules 'i2c-dev'
+    configure_etc_hosts
+    configure_mdns
+}
+
+# /etc/hosts is not rewritten from scratch -- only the 127.0.1.1 line (the
+# one hostnamectl doesn't touch) is fixed in place, or added if absent.
+# Idempotent: a re-run with the same TARGET_HOSTNAME leaves the file
+# byte-identical, so write_root_file's own no-op check skips the write.
+configure_etc_hosts() {
+    local hosts_file="/etc/hosts"
+    local desired_line="127.0.1.1	$TARGET_HOSTNAME"
+    local existing=""
+
+    log "Ensuring /etc/hosts has $desired_line"
+    if sudo test -f "$hosts_file"; then
+        existing="$(sudo cat "$hosts_file")"
+    fi
+
+    if printf '%s\n' "$existing" | grep -Eq '^127\.0\.1\.1[[:space:]]'; then
+        printf '%s\n' "$existing" \
+            | sed -E "s/^127\.0\.1\.1[[:space:]].*/$(printf '%s' "$desired_line" | sed 's/[&/\]/\\&/g')/" \
+            | write_root_file "$hosts_file" 644
+    else
+        { printf '%s\n' "$existing"; printf '%s\n' "$desired_line"; } | write_root_file "$hosts_file" 644
+    fi
+}
+
+# Nothing in this repo installed or enabled avahi so <hostname>.local only
+# ever resolved when the base image happened to ship it (F-289). Both
+# packages are idempotent to (re)install; systemctl enable --now is
+# idempotent too.
+configure_mdns() {
+    log "Installing avahi for $TARGET_HOSTNAME.local resolution"
+    sudo apt install -y avahi-daemon libnss-mdns
+    sudo systemctl enable --now avahi-daemon
 }
 
 configure_console_font() {
@@ -1544,6 +1579,43 @@ EOF
     detail "Added $PI_USER to audio group; re-login required for limits to take effect"
 }
 
+CONFIG_TXT_APPLY_HELPER="/usr/local/bin/cinemate-apply-config-txt"
+
+# The settings editor runs as $PI_USER, which cannot write into root-owned
+# /boot/firmware (F-288). This is the one narrow privileged step that lets
+# it anyway: it reads only a fixed, already-pi-written staging file and
+# copies it over config.txt, preserving that file's existing owner/mode
+# rather than assuming one. It takes no arguments -- the sudoers rule below
+# grants it with none, so a compromised or buggy caller cannot redirect it
+# at an arbitrary destination.
+configure_config_txt_apply_helper() {
+    log "Installing $CONFIG_TXT_APPLY_HELPER"
+    write_root_file "$CONFIG_TXT_APPLY_HELPER" 755 <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+STAGED="/home/pi/cinemate/.settings-editor-config-txt.staged"
+DEST="/boot/firmware/config.txt"
+
+if [[ ! -f "$STAGED" ]]; then
+    echo "cinemate-apply-config-txt: no staged file at $STAGED" >&2
+    exit 1
+fi
+
+OWNER="$(stat -c '%u:%g' "$DEST" 2>/dev/null || echo '0:0')"
+MODE="$(stat -c '%a' "$DEST" 2>/dev/null || echo '644')"
+
+TMP="$(mktemp "${DEST}.XXXXXX")"
+trap 'rm -f "$TMP"' EXIT
+cp "$STAGED" "$TMP"
+chown "$OWNER" "$TMP"
+chmod "$MODE" "$TMP"
+mv -f "$TMP" "$DEST"
+trap - EXIT
+rm -f "$STAGED"
+EOF
+}
+
 configure_sudoers() {
     log "Writing sudoers drop-ins"
     backup_file /etc/sudoers.d/pi_cinemate
@@ -1559,6 +1631,7 @@ $PI_USER ALL=(ALL) NOPASSWD: $PI_HOME/run_cinemate.sh
 $PI_USER ALL=(ALL) NOPASSWD: $CINEMATE_DIR/src/main.py
 $PI_USER ALL=(ALL) NOPASSWD: /bin/mount, /bin/umount, /usr/bin/ntfs-3g
 $PI_USER ALL=(ALL) NOPASSWD: /sbin/mount.ext4
+$PI_USER ALL=(ALL) NOPASSWD: $CONFIG_TXT_APPLY_HELPER
 EOF
     sudo visudo -cf /etc/sudoers.d/pi_cinemate >/dev/null
     detail "sudoers validation passed"
@@ -1952,6 +2025,7 @@ main() {
     section "Preparing runtime wrappers and permissions"
     configure_media_permissions
     configure_run_wrapper
+    configure_config_txt_apply_helper
     configure_sudoers
     configure_audio_rtprio
     configure_logrotate

--- a/src/module/app/boot_config.py
+++ b/src/module/app/boot_config.py
@@ -19,10 +19,21 @@ to regenerate wholesale from a from-scratch template on every save.
 """
 from __future__ import annotations
 
+import os
 import re
+import subprocess
+import tempfile
 from pathlib import Path
 
 CONFIG_TXT_PATH = "/boot/firmware/config.txt"
+
+# /boot/firmware is root-owned; the settings editor runs as an unprivileged
+# user (F-288). STAGED_CONFIG_TXT_PATH is a fixed, pi-writable location the
+# privileged helper below reads from -- fixed so the sudoers rule installed
+# by configure_sudoers() can be scoped to one exact command with no
+# arguments, rather than a general "write anywhere as root" grant.
+STAGED_CONFIG_TXT_PATH = "/home/pi/cinemate/.settings-editor-config-txt.staged"
+APPLY_CONFIG_TXT_HELPER = "/usr/local/bin/cinemate-apply-config-txt"
 
 MANAGED_BEGIN = "# >>> cinemate-install >>>"
 MANAGED_END = "# <<< cinemate-install <<<"
@@ -208,3 +219,53 @@ def apply_config_txt_state(full_text: str, state: dict) -> str:
         )
 
     return full_text[:start] + new_block + full_text[end:]
+
+
+def _atomic_write(dest: Path, text: str) -> None:
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(dest.parent), prefix=".settings-editor-", suffix=dest.suffix + ".tmp",
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fp:
+            fp.write(text)
+        os.replace(tmp_path, dest)
+    except Exception:
+        os.unlink(tmp_path)
+        raise
+
+
+def write_config_txt(text: str) -> None:
+    """Atomically replace CONFIG_TXT_PATH with *text* (F-288).
+
+    /boot/firmware is root-owned and the settings editor runs as an
+    unprivileged user, so the direct write below only succeeds when this
+    process already has root (tests, or a root-run dev shell) -- on a real
+    install it raises PermissionError before writing a byte. Only that
+    specific failure falls back to staging the text somewhere pi-writable
+    and handing it to APPLY_CONFIG_TXT_HELPER, a narrowly-scoped privileged
+    helper installed by cinemate-install.sh's configure_sudoers(). Any other
+    OSError (full disk, missing directory) is left to surface directly
+    rather than being redirected into the harder-to-debug sudo path.
+    """
+    dest = Path(CONFIG_TXT_PATH)
+    try:
+        _atomic_write(dest, text)
+        return
+    except PermissionError:
+        pass
+
+    staged = Path(STAGED_CONFIG_TXT_PATH)
+    _atomic_write(staged, text)
+    try:
+        result = subprocess.run(
+            ["sudo", "-n", APPLY_CONFIG_TXT_HELPER],
+            capture_output=True, text=True, timeout=10, check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        staged.unlink(missing_ok=True)
+        raise PermissionError(f"could not invoke privileged helper: {exc}") from exc
+
+    if result.returncode != 0:
+        staged.unlink(missing_ok=True)
+        detail = (result.stderr or result.stdout or "").strip()
+        raise PermissionError(f"privileged helper exited {result.returncode}: {detail}")

--- a/src/module/app/settings_editor.py
+++ b/src/module/app/settings_editor.py
@@ -362,14 +362,7 @@ def put_config_txt():
         return jsonify({"ok": False, "message": str(exc)}), 400
 
     try:
-        fd, tmp_path = tempfile.mkstemp(dir=str(dest.parent), prefix=".settings-editor-", suffix=".config.txt.tmp")
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as fp:
-                fp.write(new_text)
-            os.replace(tmp_path, dest)
-        except Exception:
-            os.unlink(tmp_path)
-            raise
+        boot_config.write_config_txt(new_text)
     except OSError as exc:
         logger.exception("Failed to write %s", dest)
         return jsonify({"ok": False, "message": f"Could not write {dest}: {exc}"}), 500


### PR DESCRIPTION
The two field-reported defects that are broken in use rather than merely untidy. **Merge this one first** — neither depends on the rest of B11.

- **F-288** — the settings editor could not save `config.txt` at all. `settings_editor.py:365` mkstemp'd into `dest.parent`, which for `/boot/firmware/config.txt` is root-owned while the app runs as `User=pi`, so it failed with `EACCES` before writing a byte. The settings.jsonc save at `:268` is the byte-identical pattern and worked only because `/home/pi` is pi-writable.
- **F-289** — nothing in either repository installed or enabled `avahi-daemon`, so `cinepi.local` only ever resolved by accident of the base image. `configure_hostname_and_i2c()` set the hostname and stopped.

Plan: `system-review/deliverables/REMEDIATION-PLAN.md` §3 batch B11, findings F-288/F-289.

## Review notes

- The privileged write for B11.1 should be **scoped to the single `/boot/firmware/config.txt` destination**, not a general file write — a web form reachable on the LAN that can write arbitrary root-owned files is a much larger change than the bug warrants.
- B11.2 touches the installer, whose designed idempotency is a recorded strength (F-192); `/etc/hosts` should use the managed-block pattern already in the file rather than appending unconditionally.
- **Verification for both should be a clean install, not a running camera** — PI-004 and PI-012 are the precedent for why the two differ.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBku1dDuju5t762UogsJRq)_