### PR TITLE
B9 · one fact, one home — the five desk commits (plus a live Event bug)

### DIFF
--- a/_test/test_b95_config_defaults_consistency.py
+++ b/_test/test_b95_config_defaults_consistency.py
@@ -1,0 +1,211 @@
+"""B9.5: config defaults stated in several places, locked in with a check.
+
+F-256 (already drifted, fixed by this batch): arrays.iso.steps /
+arrays.shutter_a.steps were stated 7x across Python, JSONC and the settings
+editor's HTML+JS -- and config_loader.py's Python fallback was missing
+346.6 from the shutter table. Restoring the value fixes the live bug;
+this test is the check that stops it drifting back, across every source
+that must agree: config_loader.py's built-in defaults (the fallback used
+when settings.jsonc omits the block), settings.jsonc and
+settings_default.jsonc (JSONC), and the settings editor's Python
+ACTION_METHODS catalogue and its HTML-template JS twin.
+
+F-252: system.web_api.* / system.recovery.* defaults are stated 3x each
+(settings.schema.json, web_api_settings.py / cinemate-recovery.py) and
+currently agree -- this is the check that was missing, not a fix to a
+disagreement.
+
+F-180: pwm_pin's default of 19 is stated twice (schema, config_loader.py)
+and was "caught before it drifted" -- same shape, same fix: add the check.
+
+F-260: the settings.jsonc absolute path used to be an independent literal
+in six files; one had already drifted out of a comment that tried to
+enumerate the others by line number. All six now import
+config_loader.DEFAULT_SETTINGS_PATH. This test guards against a new literal
+creeping back in. services/cinemate-recovery/cinemate-recovery.py keeps its
+own copy deliberately (F-221 isolation) and is excluded on purpose.
+"""
+
+import json
+import re
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+sys.modules.setdefault("redis", types.SimpleNamespace(StrictRedis=object))
+
+from module.config_loader import (  # noqa: E402
+    _apply_settings_defaults,
+    strip_jsonc,
+    DEFAULT_SETTINGS_PATH,
+)
+
+
+def _load_jsonc(path: Path) -> dict:
+    return json.loads(strip_jsonc(path.read_text(encoding="utf-8")))
+
+
+class ArraysStepsConsistencyTests(unittest.TestCase):
+    """F-256."""
+
+    def setUp(self):
+        self.config_loader_defaults = _apply_settings_defaults({})
+        self.settings_jsonc = _load_jsonc(ROOT / "settings.jsonc")
+        self.settings_default_jsonc = _load_jsonc(
+            ROOT / "resources/settings/settings_default.jsonc"
+        )
+        editor_py = (ROOT / "src/module/app/settings_editor.py").read_text(encoding="utf-8")
+        editor_html = (ROOT / "src/module/app/templates/settings_editor.html").read_text(
+            encoding="utf-8"
+        )
+        iso_m = re.search(
+            r'"value":\s*"set_iso".*?"options":\s*(\[[^\]]*\])', editor_py, re.S
+        )
+        shutter_m = re.search(
+            r'"value":\s*"set_shutter_a".*?"options":\s*(\[[^\]]*\])', editor_py, re.S
+        )
+        self.editor_py_iso = json.loads(iso_m.group(1))
+        self.editor_py_shutter_a = json.loads(shutter_m.group(1))
+
+        html_iso_m = re.search(
+            r"data-chip-path=\"arrays\.iso\.steps\"[^>]*data-chip-original=\"(\[[^\"]*\])\"",
+            editor_html,
+        )
+        html_shutter_m = re.search(
+            r"data-chip-path=\"arrays\.shutter_a\.steps\"[^>]*data-chip-original=\"(\[[^\"]*\])\"",
+            editor_html,
+        )
+        self.editor_html_iso = json.loads(html_iso_m.group(1))
+        self.editor_html_shutter_a = json.loads(html_shutter_m.group(1))
+
+        js_iso_m = re.search(
+            r"value:\s*'set_iso'.*?options:\s*(\[[^\]]*\])", editor_html, re.S
+        )
+        js_shutter_m = re.search(
+            r"value:\s*'set_shutter_a'.*?options:\s*(\[[^\]]*\])", editor_html, re.S
+        )
+        self.editor_js_iso = json.loads(js_iso_m.group(1))
+        self.editor_js_shutter_a = json.loads(js_shutter_m.group(1))
+
+    def test_iso_steps_agree_everywhere(self):
+        sources = {
+            "config_loader.py default": self.config_loader_defaults["arrays"]["iso"]["steps"],
+            "settings.jsonc": self.settings_jsonc["arrays"]["iso"]["steps"],
+            "settings_default.jsonc": self.settings_default_jsonc["arrays"]["iso"]["steps"],
+            "settings_editor.py ACTION_METHODS": self.editor_py_iso,
+            "settings_editor.html data-chip-original": self.editor_html_iso,
+            "settings_editor.html JS ACTION_METHODS": self.editor_js_iso,
+        }
+        canonical = sources["settings.jsonc"]
+        for name, steps in sources.items():
+            self.assertEqual(steps, canonical, f"{name} disagrees with settings.jsonc")
+
+    def test_shutter_a_steps_agree_everywhere(self):
+        sources = {
+            "config_loader.py default": self.config_loader_defaults["arrays"]["shutter_a"]["steps"],
+            "settings.jsonc": self.settings_jsonc["arrays"]["shutter_a"]["steps"],
+            "settings_default.jsonc": self.settings_default_jsonc["arrays"]["shutter_a"]["steps"],
+            "settings_editor.py ACTION_METHODS": self.editor_py_shutter_a,
+            "settings_editor.html data-chip-original": self.editor_html_shutter_a,
+            "settings_editor.html JS ACTION_METHODS": self.editor_js_shutter_a,
+        }
+        canonical = sources["settings.jsonc"]
+        for name, steps in sources.items():
+            self.assertEqual(steps, canonical, f"{name} disagrees with settings.jsonc")
+            # The bug this test exists to catch: 346.6 quietly missing from
+            # exactly one copy.
+            self.assertIn(346.6, steps, f"{name} is missing 346.6")
+
+
+class WebApiAndRecoveryDefaultsConsistencyTests(unittest.TestCase):
+    """F-252."""
+
+    def setUp(self):
+        schema = json.loads((ROOT / "settings.schema.json").read_text(encoding="utf-8"))
+        self.schema_web_api = schema["properties"]["system"]["properties"]["web_api"]["properties"]
+        self.schema_recovery = schema["properties"]["system"]["properties"]["recovery"]["properties"]
+
+        from module.web_api_settings import DEFAULT_WEB_API_SETTINGS
+
+        self.web_api_settings_py = DEFAULT_WEB_API_SETTINGS
+
+        recovery_src = (
+            ROOT / "services/cinemate-recovery/cinemate-recovery.py"
+        ).read_text(encoding="utf-8")
+        m = re.search(r"^DEFAULTS = \{(.*?)^\}", recovery_src, re.S | re.M)
+        # Evaluate the dict literal in isolation -- no import needed, and this
+        # is the actual source text, not a re-typed copy of it.
+        self.recovery_defaults = eval("{" + m.group(1) + "}")  # noqa: S307
+
+    def test_web_api_scalar_defaults_agree(self):
+        for key in ("enabled", "token", "allow_destructive", "max_commands_per_sec", "max_sse_clients"):
+            self.assertEqual(
+                self.schema_web_api[key]["default"],
+                self.web_api_settings_py[key],
+                f"system.web_api.{key} disagrees between the schema and web_api_settings.py",
+            )
+
+    def test_web_api_broadcast_defaults_agree(self):
+        schema_bc = self.schema_web_api["broadcast"]["properties"]
+        py_bc = self.web_api_settings_py["broadcast"]
+        for key in ("enabled", "port", "hz", "keys"):
+            self.assertEqual(
+                schema_bc[key]["default"],
+                py_bc[key],
+                f"system.web_api.broadcast.{key} disagrees between the schema and web_api_settings.py",
+            )
+
+    def test_recovery_defaults_agree(self):
+        for key in ("enabled", "port", "token", "allow_config_txt", "config_confirm_timeout_s"):
+            self.assertEqual(
+                self.schema_recovery[key]["default"],
+                self.recovery_defaults[key],
+                f"system.recovery.{key} disagrees between the schema and cinemate-recovery.py",
+            )
+
+
+class PwmPinDefaultConsistencyTests(unittest.TestCase):
+    """F-180."""
+
+    def test_pwm_pin_default_agrees(self):
+        schema = json.loads((ROOT / "settings.schema.json").read_text(encoding="utf-8"))
+        schema_default = schema["properties"]["hardware_outputs"]["properties"]["pwm_pin"]["default"]
+
+        result = _apply_settings_defaults({})
+        loader_default = result["hardware_outputs"]["pwm_pin"]
+
+        self.assertEqual(schema_default, loader_default)
+
+
+class SettingsPathSingleSourceTests(unittest.TestCase):
+    """F-260."""
+
+    SIX_FILES = [
+        "src/main.py",
+        "src/module/cinepi_multi.py",
+        "src/module/cinepi_controller.py",
+        "src/module/wifi_hotspot.py",
+        "src/module/simple_gui.py",
+        "src/module/app/settings_editor.py",
+    ]
+
+    def test_default_settings_path_is_the_expected_live_path(self):
+        self.assertEqual(DEFAULT_SETTINGS_PATH, "/home/pi/cinemate/settings.jsonc")
+
+    def test_no_file_restates_the_path_as_a_new_literal(self):
+        # The recovery console is excluded deliberately (F-221 isolation) --
+        # everything else must go through DEFAULT_SETTINGS_PATH.
+        offenders = []
+        for rel in self.SIX_FILES:
+            text = (ROOT / rel).read_text(encoding="utf-8")
+            if '"/home/pi/cinemate/settings.jsonc"' in text:
+                offenders.append(rel)
+        self.assertEqual(offenders, [], f"re-typed the literal instead of importing it: {offenders}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_test/test_b95_installer_strip_jsonc_equivalence.py
+++ b/_test/test_b95_installer_strip_jsonc_equivalence.py
@@ -1,0 +1,83 @@
+"""F-191: cinemate-install.sh's settings-patcher heredoc reimplements
+module.config_loader.strip_jsonc() by hand, with a comment explaining why:
+the heredoc runs under the system python3 during install, outside the
+cinemate package/venv, so it cannot import module.config_loader. That is a
+legitimate reason -- unlike the codebase's other hand-sync comments, this
+one names it -- but the finding is right that it still had no check.
+
+The two implementations are NOT byte-identical by design: config_loader's
+version blanks comments/trailing-commas to spaces to stay length- and
+line-preserving (for accurate error reporting), while the installer's
+heredoc simply deletes them (it only needs to produce parseable JSON once,
+during an install step, not point at a source line in a later error). The
+actual contract that matters is: given the same well-formed settings.jsonc
+text, both must parse to the *same dict*. That's what this test checks --
+by extracting the live function straight out of cinemate-install.sh, never
+a copy of it, so this test can't silently stop testing the real thing.
+"""
+
+import json
+import re
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+sys.modules.setdefault("redis", types.SimpleNamespace(StrictRedis=object))
+
+from module.config_loader import strip_jsonc  # noqa: E402
+
+
+def _extract_heredoc_strip_jsonc():
+    text = (ROOT / "cinemate-install.sh").read_text(encoding="utf-8")
+    m = re.search(
+        r"^def _strip_jsonc\(text\):.*?\n    return \"\"\.join\(out\)\n",
+        text,
+        re.S | re.M,
+    )
+    assert m, "_strip_jsonc() not found in cinemate-install.sh -- did it move or get renamed?"
+    namespace = {}
+    exec(m.group(0), namespace)  # noqa: S102 -- test-only, extracting known-local source
+    return namespace["_strip_jsonc"]
+
+
+SAMPLES = [
+    '{"a": 1, "b": 2}',
+    '{\n  // a leading comment\n  "a": 1,\n}',
+    '{\n  "a": 1, /* trailing block comment */\n  "b": [1, 2, 3,],\n}',
+    '{"note": "a string with // not a comment and a , trailing comma-look-alike"}',
+    '{"note": "an escaped \\" quote then // still not a comment"}',
+    '{\n  /* multi\n     line\n     block */\n  "shutter_a": {"steps": [1, 45, 346.6,],},\n}',
+    '{"nested": {"deep": {"steps": [1, 2, 3,],},}, "trailing": true,}',
+]
+
+
+class InstallerStripJsoncEquivalenceTests(unittest.TestCase):
+    def setUp(self):
+        self.heredoc_strip_jsonc = _extract_heredoc_strip_jsonc()
+
+    def test_both_implementations_parse_representative_input_identically(self):
+        for sample in SAMPLES:
+            with self.subTest(sample=sample):
+                canonical = json.loads(strip_jsonc(sample))
+                heredoc = json.loads(self.heredoc_strip_jsonc(sample))
+                self.assertEqual(
+                    canonical, heredoc,
+                    "config_loader.strip_jsonc() and the installer's hand-synced "
+                    "copy parsed this input to different results",
+                )
+
+    def test_both_implementations_agree_on_the_real_settings_default_jsonc(self):
+        real_text = (ROOT / "resources/settings/settings_default.jsonc").read_text(
+            encoding="utf-8"
+        )
+        canonical = json.loads(strip_jsonc(real_text))
+        heredoc = json.loads(self.heredoc_strip_jsonc(real_text))
+        self.assertEqual(canonical, heredoc)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_test/test_b95_sync_box_crossed_consistency.py
+++ b/_test/test_b95_sync_box_crossed_consistency.py
@@ -1,0 +1,82 @@
+"""F-217: a fifth hand-sync comment. template.html:216 says
+`/* _draw_status_box(crossed=True) strikes the SYNC box through */` --
+CSS naming a Python method as the thing it must stay consistent with, with
+no check (same mechanism as F-007's colour comments, which have
+tools/design_token_diff.py; this pair didn't have anything).
+
+The comment is accurate on this checkout, but accurate-today is not the
+same as checked. Three things have to move together for the HDMI GUI and
+the web GUI to show the same SYNC state the same way:
+
+1. simple_gui.py draws the SYNC box with crossed=True, gated on
+   values.get("frames_off_sync").
+2. template.html's JS only adds the 'sync' CSS class to the SYNC box when
+   the same V.frames_off_sync flag is set.
+3. The .box.sync::after CSS rule actually renders a strike-through, so
+   adding the class has a visible effect.
+
+A change to any one of these without the others would desync the two GUIs
+silently -- exactly what this batch's other hand-sync-comment findings
+turned out to hide.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SIMPLE_GUI = ROOT / "src/module/simple_gui.py"
+TEMPLATE = ROOT / "src/module/app/templates/template.html"
+
+
+class SyncBoxCrossedConsistencyTests(unittest.TestCase):
+    def setUp(self):
+        self.simple_gui_src = SIMPLE_GUI.read_text(encoding="utf-8")
+        self.template_src = TEMPLATE.read_text(encoding="utf-8")
+
+    def test_simple_gui_draws_the_sync_box_crossed_and_gated_on_frames_off_sync(self):
+        # The SYNC box's _draw_status_box(...) call, up to its closing paren,
+        # must both request crossed=True and sit under an
+        # `if values.get("frames_off_sync")` guard immediately above it.
+        m = re.search(
+            r'if values\.get\("frames_off_sync"\):\s*'
+            r"self\._draw_status_box\((?:[^()]|\([^()]*\))*?\"SYNC\"(?:[^()]|\([^()]*\))*?crossed=True",
+            self.simple_gui_src,
+            re.S,
+        )
+        self.assertIsNotNone(
+            m,
+            "simple_gui.py no longer draws the SYNC box with crossed=True "
+            "gated on frames_off_sync -- update template.html's comment and "
+            "CSS (or this test) to match the new behaviour",
+        )
+
+    def test_template_js_gates_the_sync_class_on_frames_off_sync(self):
+        self.assertIn(
+            "if (V.frames_off_sync) { out.push(box('SYNC', 'sync')); }",
+            self.template_src,
+            "the web GUI no longer gates the SYNC box's 'sync' class on "
+            "V.frames_off_sync -- it will disagree with the HDMI GUI's "
+            "crossed=True condition",
+        )
+
+    def test_template_css_actually_renders_a_strike_through_for_the_sync_class(self):
+        self.assertIn(".box.sync::after", self.template_src)
+        # The rule must exist and not be empty/no-op -- a linear-gradient
+        # background is the actual diagonal-line mechanism.
+        m = re.search(r"\.box\.sync::after\s*\{([^}]*)\}", self.template_src, re.S)
+        self.assertIsNotNone(m, ".box.sync::after rule not found")
+        self.assertIn("linear-gradient", m.group(1))
+
+    def test_the_hand_sync_comment_still_names_the_right_python_call(self):
+        # If this ever goes stale, it should say so explicitly rather than
+        # silently describe the wrong thing.
+        self.assertIn(
+            "_draw_status_box(crossed=True) strikes the SYNC box through",
+            self.template_src,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_test/test_b97_web_gui_drop_count.py
+++ b/_test/test_b97_web_gui_drop_count.py
@@ -1,0 +1,52 @@
+"""F-211: the web GUI showed the drop/sync warning *state* (a DROP or SYNC
+box appears) but never the *count* behind it, even though
+populate_values() already publishes drop_frame_count (an alias of
+tc_hole_count -- see docs/redis-keys.md) into the same values dict the web
+GUI receives verbatim.
+
+Scope, deliberately: only the DROP box gains a count here. The framebuffer
+GUI's on-camera boxes are untouched (fixed physical size, no verification
+device available in this batch). frames_off_sync has no published numeric
+companion today -- the frame-difference number that would latch it
+(redis_listener.py's live/final sync analysis) is only ever logged, never
+set_value()'d to Redis -- so adding a SYNC count would mean adding new
+telemetry to a live recording-time code path with no Pi available to verify
+it doesn't regress real takes. That's out of scope for a desk-only commit;
+SYNC stays word-only on purpose, and this test checks that it stays that way
+rather than growing silently.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE = ROOT / "src/module/app/templates/template.html"
+
+
+class WebGuiDropCountTests(unittest.TestCase):
+    def setUp(self):
+        self.template_src = TEMPLATE.read_text(encoding="utf-8")
+        m = re.search(r"function warningBoxes\(\) \{(.*?)\n    \}", self.template_src, re.S)
+        self.assertIsNotNone(m, "warningBoxes() not found")
+        self.warning_boxes_body = m.group(1)
+
+    def test_drop_box_reads_the_published_count(self):
+        self.assertIn("V.drop_frame_count", self.warning_boxes_body)
+
+    def test_drop_box_falls_back_to_plain_drop_when_count_is_zero(self):
+        self.assertIn("'DROP'", self.warning_boxes_body)
+        self.assertIn("DROP ${count}", self.warning_boxes_body)
+
+    def test_drop_box_gets_the_small_class_when_it_carries_a_count(self):
+        self.assertIn("' small'", self.warning_boxes_body)
+
+    def test_sync_box_intentionally_stays_word_only(self):
+        self.assertIn("box('SYNC', 'sync')", self.warning_boxes_body)
+        self.assertNotIn("frames_off_sync_count", self.template_src)
+        self.assertNotIn("sync_diff", self.template_src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_test/test_b97_web_gui_labels_from_populate_values.py
+++ b/_test/test_b97_web_gui_labels_from_populate_values.py
@@ -1,0 +1,90 @@
+"""F-257: populate_values() publishes fps_label/shutter_label/exposure_label/
+iso_label/wb_label/res_label for the web GUI, but the template derived its
+own -- six words hardcoded as static HTML markup, completely independent of
+what Python sends. The web GUI is supposed to have no state of its own (it
+consumes the HDMI GUI's value dictionary verbatim over Socket.IO); these six
+were the exception, and the exception was never even read back client-side.
+
+Fix: the six label spans now carry ids (l-fps, l-shutter, l-exp, l-iso,
+l-wb, l-res) and renderTopRow() sets their text from V.*_label, the same
+pattern already used for every value span (v-fps, v-iso, ...). This test
+checks the wiring end to end: Python publishes the key, the HTML element
+exists, and the JS actually reads that key into that element.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SIMPLE_GUI = ROOT / "src/module/simple_gui.py"
+TEMPLATE = ROOT / "src/module/app/templates/template.html"
+
+LABEL_KEYS = (
+    "fps_label",
+    "shutter_label",
+    "exposure_label",
+    "iso_label",
+    "wb_label",
+    "res_label",
+)
+LABEL_IDS = {
+    "fps_label": "l-fps",
+    "shutter_label": "l-shutter",
+    "exposure_label": "l-exp",
+    "iso_label": "l-iso",
+    "wb_label": "l-wb",
+    "res_label": "l-res",
+}
+
+
+class WebGuiLabelsFromPopulateValuesTests(unittest.TestCase):
+    def setUp(self):
+        self.simple_gui_src = SIMPLE_GUI.read_text(encoding="utf-8")
+        self.template_src = TEMPLATE.read_text(encoding="utf-8")
+
+    def test_populate_values_still_publishes_every_label_key(self):
+        for key in LABEL_KEYS:
+            with self.subTest(key=key):
+                self.assertRegex(
+                    self.simple_gui_src,
+                    rf'"{key}":\s*"',
+                    f"populate_values() no longer publishes {key}",
+                )
+
+    def test_every_label_span_has_an_id(self):
+        for key, element_id in LABEL_IDS.items():
+            with self.subTest(key=key):
+                self.assertIn(
+                    f'id="{element_id}"',
+                    self.template_src,
+                    f"label span for {key} lost its id={element_id}",
+                )
+
+    def test_render_top_row_sets_every_label_from_v(self):
+        m = re.search(r"function renderTopRow\(\) \{(.*?)\n    \}", self.template_src, re.S)
+        self.assertIsNotNone(m, "renderTopRow() not found")
+        body = m.group(1)
+        for key, element_id in LABEL_IDS.items():
+            with self.subTest(key=key):
+                self.assertIn(
+                    f"text('{element_id}', V.{key})",
+                    body,
+                    f"renderTopRow() no longer sets {element_id} from V.{key}",
+                )
+
+    def test_no_static_fallback_text_remains_in_the_label_spans(self):
+        # The whole point: the span must be empty in markup (JS fills it),
+        # not carrying its own hardcoded word that V.*_label duplicates.
+        for word in ("FPS", "SHUTTER", "EXP", "EI", "WB", "RES"):
+            with self.subTest(word=word):
+                self.assertNotRegex(
+                    self.template_src,
+                    rf'<span class="label"[^>]*>{word}</span>',
+                    f'a label span still hardcodes "{word}" instead of being filled from V',
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_test/test_cinepi_multi_event_dispatch.py
+++ b/_test/test_cinepi_multi_event_dispatch.py
@@ -2,7 +2,12 @@
 thread (CinePiManager.message, see cinepi_multi.py:281/:299, subscribed by
 Mediator.handle_cinepi_message via main.py's CinePi alias). This was F-204
 verbatim -- the same defect B3.1 fixed in redis_controller.Event -- until a
-raising listener could kill that thread and silently stop the log relay.
+raising listener could kill that thread and silently stop the log relay
+(fixed in place by B9.6a). B9.6b then collapsed the four independent Event
+classes (F-127) into one: cinepi_multi.Event is now a re-exported alias of
+redis_controller.Event, not a copy. The identity check below is what proves
+that; the behavioural tests keep exercising the actual imported name so a
+future re-introduction of a local copy fails here, not just in principle.
 """
 
 import sys
@@ -16,9 +21,13 @@ sys.path.insert(0, str(ROOT / "src"))
 sys.modules.setdefault("redis", types.SimpleNamespace(StrictRedis=object))
 
 from module.cinepi_multi import Event
+from module.redis_controller import Event as RedisControllerEvent
 
 
 class CinepiMultiEventDispatchTests(unittest.TestCase):
+    def test_is_the_shared_redis_controller_event_not_a_copy(self):
+        self.assertIs(Event, RedisControllerEvent)
+
     def test_a_raising_listener_does_not_stop_the_others(self):
         seen = []
 

--- a/_test/test_cinepi_multi_event_dispatch.py
+++ b/_test/test_cinepi_multi_event_dispatch.py
@@ -1,0 +1,51 @@
+"""cinepi_multi.Event fans out cinepi-raw's subprocess output on the reader
+thread (CinePiManager.message, see cinepi_multi.py:281/:299, subscribed by
+Mediator.handle_cinepi_message via main.py's CinePi alias). This was F-204
+verbatim -- the same defect B3.1 fixed in redis_controller.Event -- until a
+raising listener could kill that thread and silently stop the log relay.
+"""
+
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+sys.modules.setdefault("redis", types.SimpleNamespace(StrictRedis=object))
+
+from module.cinepi_multi import Event
+
+
+class CinepiMultiEventDispatchTests(unittest.TestCase):
+    def test_a_raising_listener_does_not_stop_the_others(self):
+        seen = []
+
+        event = Event()
+        event.subscribe(lambda data: seen.append(("first", data)))
+        event.subscribe(lambda data: (_ for _ in ()).throw(RuntimeError("boom")))
+        event.subscribe(lambda data: seen.append(("third", data)))
+
+        with self.assertLogs(level="ERROR"):
+            event.emit("cinepi-raw stdout line")
+
+        self.assertEqual(
+            seen,
+            [("first", "cinepi-raw stdout line"), ("third", "cinepi-raw stdout line")],
+        )
+
+    def test_the_failure_is_logged_not_swallowed(self):
+        event = Event()
+        event.subscribe(lambda data: (_ for _ in ()).throw(ValueError("nope")))
+
+        with self.assertLogs(level="ERROR") as captured:
+            event.emit(None)
+
+        joined = "\n".join(captured.output)
+        self.assertIn("ValueError", joined)
+        self.assertIn("nope", joined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_test/test_config_loader_as_bool.py
+++ b/_test/test_config_loader_as_bool.py
@@ -1,0 +1,110 @@
+"""config_loader.as_bool is the one boolean decoder (F-126): it replaces four
+independent `_as_bool` implementations (cinepi_controller, dynamic_resolution,
+gpio_input, mediator) that genuinely disagreed -- `_as_bool(2)` was `True` in
+gpio_input and `False` in the other three -- plus the same
+`("1","true","yes","on")` truth-set re-typed standalone in half a dozen more
+places (redis_controller, redis_listener, ssd_monitor, usb_monitor,
+simple_gui, app/main/events).
+
+This table is the decision record for the two questions the unification
+raised:
+
+1. What does a bare number mean? -- Python truthiness (`bool(value)`): 2 is
+   True. This matches gpio_input's prior behaviour and config_loader's own
+   settings-coercion helper, and no observed settings.jsonc value currently
+   sends a non-0/1 number through any of the four call sites, so this is a
+   forward-looking decision, not a fix to an observed bug.
+2. What does an unrecognised string mean? -- NOT the same as an explicit
+   false. It falls back to `default`, same as an absent value, distinguishing
+   "the user wrote maybe" from "the user wrote off". This is a behaviour
+   change from three of the four originals, which folded "unrecognised" into
+   "false" by construction (a failed `in (...)` membership test has no third
+   outcome). The recovery console's own standalone `_as_bool` (services/
+   cinemate-recovery/cinemate-recovery.py) is deliberately NOT part of this
+   unification -- it must import nothing from `module.*` so it can still run
+   when the rest of the stack cannot (F-221).
+"""
+
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+sys.modules.setdefault("redis", types.SimpleNamespace(StrictRedis=object))
+
+from module.config_loader import as_bool, TRUE_VALUES, FALSE_VALUES
+
+
+class AsBoolDecisionTableTests(unittest.TestCase):
+    # (value, default, expected) -- the decision record in executable form.
+    CASES = [
+        # bool passes through untouched, default is irrelevant.
+        (True, False, True),
+        (False, True, False),
+        # None means "not set": always the caller's default, never a warning.
+        (None, False, False),
+        (None, True, True),
+        # int/float: Python truthiness. 2 is True (decision 1).
+        (0, True, False),
+        (1, False, True),
+        (2, False, True),
+        (-1, False, True),
+        (0.0, True, False),
+        (0.5, False, True),
+        # Recognised strings, case- and whitespace-insensitive.
+        ("1", False, True),
+        ("0", True, False),
+        ("true", False, True),
+        ("False", True, False),
+        ("  YES  ", False, True),
+        ("no", True, False),
+        ("on", False, True),
+        ("Off", True, False),
+        # Numeric strings fall back to int() truthiness, same as a bare
+        # number -- three call sites (ssd_monitor, redis_listener,
+        # redis_controller) already relied on exactly this before the merge.
+        ("2", False, True),
+        ("-3", False, True),
+        ("0", False, False),
+        # Empty string: not in either set, not a valid int -- unrecognised.
+        ("", True, True),
+        ("", False, False),
+        # Unrecognised string is NOT coerced to False (decision 2): it is
+        # indistinguishable from "not set" and returns default either way.
+        ("maybe", True, True),
+        ("maybe", False, False),
+        ("banana", True, True),
+        # Arbitrary object: not a real settings/Redis representation, falls
+        # back to default rather than guessing via bool(obj).
+        (object(), True, True),
+        (object(), False, False),
+    ]
+
+    def test_decision_table(self):
+        for value, default, expected in self.CASES:
+            with self.subTest(value=value, default=default):
+                self.assertIs(as_bool(value, default), expected)
+
+    def test_default_parameter_defaults_to_false(self):
+        self.assertIs(as_bool(None), False)
+        self.assertIs(as_bool("maybe"), False)
+
+    def test_true_and_false_value_sets_are_disjoint(self):
+        self.assertEqual(TRUE_VALUES & FALSE_VALUES, set())
+
+    def test_unrecognised_string_does_not_raise_or_warn_at_warning_level(self):
+        # This runs on the 12 fps GUI redraw path (simple_gui.py). A stuck
+        # bad value must not flood the log at warning level every frame --
+        # it logs at debug instead. assertNoLogs would over-assert (debug
+        # logging is fine); this just checks no exception and the right
+        # answer, and that nothing escalates to WARNING+.
+        with self.assertRaises(AssertionError):
+            with self.assertLogs(level="WARNING"):
+                as_bool("not-a-real-value")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_test/test_redis_controller_set_value.py
+++ b/_test/test_redis_controller_set_value.py
@@ -1,0 +1,101 @@
+"""F-015: set_value() used to accept any string key silently -- the
+ParameterKey enum was a convention, never enforced. This locks in the
+visible-but-non-blocking fix: an un-enumerated key still gets written (a
+hard reject with no Pi available to verify every call site was judged too
+risky -- see the commit message), but it now logs a warning, once per key,
+so the drift is observable instead of silent.
+"""
+
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+
+class _FakePubSub:
+    def subscribe(self, channel):
+        pass
+
+    def listen(self):
+        return iter([])  # background thread exits immediately
+
+
+class _FakeStrictRedis:
+    def __init__(self, *args, **kwargs):
+        self._store = {}
+
+    def keys(self, pattern="*"):
+        return []
+
+    def get(self, key):
+        return self._store.get(key, b"")
+
+    def set(self, key, value):
+        self._store[key] = str(value).encode()
+
+    def publish(self, channel, message):
+        pass
+
+    def pubsub(self):
+        return _FakePubSub()
+
+
+sys.modules.setdefault("redis", types.SimpleNamespace(StrictRedis=object))
+
+import module.redis_controller as _redis_controller_module  # noqa: E402
+
+# Other test modules import module.redis_controller before this one runs and
+# share the same process-wide `redis` stub (sys.modules is not reset between
+# test files), so redis_controller.py's own `redis` name may already be bound
+# to a stub whose StrictRedis is just `object`. Patch the attribute on the
+# module it actually holds, rather than trying to win a sys.modules race.
+_redis_controller_module.redis.StrictRedis = _FakeStrictRedis
+
+RedisController = _redis_controller_module.RedisController
+ParameterKey = _redis_controller_module.ParameterKey
+
+
+class SetValueParameterKeyEnforcementTests(unittest.TestCase):
+    def setUp(self):
+        self.controller = RedisController()
+
+    def test_a_known_parameter_key_does_not_warn(self):
+        with self.assertRaises(AssertionError):
+            with self.assertLogs(level="WARNING"):
+                self.controller.set_value(ParameterKey.FPS.value, "25")
+
+    def test_a_known_parameter_key_enum_member_does_not_warn(self):
+        with self.assertRaises(AssertionError):
+            with self.assertLogs(level="WARNING"):
+                self.controller.set_value(ParameterKey.IS_RECORDING, "1")
+
+    def test_an_unenumerated_key_warns(self):
+        with self.assertLogs(level="WARNING") as captured:
+            self.controller.set_value("totally_made_up_key", "1")
+        joined = "\n".join(captured.output)
+        self.assertIn("totally_made_up_key", joined)
+
+    def test_an_unenumerated_key_only_warns_once(self):
+        with self.assertLogs(level="WARNING"):
+            self.controller.set_value("repeated_unknown_key", "1")
+        # Second write changes the value again so it isn't short-circuited
+        # by the "unchanged -- nothing to do" cache check; the warning must
+        # still not repeat, or a value written every frame would flood the
+        # log exactly like the case this fix exists to prevent.
+        with self.assertRaises(AssertionError):
+            with self.assertLogs(level="WARNING"):
+                self.controller.set_value("repeated_unknown_key", "2")
+
+    def test_the_write_still_happens_for_an_unenumerated_key(self):
+        # Visible, not blocking: rejecting outright risked breaking a real
+        # call site with no Pi available to verify every one of them.
+        self.controller.set_value("totally_made_up_key", "42")
+        self.assertEqual(self.controller.get_value("totally_made_up_key"), "42")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_test/test_usb_monitor_event_dispatch.py
+++ b/_test/test_usb_monitor_event_dispatch.py
@@ -4,7 +4,10 @@ with no copy, so a listener that subscribes/unsubscribes in response to its
 own event -- the mic hotswap handlers do -- could raise RuntimeError and take
 the whole emit down with it. It also logged failures with traceback.print_exc()
 to stdout instead of the log file, so a raising listener was invisible outside
-a live terminal.
+a live terminal (fixed in place by B9.6a). B9.6b then collapsed the four
+independent Event classes (F-127) into one: usb_monitor.Event is now a
+re-exported alias of redis_controller.Event, not a copy -- see the identity
+check below.
 """
 
 import sys
@@ -19,11 +22,16 @@ sys.modules.setdefault(
     "pyudev",
     types.SimpleNamespace(Context=object, Monitor=object, MonitorObserver=object),
 )
+sys.modules.setdefault("redis", types.SimpleNamespace(StrictRedis=object))
 
 from module.usb_monitor import Event
+from module.redis_controller import Event as RedisControllerEvent
 
 
 class UsbMonitorEventDispatchTests(unittest.TestCase):
+    def test_is_the_shared_redis_controller_event_not_a_copy(self):
+        self.assertIs(Event, RedisControllerEvent)
+
     def test_a_raising_listener_does_not_stop_the_others(self):
         seen = []
 
@@ -62,7 +70,7 @@ class UsbMonitorEventDispatchTests(unittest.TestCase):
 
         def self_removing(*args):
             calls.append(args)
-            event._listeners.remove(self_removing)
+            event._handlers.remove(self_removing)
 
         event.subscribe(self_removing)
         event.subscribe(lambda *args: calls.append(("second", args)))
@@ -70,7 +78,7 @@ class UsbMonitorEventDispatchTests(unittest.TestCase):
         event.emit("add", "/dev/snd/card2")
 
         self.assertEqual(len(calls), 2)
-        self.assertNotIn(self_removing, event._listeners)
+        self.assertNotIn(self_removing, event._handlers)
 
 
 if __name__ == "__main__":

--- a/_test/test_usb_monitor_event_dispatch.py
+++ b/_test/test_usb_monitor_event_dispatch.py
@@ -1,0 +1,77 @@
+"""usb_monitor.Event.emit takes *args (mic hotswap payloads carry action,
+device, model, serial). Before this fix it iterated the live listener list
+with no copy, so a listener that subscribes/unsubscribes in response to its
+own event -- the mic hotswap handlers do -- could raise RuntimeError and take
+the whole emit down with it. It also logged failures with traceback.print_exc()
+to stdout instead of the log file, so a raising listener was invisible outside
+a live terminal.
+"""
+
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+sys.modules.setdefault(
+    "pyudev",
+    types.SimpleNamespace(Context=object, Monitor=object, MonitorObserver=object),
+)
+
+from module.usb_monitor import Event
+
+
+class UsbMonitorEventDispatchTests(unittest.TestCase):
+    def test_a_raising_listener_does_not_stop_the_others(self):
+        seen = []
+
+        event = Event()
+        event.subscribe(lambda *args: seen.append(("first", args)))
+        event.subscribe(lambda *args: (_ for _ in ()).throw(RuntimeError("boom")))
+        event.subscribe(lambda *args: seen.append(("third", args)))
+
+        with self.assertLogs(level="ERROR"):
+            event.emit("mic_changed", "/dev/snd/card1", "USB Mic", "12345")
+
+        self.assertEqual(
+            seen,
+            [
+                ("first", ("mic_changed", "/dev/snd/card1", "USB Mic", "12345")),
+                ("third", ("mic_changed", "/dev/snd/card1", "USB Mic", "12345")),
+            ],
+        )
+
+    def test_the_failure_is_logged_not_swallowed(self):
+        event = Event()
+        event.subscribe(lambda *args: (_ for _ in ()).throw(ValueError("nope")))
+
+        with self.assertLogs(level="ERROR") as captured:
+            event.emit("add", "/dev/snd/card0")
+
+        joined = "\n".join(captured.output)
+        self.assertIn("ValueError", joined)
+        self.assertIn("nope", joined)
+
+    def test_a_listener_that_unsubscribes_itself_mid_emit_does_not_crash(self):
+        # Mutating the listener list while emit() is iterating it used to
+        # raise RuntimeError: list changed size during iteration.
+        calls = []
+        event = Event()
+
+        def self_removing(*args):
+            calls.append(args)
+            event._listeners.remove(self_removing)
+
+        event.subscribe(self_removing)
+        event.subscribe(lambda *args: calls.append(("second", args)))
+
+        event.emit("add", "/dev/snd/card2")
+
+        self.assertEqual(len(calls), 2)
+        self.assertNotIn(self_removing, event._listeners)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/redis-keys.md
+++ b/docs/redis-keys.md
@@ -17,6 +17,7 @@ Each entry explains which component normally writes the key and whether it makes
 | fps | Cinemate -> CinePi-raw | Target frames per second | Yes |
 | fps_user | Cinemate | User-selected FPS value stored by the UI/controller | No |
 | fps_actual | CinePi-raw -> Cinemate | Measured FPS from the running pipeline | No |
+| user_changing_fps | Cinemate (RedisListener) | `1` while an fps change is debouncing; cleared once `fps` has been stable for a while | No |
 | fps_last | Cinemate | Previous stable FPS value from stats | No |
 | fps_max | Cinemate startup | Maximum FPS supported by the current sensor mode | No |
 | fps_phase_lock | Cinemate startup | Runtime enable for CinePi-raw's closed-loop frame-rate phase lock, from `sensors.<cam>.phase_lock` in settings.jsonc (default on); read once at CinePi-raw startup, not live | No |
@@ -84,6 +85,7 @@ transition instead of a stale value.
 | storage_recorder_profile | Cinemate (SSD monitor) | Recorder worker profile selected from the current filesystem | No |
 | space_left | Cinemate (SSD monitor) | Remaining free space in GB | No |
 | write_speed_to_drive | Cinemate (SSD monitor) | Current write speed in MB/s | No |
+| FSCK_STATUS | Cinemate (SSD monitor) | Result of the periodic filesystem check run after mount, e.g. `OK ...` / `FAIL ...`; cinemate-internal, cinepi-raw never reads it | No |
 | file_size | Cinemate | Bytes per frame for the current mode | No |
 | memory_alert | Cinemate | RAM percentage at which the watchdog auto-stopped recording (integer, set at the 80 % trip point); `0` when clear | No |
 | cam_init | CinePi-raw | Internal startup flag | No |

--- a/src/main.py
+++ b/src/main.py
@@ -605,7 +605,7 @@ def initialize_system(settings, pi_model="unknown"):
     redis_controller = RedisController(conform_frame_rate=conf_rate)
     sensor_detect = SensorDetect(settings)
     ssd_monitor = SSDMonitor(redis_controller=redis_controller)
-    usb_monitor = USBMonitor(ssd_monitor, settings=settings)
+    usb_monitor = USBMonitor(ssd_monitor, settings=settings, redis_controller=redis_controller)
 
     gpio_cfg = settings["hardware_outputs"]
     rec_tone_pins = gpio_cfg.get("rec_tone_pin")

--- a/src/main.py
+++ b/src/main.py
@@ -11,7 +11,12 @@ import socket
 from PIL import Image, ImageDraw, ImageFont
 import glob
 
-from module.config_loader import SettingsLoadError, auto_storage_preroll_enabled, load_settings
+from module.config_loader import (
+    SettingsLoadError,
+    auto_storage_preroll_enabled,
+    load_settings,
+    DEFAULT_SETTINGS_PATH,
+)
 from module.logger import configure_logging, log_directory
 from module.redis_controller import RedisController, ParameterKey
 from module.ssd_monitor import SSDMonitor
@@ -45,7 +50,7 @@ from module.console_display import (
 from module.framebuffer import acquire_framebuffer
 
 # Constants
-SETTINGS_FILE = "/home/pi/cinemate/settings.jsonc"
+SETTINGS_FILE = DEFAULT_SETTINGS_PATH
 STARTUP_MESSAGE_MIN_DURATION = 3.0
 CLI_COLOR_RED = "\033[1;31m"
 CLI_COLOR_YELLOW = "\033[1;33m"

--- a/src/module/app/main/events.py
+++ b/src/module/app/main/events.py
@@ -1,6 +1,7 @@
 from flask_socketio import emit
 import threading
 from module.redis_controller import ParameterKey
+from module.config_loader import as_bool
 
 def register_events(socketio, redis_controller, cinepi_controller, simple_gui, sensor_detect):
     """Server → browser push only.
@@ -12,10 +13,9 @@ def register_events(socketio, redis_controller, cinepi_controller, simple_gui, s
     """
 
     def resolution_switching_active():
-        return str(
+        return as_bool(
             redis_controller.get_value(ParameterKey.RESOLUTION_SWITCHING.value, "0")
-            or "0"
-        ).strip().lower() in ("1", "true", "yes", "on")
+        )
 
     def selected_resolution_mode():
         target_mode = redis_controller.get_value(ParameterKey.RESOLUTION_TARGET_MODE.value)

--- a/src/module/app/settings_editor.py
+++ b/src/module/app/settings_editor.py
@@ -31,6 +31,7 @@ from module.config_loader import (
     _apply_settings_defaults,
     load_settings,
     strip_jsonc,
+    DEFAULT_SETTINGS_PATH,
 )
 from module.app import boot_config, raw_files
 from module.jsonc_edit import apply_updates
@@ -44,10 +45,7 @@ settings_editor_bp = Blueprint(
     template_folder="templates",
 )
 
-# Every settings.jsonc caller in this codebase hardcodes this same absolute
-# path (src/main.py:51, cinepi_multi.py:27, cinepi_controller.py:27,
-# wifi_hotspot.py:37) -- it is a live-hardware constant, not configurable.
-SETTINGS_FILE = "/home/pi/cinemate/settings.jsonc"
+SETTINGS_FILE = DEFAULT_SETTINGS_PATH
 
 # Shipped template (resources/settings/settings_default.jsonc) -- used as
 # (a) the GET /api/settings fallback when the live file is missing, and

--- a/src/module/app/templates/template.html
+++ b/src/module/app/templates/template.html
@@ -426,26 +426,26 @@
 
     <div id="top-row">
         <div class="group selectable" id="g-fps">
-            <span class="label">FPS</span><span class="value" id="v-fps"></span>
+            <span class="label" id="l-fps"></span><span class="value" id="v-fps"></span>
             <select id="s-fps" aria-label="Frame rate"></select>
         </div>
         <div class="group selectable" id="g-shutter">
-            <span class="label">SHUTTER</span><span class="value" id="v-shutter"></span>
+            <span class="label" id="l-shutter"></span><span class="value" id="v-shutter"></span>
             <select id="s-shutter" aria-label="Shutter angle"></select>
         </div>
         <div class="group" id="g-exp">
-            <span class="label">EXP</span><span class="value" id="v-exp"></span>
+            <span class="label" id="l-exp"></span><span class="value" id="v-exp"></span>
         </div>
         <div class="group selectable" id="g-iso">
-            <span class="label">EI</span><span class="value" id="v-iso"></span>
+            <span class="label" id="l-iso"></span><span class="value" id="v-iso"></span>
             <select id="s-iso" aria-label="ISO"></select>
         </div>
         <div class="group selectable" id="g-wb">
-            <span class="label">WB</span><span class="value" id="v-wb"></span>
+            <span class="label" id="l-wb"></span><span class="value" id="v-wb"></span>
             <select id="s-wb" aria-label="White balance"></select>
         </div>
         <div class="group selectable" id="g-res">
-            <span class="label">RES</span><span class="value" id="v-res"></span>
+            <span class="label" id="l-res"></span><span class="value" id="v-res"></span>
             <span class="badge hidden" id="v-hdr-badge"></span>
             <select id="s-res" aria-label="Resolution"></select>
         </div>
@@ -601,8 +601,21 @@
     }
 
     function warningBoxes() {
+        // F-211: the framebuffer GUI's DROP/SYNC boxes are a fixed on-camera
+        // size and only ever show the word, never a count -- there is no
+        // room. The browser has room. drop_frame_count is already published
+        // (populate_values(), aliases tc_hole_count) and unused here; show
+        // it. frames_off_sync has no equivalent published count today -- the
+        // frame-difference number that latches it (redis_listener.py) is
+        // only logged, never set_value()'d -- so SYNC stays word-only rather
+        // than this display change quietly growing into new live-path
+        // telemetry with no Pi available to verify it.
         const out = [];
-        if (V.drop_frame_latched) { out.push(box('DROP', 'drop')); }
+        if (V.drop_frame_latched) {
+            const count = Number(V.drop_frame_count) || 0;
+            const label = count > 0 ? `DROP ${count}` : 'DROP';
+            out.push(box(label, 'drop' + (label.length > 4 ? ' small' : '')));
+        }
         if (V.frames_off_sync) { out.push(box('SYNC', 'sync')); }
         return out;
     }
@@ -773,6 +786,17 @@
     window.addEventListener('resize', sizePreview);
 
     function renderTopRow() {
+        // Labels come from populate_values() too (fps_label, shutter_label,
+        // exposure_label, iso_label, wb_label, res_label) -- the web GUI has
+        // no state of its own, so these render whatever the HDMI GUI sent
+        // instead of a second hardcoded copy of the same six words (F-257).
+        text('l-fps', V.fps_label);
+        text('l-shutter', V.shutter_label);
+        text('l-exp', V.exposure_label);
+        text('l-iso', V.iso_label);
+        text('l-wb', V.wb_label);
+        text('l-res', V.res_label);
+
         text('v-fps', V.fps);
         text('v-shutter', V.shutter_speed);
         text('v-exp', V.exposure_time);

--- a/src/module/cinepi_controller.py
+++ b/src/module/cinepi_controller.py
@@ -12,7 +12,12 @@ import sys
 from module.redis_controller import ParameterKey, encode_log_encode_request, decode_log_encode_request
 from module.sensor_detect import compute_frame_size_mb
 from module.ir_filter import IRFilter
-from module.config_loader import load_settings as _load_settings
+from module.config_loader import (
+    load_settings as _load_settings,
+    as_bool,
+    TRUE_VALUES,
+    FALSE_VALUES,
+)
 from module.storage_profiles import recorder_profile_name_for_filesystem
 from module.dynamic_resolution import (
     choose_resolution,
@@ -181,7 +186,7 @@ class CinePiController:
         self.sensor_mode = self._get_startup_sensor_mode()
         self.sensor_mode_saved = self.sensor_mode
         self.dynamic_resolution_desired_mode = self._get_startup_dynamic_resolution_desired_mode()
-        stored_dynamic_resolution_active = self._as_bool(
+        stored_dynamic_resolution_active = as_bool(
             self.redis_controller.get_value(
                 ParameterKey.DYNAMIC_RESOLUTION_ACTIVE.value,
                 0,
@@ -322,7 +327,7 @@ class CinePiController:
         )
         if value is None:
             return True
-        return self._as_bool(value)
+        return as_bool(value)
 
     def _publish_dynamic_resolution_state(self):
         self.redis_controller.set_value(
@@ -360,12 +365,6 @@ class CinePiController:
             return float(value)
         except (TypeError, ValueError):
             return None
-
-    @staticmethod
-    def _as_bool(value):
-        if isinstance(value, bool):
-            return value
-        return str(value).strip().lower() in ("1", "true", "yes", "on")
 
     def _sensor_readout_fps_max(self, mode=None):
         mode = self.sensor_mode if mode is None else mode
@@ -707,9 +706,9 @@ class CinePiController:
             new_value = False if current else True
         elif isinstance(value, str):
             low = value.strip().lower()
-            if low in ("off", "0", "false", "no"):
+            if low in FALSE_VALUES:
                 new_value = False
-            elif low in ("on", "1", "true", "yes"):
+            elif low in TRUE_VALUES:
                 new_value = True
             else:
                 logging.warning("set log: unrecognized value %r, ignoring", value)

--- a/src/module/cinepi_controller.py
+++ b/src/module/cinepi_controller.py
@@ -17,6 +17,7 @@ from module.config_loader import (
     as_bool,
     TRUE_VALUES,
     FALSE_VALUES,
+    DEFAULT_SETTINGS_PATH,
 )
 from module.storage_profiles import recorder_profile_name_for_filesystem
 from module.dynamic_resolution import (
@@ -26,7 +27,7 @@ from module.dynamic_resolution import (
 )
 from module import parameters
 
-SETTINGS_FILE = "/home/pi/cinemate/settings.jsonc"
+SETTINGS_FILE = DEFAULT_SETTINGS_PATH
 GUI_RESOLUTION_PREVIEW_DELAY_SECONDS = 0.12
 GUI_RESOLUTION_SWITCHING_HOLD_SECONDS = 2.5
 RAW_STREAM_READY_RE = re.compile(r"\bRaw stream:\s*(\d+)x(\d+)\b", re.IGNORECASE)

--- a/src/module/cinepi_multi.py
+++ b/src/module/cinepi_multi.py
@@ -11,7 +11,7 @@ import os
 import shutil
 
 from module.config_loader import load_settings, DEFAULT_SETTINGS_PATH
-from module.redis_controller import ParameterKey, decode_log_encode_request
+from module.redis_controller import ParameterKey, decode_log_encode_request, Event
 from module.framebuffer import Framebuffer
 from module.sensor_detect import is_pi4_family
 from module.storage_profiles import (
@@ -106,27 +106,6 @@ def _audio_timecode_offset_frames(settings: dict | None = None) -> int:
         logging.warning("Invalid audio.24bit.timecode_offset_frames=%r; using 0", raw_value)
         return 0
 
-
-# ───────────────────────── Event ─────────────────────────
-class Event:
-    def __init__(self):
-        self._listeners = []
-    def subscribe(self, listener):
-        self._listeners.append(listener)
-    def emit(self, data=None):
-        # self.message fans out cinepi-raw's subprocess output (see :281/:299
-        # below) to every subscriber, synchronously, on the reader thread. An
-        # unguarded raise here used to kill that thread outright and silently
-        # stop the log relay. One bad listener must not take the others down
-        # with it. Mirrors RedisController's Event (module/redis_controller.py).
-        for listener in list(self._listeners):
-            try:
-                listener(data)
-            except Exception:
-                logging.exception(
-                    "cinepi_multi listener %s failed; continuing with the rest",
-                    getattr(listener, "__qualname__", listener),
-                )
 
 # ───────────────────── Camera Discovery ──────────────────
 class CameraInfo:

--- a/src/module/cinepi_multi.py
+++ b/src/module/cinepi_multi.py
@@ -10,7 +10,7 @@ from typing import List
 import os
 import shutil
 
-from module.config_loader import load_settings
+from module.config_loader import load_settings, DEFAULT_SETTINGS_PATH
 from module.redis_controller import ParameterKey, decode_log_encode_request
 from module.framebuffer import Framebuffer
 from module.sensor_detect import is_pi4_family
@@ -22,7 +22,7 @@ from module.storage_profiles import (
 )
 
 # Path to settings file
-SETTINGS_FILE = "/home/pi/cinemate/settings.jsonc"
+SETTINGS_FILE = DEFAULT_SETTINGS_PATH
 _SETTINGS: dict | None = None
 
 

--- a/src/module/cinepi_multi.py
+++ b/src/module/cinepi_multi.py
@@ -114,8 +114,19 @@ class Event:
     def subscribe(self, listener):
         self._listeners.append(listener)
     def emit(self, data=None):
-        for l in self._listeners:
-            l(data)
+        # self.message fans out cinepi-raw's subprocess output (see :281/:299
+        # below) to every subscriber, synchronously, on the reader thread. An
+        # unguarded raise here used to kill that thread outright and silently
+        # stop the log relay. One bad listener must not take the others down
+        # with it. Mirrors RedisController's Event (module/redis_controller.py).
+        for listener in list(self._listeners):
+            try:
+                listener(data)
+            except Exception:
+                logging.exception(
+                    "cinepi_multi listener %s failed; continuing with the rest",
+                    getattr(listener, "__qualname__", listener),
+                )
 
 # ───────────────────── Camera Discovery ──────────────────
 class CameraInfo:

--- a/src/module/config_loader.py
+++ b/src/module/config_loader.py
@@ -7,8 +7,11 @@ ANSI_RED = "\033[1;31m"
 ANSI_YELLOW = "\033[1;33m"
 ANSI_CYAN = "\033[1;36m"
 
-_TRUE_VALUES = {"1", "true", "yes", "on"}
-_FALSE_VALUES = {"0", "false", "no", "off"}
+# Public: a handful of call sites need the raw membership test (e.g. a CLI
+# parser that must reject an unrecognised value outright rather than fall
+# back to a default) instead of the as_bool() default-fallback shape below.
+TRUE_VALUES = {"1", "true", "yes", "on"}
+FALSE_VALUES = {"0", "false", "no", "off"}
 
 
 class SettingsLoadError(RuntimeError):
@@ -115,7 +118,35 @@ def _format_error_context(path: Path, line: int, column: int, radius: int = 1) -
     return "\n".join(snippet)
 
 
-def _coerce_bool_setting(value, default: bool) -> bool:
+def as_bool(value, default: bool = False) -> bool:
+    """Decode a settings.jsonc / Redis boolean the same way everywhere.
+
+    This used to be four independent copies (cinepi_controller, gpio_input,
+    dynamic_resolution, mediator) that quietly disagreed -- e.g. `_as_bool(2)`
+    was `True` in gpio_input and `False` in the other three (F-126) -- plus
+    the same `("1","true","yes","on")` truth-set re-typed standalone in half
+    a dozen more places. This is the one decoder; everything routes here now.
+
+    - bool passes through unchanged.
+    - None means "not set" and returns `default` silently -- that is the
+      normal, expected shape of an absent key.
+    - int/float use Python truthiness (`bool(value)`): 2 is True, matching
+      how a settings-file author reads a truthy value, and matching what
+      gpio_input already did. (Nothing in settings.jsonc currently sends a
+      non-0/1 number through here -- checked when this was unified -- so
+      this is a decision for future values, not an observed behaviour fix.)
+    - str is matched case-insensitively against `TRUE_VALUES`/`FALSE_VALUES`
+      first (Redis stores every value as text, so this is the common path),
+      then against a numeric fallback (`bool(int(text))`) so a stray "2"
+      decodes the same way the int 2 does instead of being "unrecognised" --
+      three call sites already relied on exactly this before the merge.
+    - Anything else -- an unrecognised string, or a non-str/bool/int/float/
+      None object -- is NOT the same as an explicit false. It falls back to
+      `default`, same as an absent value, but at `debug` level (not `warning`)
+      because this runs on the 12 fps GUI redraw path and a stuck bad value
+      must not flood the log every frame -- see "fail visible" vs. the
+      redraw-path logging rule, both in the project's own conventions.
+    """
     if isinstance(value, bool):
         return value
     if value is None:
@@ -124,10 +155,17 @@ def _coerce_bool_setting(value, default: bool) -> bool:
         return bool(value)
     if isinstance(value, str):
         normalized = value.strip().lower()
-        if normalized in _TRUE_VALUES:
+        if normalized in TRUE_VALUES:
             return True
-        if normalized in _FALSE_VALUES:
+        if normalized in FALSE_VALUES:
             return False
+        try:
+            return bool(int(normalized))
+        except ValueError:
+            pass
+    logging.debug(
+        "as_bool: unrecognised value %r, defaulting to %s", value, default
+    )
     return default
 
 
@@ -135,7 +173,7 @@ def auto_storage_preroll_enabled(settings: dict) -> bool:
     """Return whether automatic storage pre-roll should run."""
 
     storage_cfg = settings.get("system", {}).get("storage", {})
-    return _coerce_bool_setting(
+    return as_bool(
         storage_cfg.get("auto_preroll") if isinstance(storage_cfg, dict) else None, True
     )
 
@@ -168,7 +206,7 @@ def _apply_settings_defaults(settings: dict) -> dict:
 
     storage_cfg = system_cfg.setdefault("storage", {})
     storage_cfg.setdefault("auto_preroll", True)
-    storage_cfg["auto_preroll"] = _coerce_bool_setting(storage_cfg.get("auto_preroll"), True)
+    storage_cfg["auto_preroll"] = as_bool(storage_cfg.get("auto_preroll"), True)
     storage_cfg.setdefault("recognized_ssds", [])
     system_cfg["storage"] = storage_cfg
 

--- a/src/module/config_loader.py
+++ b/src/module/config_loader.py
@@ -7,6 +7,15 @@ ANSI_RED = "\033[1;31m"
 ANSI_YELLOW = "\033[1;33m"
 ANSI_CYAN = "\033[1;36m"
 
+# F-260: this absolute path used to be hardcoded independently in six files
+# (main.py, cinepi_multi.py, cinepi_controller.py, wifi_hotspot.py,
+# simple_gui.py, app/settings_editor.py); one had already drifted out of
+# sync with a comment that tried to enumerate the others by line number.
+# services/cinemate-recovery/cinemate-recovery.py keeps its own copy
+# deliberately -- that process must import nothing from module.* (F-221) so
+# it can still run when the rest of the stack cannot.
+DEFAULT_SETTINGS_PATH = "/home/pi/cinemate/settings.jsonc"
+
 # Public: a handful of call sites need the raw membership test (e.g. a CLI
 # parser that must reject an unrecognised value outright rather than fall
 # back to a default) instead of the as_bool() default-fallback shape below.
@@ -281,7 +290,7 @@ def _apply_settings_defaults(settings: dict) -> dict:
             "free_increment": 100,
         },
         "shutter_a": {
-            "steps": [1, 45, 90, 135, 172.8, 180, 225, 270, 315, 360],
+            "steps": [1, 45, 90, 135, 172.8, 180, 225, 270, 315, 346.6, 360],
             "free": False,
             "free_increment": 1,
             # Own granularity used only while shutter-angle sync mode is on

--- a/src/module/dynamic_resolution.py
+++ b/src/module/dynamic_resolution.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from module.config_loader import as_bool
+
 
 @dataclass(frozen=True)
 class DynamicResolutionChoice:
@@ -38,12 +40,6 @@ def _as_float(value: Any) -> float | None:
     if result <= 0:
         return None
     return result
-
-
-def _as_bool(value: Any) -> bool:
-    if isinstance(value, bool):
-        return value
-    return str(value or "").strip().lower() in ("1", "true", "yes", "on")
 
 
 def _normalize_modes(sensor_modes: dict[int, dict[str, Any]] | None) -> dict[int, dict[str, Any]]:
@@ -94,7 +90,7 @@ def dynamic_resolution_indicator_active(
     sensor_modes: dict[int, dict[str, Any]] | None = None,
 ) -> bool:
     """Return True while dynamic resolution is actively showing a substitute mode."""
-    if not _as_bool(enabled) or not _as_bool(active):
+    if not as_bool(enabled) or not as_bool(active):
         return False
     return dynamic_resolution_is_lower_substitute(
         sensor_modes=sensor_modes,

--- a/src/module/gpio_input.py
+++ b/src/module/gpio_input.py
@@ -7,7 +7,9 @@ import shlex  # Add this import
 import warnings
 import logging
 import time
-    
+
+from module.config_loader import as_bool
+
 class ComponentInitializer:
     def __init__(self, cinepi_controller, settings, reserved_output_pins=None):
         self.cinepi_controller = cinepi_controller
@@ -52,7 +54,7 @@ class ComponentInitializer:
             smart_button = SmartButton(
                 cinepi_controller=self.cinepi_controller,
                 pin=pin,
-                pull_up=self._as_bool(button_config.get('pull_up'), default=True),
+                pull_up=as_bool(button_config.get('pull_up'), default=True),
                 debounce_time=float(button_config['debounce_time']),
                 actions=button_config,
                 identifier=str(pin),
@@ -99,7 +101,7 @@ class ComponentInitializer:
         
         # Initialize Rotary Encoders with Buttons
         for encoder_config in controls_cfg.get('rotary_encoders', []):
-            if not self._as_bool(encoder_config.get('enabled', True), default=True):
+            if not as_bool(encoder_config.get('enabled', True), default=True):
                 self.logger.info("Skipping disabled rotary encoder config: %s", encoder_config)
                 continue
 
@@ -134,7 +136,7 @@ class ComponentInitializer:
             smart_button = SmartButton(
                 cinepi_controller=self.cinepi_controller,
                 pin=button_pin,
-                pull_up=self._as_bool(encoder_config.get('pull_up'), default=True),
+                pull_up=as_bool(encoder_config.get('pull_up'), default=True),
                 debounce_time=float(encoder_config.get('debounce_time', 0.05)),
                 actions=button_actions,
                 identifier=str(button_pin),
@@ -158,18 +160,6 @@ class ComponentInitializer:
             return action_config.get('method')
         else:
             return None
-
-    @staticmethod
-    def _as_bool(value, default=False):
-        if isinstance(value, bool):
-            return value
-        if value is None:
-            return default
-        if isinstance(value, (int, float)):
-            return bool(value)
-        if isinstance(value, str):
-            return value.strip().lower() in {"1", "true", "yes", "on"}
-        return bool(value)
 
     @staticmethod
     def _is_noop_action(action):

--- a/src/module/mediator.py
+++ b/src/module/mediator.py
@@ -2,6 +2,7 @@ import logging
 import threading
 import json
 from module.redis_controller import ParameterKey
+from module.config_loader import as_bool
 
 class Mediator:
     def __init__(self, cinepi_app, cinepi_controller, redis_listener, redis_controller, ssd_monitor, gpio_output, stream, usb_monitor):
@@ -75,14 +76,6 @@ class Mediator:
             if self.stop_recording_timer and self.stop_recording_timer.is_alive():
                 self.stop_recording_timer.cancel()        
 
-    @staticmethod
-    def _as_bool(value):
-        if isinstance(value, bool):
-            return value
-        if value is None:
-            return False
-        return str(value).strip().lower() in ("1", "true", "yes", "on")
-
     def _refresh_gpio_outputs(self):
         # REC light follows actual write status.
         self.gpio_output.set_rec_light(self._is_writing)
@@ -96,21 +89,21 @@ class Mediator:
         key = data.get('key')
 
         if key == ParameterKey.STORAGE_PREROLL_ACTIVE.value:
-            self._storage_preroll_active = self._as_bool(data.get('value'))
+            self._storage_preroll_active = as_bool(data.get('value'))
             self._refresh_gpio_outputs()
             return
 
         # Start REC tone immediately on REC command edge, but do not use REC
         # as a persistent recording-state source (REC can be edge-triggered).
         if key == ParameterKey.REC.value:
-            rec_edge = self._as_bool(data.get('value'))
+            rec_edge = as_bool(data.get('value'))
             if rec_edge and not self._storage_preroll_active:
                 self.gpio_output.set_rec_tone(1)
             return
 
         # IS_RECORDING is the authoritative persistent recording state.
         if key == ParameterKey.IS_RECORDING.value:
-            self._is_recording = self._as_bool(data.get('value'))
+            self._is_recording = as_bool(data.get('value'))
             if self._is_recording:
                 logging.info("Recording started!")
                 if not self._storage_preroll_active:
@@ -140,13 +133,13 @@ class Mediator:
             return
 
         if key == ParameterKey.DROP_FRAME_RELAY.value:
-            self._drop_frame_relay_active = self._as_bool(data.get('value'))
+            self._drop_frame_relay_active = as_bool(data.get('value'))
             self.gpio_output.relay_drop_frame_on_rec_tone(self._drop_frame_relay_active)
             return
 
         # Handle "is_writing" key changes
         if key == ParameterKey.IS_WRITING.value:
-            self._is_writing = self._as_bool(data.get('value'))
+            self._is_writing = as_bool(data.get('value'))
             if self._is_writing and hasattr(self.stream, "toggle_background_color"):
                 try:
                     self.stream.toggle_background_color()

--- a/src/module/redis_controller.py
+++ b/src/module/redis_controller.py
@@ -113,6 +113,11 @@ class ParameterKey(Enum):
     RECORDING_TC_REC     = "recording_tc_rec"    # elapsed-time time-code
     RECORDING_TC_TOD   = "recording_time_tod"    # time-of-day time-code
     FRAMES_IN_SYNC      = "frames_in_sync"
+    USER_CHANGING_FPS   = "user_changing_fps"
+    FSCK_STATUS         = "FSCK_STATUS"  # ssd_monitor's own fsck result; cinepi-raw never reads this one
+
+
+_KNOWN_PARAMETER_VALUES = {member.value for member in ParameterKey}
 
 
 def encode_log_encode_request(value) -> int:
@@ -178,6 +183,7 @@ class RedisController:
         self.lock   = threading.Lock()
         self.cache  = {}
         self.local_updates: set[str] = set()
+        self._unknown_keys_warned: set[str] = set()
 
         self.redis_parameter_changed = Event()
 
@@ -257,6 +263,20 @@ class RedisController:
             return
 
         key_name = key.value if isinstance(key, ParameterKey) else str(key)
+
+        # F-015: the enum was convention, not enforcement -- any string was
+        # accepted silently. This makes an un-enumerated key visible without
+        # blocking the write: rejecting outright here, with no Pi available
+        # to verify every call site this touches, risks silently breaking a
+        # working recording path over a naming gap. Warn once per key so a
+        # value written every frame (e.g. framecount) can't flood the log.
+        if key_name not in _KNOWN_PARAMETER_VALUES and key_name not in self._unknown_keys_warned:
+            self._unknown_keys_warned.add(key_name)
+            logging.warning(
+                "set_value('%s', ...): not a ParameterKey member -- writing anyway, "
+                "but this key has no enum entry to keep readers in sync with it.",
+                key_name,
+            )
 
         # ─── Redis write / publish / cache ───────────────────────────
         with self.lock:

--- a/src/module/redis_controller.py
+++ b/src/module/redis_controller.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import logging, threading, redis, psutil, time
 from enum import Enum
 import time, math
+from module.config_loader import as_bool
 
 # ───────────────────────── parameter keys ────────────────────────────
 class ParameterKey(Enum):
@@ -246,14 +247,7 @@ class RedisController:
             return self.cache.get(key, default)
 
     def _storage_preroll_active(self) -> bool:
-        value = self.cache.get(ParameterKey.STORAGE_PREROLL_ACTIVE.value, "0")
-        text = str(value).strip().lower()
-        if text in ("1", "true", "yes", "on"):
-            return True
-        try:
-            return bool(int(text))
-        except (TypeError, ValueError):
-            return False
+        return as_bool(self.cache.get(ParameterKey.STORAGE_PREROLL_ACTIVE.value, "0"))
 
         # ────────────────────────── public helpers ───────────────────────
     def set_value(self, key, value):

--- a/src/module/redis_controller.py
+++ b/src/module/redis_controller.py
@@ -149,6 +149,20 @@ def decode_log_encode_request(raw):
 
 # ────────────────────────── tiny pub‑sub helper ──────────────────────
 class Event:
+    """Shared pub/sub helper (F-127). Used to be four independent copies --
+    redis_controller's own, plus ssd_monitor.mount_event, usb_monitor.usb_event
+    and cinepi_multi.message -- with divergent error handling; B3.1 fixed this
+    one, B9.6a fixed the other two in place, this collapses all three into it.
+    This is the only copy with unsubscribe, and the one PI-014 exercised on
+    hardware for the redis bus.
+
+    emit() takes *args, not a single data param: ssd_monitor's mount_event and
+    usb_monitor's usb_event were already emitting several positional args
+    (mount path/device/filesystem/profile; device/model/serial/card name), and
+    every existing single-arg caller (redis_parameter_changed.emit(data),
+    cinepi_multi's message.emit(line)) keeps working unchanged -- one
+    positional arg through *args reaches the subscriber exactly as before.
+    """
     def __init__(self):
         self._handlers = []
     def subscribe(self, fn):
@@ -158,19 +172,22 @@ class Event:
             self._handlers.remove(fn)
         except ValueError:
             pass
-    def emit(self, data=None):
-        # Every subscriber runs on the single _listen thread, synchronously. An
-        # unguarded raise here used to kill that thread outright, and because
-        # get_value() serves the cache rather than redis, every surface then went
-        # on rendering its last values with no error anywhere -- the operator sees
-        # plausible frozen numbers mid-take. One bad subscriber must not silence
-        # the others or the bus. Mirrors CinePiController._notify_resolution_change.
+    def emit(self, *args):
+        # Every subscriber runs synchronously on whatever thread calls emit()
+        # (redis_controller's single _listen thread for its own event; the
+        # log-relay/USB-monitor/mount threads for the others). An unguarded
+        # raise here used to kill that thread outright, and because
+        # get_value() serves the cache rather than redis, every surface then
+        # went on rendering its last values with no error anywhere -- the
+        # operator sees plausible frozen numbers mid-take. One bad subscriber
+        # must not silence the others or the bus. Mirrors
+        # CinePiController._notify_resolution_change.
         for fn in list(self._handlers):
             try:
-                fn(data)
+                fn(*args)
             except Exception:
                 logging.exception(
-                    "Redis subscriber %s failed; continuing with the rest",
+                    "Event subscriber %s failed; continuing with the rest",
                     getattr(fn, "__qualname__", fn),
                 )
 

--- a/src/module/redis_listener.py
+++ b/src/module/redis_listener.py
@@ -1,4 +1,3 @@
-import redis
 import logging
 import threading
 import datetime
@@ -18,17 +17,18 @@ class RedisListener:
         redis_controller,
         ssd_monitor,
         framerate_callback=None,
-        host='localhost',
-        port=6379,
-        db=0,
         *,
         live_sync_warning_tolerance_frames: int | float = 5,
         live_sync_startup_guard_frames: int | float = 10,
         final_sync_analysis_tolerance_frames: int | float = 1,
         tc_drop_jitter_tolerance_frames: int | float = 1,
     ):
-        self.redis_client = redis.StrictRedis(host=host, port=port, db=db)
-        
+        # Share redis_controller's client instead of opening a second
+        # connection to the same host/port/db (F-105) -- pubsub() still hands
+        # back a dedicated subscription per call, so cp_stats and cp_controls
+        # each get their own, same as before.
+        self.redis_client = redis_controller.r
+
         self.pubsub_stats = self.redis_client.pubsub()
         self.pubsub_controls = self.redis_client.pubsub()
         self.channel_name_stats = "cp_stats"
@@ -1140,7 +1140,7 @@ class RedisListener:
         """Debounce-timer callback – clear the flag once the fps key
         has been stable for a while."""
         self.user_changing_fps = False
-        self.redis_controller.set_value("user_changing_fps", 0)
+        self.redis_controller.set_value(ParameterKey.USER_CHANGING_FPS.value, 0)
         logging.debug("user_changing_fps → 0 (fps stable)")
 
     def _note_fps_change(self, new_fps: float):
@@ -1150,7 +1150,7 @@ class RedisListener:
 
         self.last_fps_value = new_fps
         self.user_changing_fps = True
-        self.redis_controller.set_value("user_changing_fps", 1)
+        self.redis_controller.set_value(ParameterKey.USER_CHANGING_FPS.value, 1)
         logging.debug(f"fps changed to {new_fps} → user_changing_fps = 1")
 
         # leeway = max(0.5 s, two frame-intervals)

--- a/src/module/redis_listener.py
+++ b/src/module/redis_listener.py
@@ -5,6 +5,7 @@ import datetime
 import json
 from collections import deque
 from module.redis_controller import ParameterKey
+from module.config_loader import as_bool
 
 import os
 import re
@@ -561,17 +562,7 @@ class RedisListener:
         except Exception:
             return False
 
-        if value is None:
-            return False
-
-        text = str(value).strip().lower()
-        if text in ("1", "true", "yes", "on"):
-            return True
-
-        try:
-            return bool(int(text))
-        except (TypeError, ValueError):
-            return False
+        return as_bool(value)
 
     def _determine_expected_fps(self) -> float | None:
         if self.fps_at_rec_start is not None and self.fps_at_rec_start > 0:

--- a/src/module/simple_gui.py
+++ b/src/module/simple_gui.py
@@ -5,7 +5,7 @@ import wave
 from PIL import Image, ImageDraw, ImageFont
 from module.console_display import claim_console_for_framebuffer, release_console_to_text
 from module.framebuffer import Framebuffer, acquire_framebuffer
-from module.config_loader import load_settings, as_bool
+from module.config_loader import load_settings, as_bool, DEFAULT_SETTINGS_PATH
 import logging
 from flask_socketio import SocketIO
 import re
@@ -142,7 +142,7 @@ class SimpleGUI(threading.Thread):
         self.color_mode = "normal"
         
         # Load settings, not sure when the settings will be None so left the code here
-        self.settings = settings or load_settings("/home/pi/cinemate/settings.jsonc")
+        self.settings = settings or load_settings(DEFAULT_SETTINGS_PATH)
         
         self.setup_resources()
         self.display_poll_interval = 1.0

--- a/src/module/simple_gui.py
+++ b/src/module/simple_gui.py
@@ -5,7 +5,7 @@ import wave
 from PIL import Image, ImageDraw, ImageFont
 from module.console_display import claim_console_for_framebuffer, release_console_to_text
 from module.framebuffer import Framebuffer, acquire_framebuffer
-from module.config_loader import load_settings
+from module.config_loader import load_settings, as_bool
 import logging
 from flask_socketio import SocketIO
 import re
@@ -42,13 +42,6 @@ HDR_BADGE_COLOR = (205, 205, 205)   # lighter grey
 # Grey, distinct from both the plain CAM box grey (136,136,136) and the
 # DROP/SYNC alarm colours -- this is a calm mode indicator, not a warning.
 LOG_BADGE_COLOR = (205, 205, 205)
-
-
-def _to_bool(value) -> bool:
-    """Return *value* as bool, accepting common string variants."""
-    if isinstance(value, str):
-        return value.strip().lower() in {"1", "true", "yes", "on"}
-    return bool(value)
 
 
 def _to_int(value, default=None):
@@ -188,8 +181,8 @@ class SimpleGUI(threading.Thread):
         # Buffer VU meter and hatch line toggles from settings
         if settings is not None:
             overlays_cfg = settings.get("hdmi_display", {}).get("overlays", {})
-            self.show_buffer_vu = _to_bool(overlays_cfg.get("buffer_vu_meter", True))
-            self.vu_meter_hatch_lines = _to_bool(overlays_cfg.get("vu_meter_hatch_lines", True))
+            self.show_buffer_vu = as_bool(overlays_cfg.get("buffer_vu_meter", True))
+            self.vu_meter_hatch_lines = as_bool(overlays_cfg.get("vu_meter_hatch_lines", True))
         else:
             self.show_buffer_vu = True
             self.vu_meter_hatch_lines = True
@@ -270,7 +263,7 @@ class SimpleGUI(threading.Thread):
             self.width = int(self.redis_controller.get_value(ParameterKey.WIDTH.value) or 1920)
             self.height = int(self.redis_controller.get_value(ParameterKey.HEIGHT.value) or 1080)
             self.bit_depth = int(self.redis_controller.get_value(ParameterKey.BIT_DEPTH.value) or 10)
-            self.hdr = _to_bool(self.redis_controller.get_value(ParameterKey.HDR.value, 0))
+            self.hdr = as_bool(self.redis_controller.get_value(ParameterKey.HDR.value, 0))
             #logging.info(f"Loaded sensor values from Redis: width={self.width}, height={self.height}, bit_depth={self.bit_depth}")
         except ValueError:
             logging.error("Failed to load sensor values from Redis, using default values.")
@@ -397,8 +390,8 @@ class SimpleGUI(threading.Thread):
 
     def _display_restart_allowed(self) -> bool:
         return not (
-            _to_bool(self.redis_controller.get_value(ParameterKey.IS_RECORDING.value) or 0)
-            or _to_bool(self.redis_controller.get_value(ParameterKey.IS_WRITING.value) or 0)
+            as_bool(self.redis_controller.get_value(ParameterKey.IS_RECORDING.value) or 0)
+            or as_bool(self.redis_controller.get_value(ParameterKey.IS_WRITING.value) or 0)
         )
 
     def _maybe_restart_camera_for_display_attach(self):
@@ -708,7 +701,7 @@ class SimpleGUI(threading.Thread):
         self._maybe_refresh_slow_values()
         self.load_sensor_values_from_redis()
         resolution_value = self.estimate_resolution_in_k()
-        resolution_switching = _to_bool(
+        resolution_switching = as_bool(
             self.redis_controller.get_value(ParameterKey.RESOLUTION_SWITCHING.value, 0)
         )
         display_width = self.width

--- a/src/module/ssd_monitor.py
+++ b/src/module/ssd_monitor.py
@@ -26,7 +26,7 @@ except ImportError:
 # ----------------------------------------------------------------------
 # project-local imports
 # ----------------------------------------------------------------------
-from module.redis_controller import ParameterKey
+from module.redis_controller import ParameterKey, Event
 from module.config_loader import as_bool
 from module.storage_profiles import (
     DEFAULT_RECORDER_PROFILE,
@@ -51,24 +51,6 @@ YANK_ERRNOS = {
     getattr(errno, "ENOTCONN", errno.EIO),
     getattr(errno, "ESTALE", errno.EIO),
 }
-
-
-# ----------------------------------------------------------------------
-# Event helper
-# ----------------------------------------------------------------------
-class Event:
-    def __init__(self) -> None:
-        self._listeners = []
-
-    def subscribe(self, fn):
-        self._listeners.append(fn)
-
-    def emit(self, *args):
-        for cb in list(self._listeners):     # shallow copy – safe against rm
-            try:
-                cb(*args)
-            except Exception as exc:
-                logging.exception("Mount-event listener failed: %s", exc)
 
 
 # ----------------------------------------------------------------------

--- a/src/module/ssd_monitor.py
+++ b/src/module/ssd_monitor.py
@@ -27,6 +27,7 @@ except ImportError:
 # project-local imports
 # ----------------------------------------------------------------------
 from module.redis_controller import ParameterKey
+from module.config_loader import as_bool
 from module.storage_profiles import (
     DEFAULT_RECORDER_PROFILE,
     NO_STORAGE_FILESYSTEM,
@@ -1214,10 +1215,7 @@ class SSDMonitor:
         if self._redis:
             try:
                 raw_value = self._redis.get_value(ParameterKey.STORAGE_PREROLL_ACTIVE.value)
-                text = str(raw_value or "0").strip().lower()
-                preroll_active = text in ("1", "true", "yes", "on")
-                if not preroll_active:
-                    preroll_active = bool(int(text))
+                preroll_active = as_bool(raw_value)
             except (TypeError, ValueError, AttributeError):
                 preroll_active = False
         infos = []

--- a/src/module/ssd_monitor.py
+++ b/src/module/ssd_monitor.py
@@ -42,7 +42,7 @@ from module.storage_profiles import (
 # If your recorder uses a different Redis flag, change it here.
 # ----------------------------------------------------------------------
 REDIS_KEY_IS_RECORDING = ParameterKey.IS_RECORDING.value     # "1" while cinepi-raw is running
-REDIS_KEY_FSCK_STATUS  = "FSCK_STATUS"      # "OK …"  |  "FAIL …"
+REDIS_KEY_FSCK_STATUS  = ParameterKey.FSCK_STATUS.value       # "OK …"  |  "FAIL …"
 EXT4_MOUNT_OPTIONS = "rw,noatime,nodiratime,commit=60"
 YANK_ERRNOS = {
     errno.EIO,

--- a/src/module/usb_monitor.py
+++ b/src/module/usb_monitor.py
@@ -10,6 +10,8 @@ import shlex
 from collections import deque
 from typing import Optional
 
+from module.config_loader import as_bool
+
 CAPTURE_GAIN_REDIS_KEY = "audio_capture_gain_db"
 
 
@@ -526,13 +528,7 @@ class USBMonitor():
         if isinstance(value, bytes):
             value = value.decode("utf-8", errors="replace")
 
-        text = str(value or "").strip().lower()
-        if text in ("1", "true", "yes", "on"):
-            return True
-        try:
-            return bool(int(text))
-        except (TypeError, ValueError):
-            return False
+        return as_bool(value)
 
     def _cancel_audio_prepare_timer(self) -> None:
         with self.audio_prepare_lock:

--- a/src/module/usb_monitor.py
+++ b/src/module/usb_monitor.py
@@ -11,33 +11,11 @@ from collections import deque
 from typing import Optional
 
 from module.config_loader import as_bool
-from module.redis_controller import ParameterKey
+from module.redis_controller import ParameterKey, Event
 
 # F-106: this used to re-declare ParameterKey.AUDIO_CAPTURE_GAIN_DB's value as
 # an independent string literal. Same key, one definition now.
 CAPTURE_GAIN_REDIS_KEY = ParameterKey.AUDIO_CAPTURE_GAIN_DB.value
-
-
-class Event:
-    def __init__(self):
-        self._listeners = []
-
-    def subscribe(self, listener):
-        self._listeners.append(listener)
-
-    def emit(self, *args):
-        # Iterate a copy: a listener that subscribes/unsubscribes in response
-        # to its own event (mic hotswap handlers do this) would otherwise
-        # mutate self._listeners mid-iteration and raise RuntimeError, taking
-        # the whole emit -- and its caller's thread -- down with it.
-        for listener in list(self._listeners):
-            try:
-                listener(*args)
-            except Exception:
-                logging.exception(
-                    "usb_monitor listener %s failed; continuing with the rest",
-                    getattr(listener, "__qualname__", listener),
-                )
 
 
 

--- a/src/module/usb_monitor.py
+++ b/src/module/usb_monitor.py
@@ -1,7 +1,6 @@
 import contextlib
 import pyudev
 import logging
-import traceback
 import threading
 import re
 
@@ -22,12 +21,18 @@ class Event:
         self._listeners.append(listener)
 
     def emit(self, *args):
-        for listener in self._listeners:
+        # Iterate a copy: a listener that subscribes/unsubscribes in response
+        # to its own event (mic hotswap handlers do this) would otherwise
+        # mutate self._listeners mid-iteration and raise RuntimeError, taking
+        # the whole emit -- and its caller's thread -- down with it.
+        for listener in list(self._listeners):
             try:
                 listener(*args)
-            except Exception as e:
-                logging.error(f"Error while invoking listener: {e}")
-                traceback.print_exc()  # Print the traceback for better debugging
+            except Exception:
+                logging.exception(
+                    "usb_monitor listener %s failed; continuing with the rest",
+                    getattr(listener, "__qualname__", listener),
+                )
 
 
 

--- a/src/module/usb_monitor.py
+++ b/src/module/usb_monitor.py
@@ -11,8 +11,11 @@ from collections import deque
 from typing import Optional
 
 from module.config_loader import as_bool
+from module.redis_controller import ParameterKey
 
-CAPTURE_GAIN_REDIS_KEY = "audio_capture_gain_db"
+# F-106: this used to re-declare ParameterKey.AUDIO_CAPTURE_GAIN_DB's value as
+# an independent string literal. Same key, one definition now.
+CAPTURE_GAIN_REDIS_KEY = ParameterKey.AUDIO_CAPTURE_GAIN_DB.value
 
 
 class Event:
@@ -39,8 +42,9 @@ class Event:
 
 
 class AudioMonitor:
-    def __init__(self, settings: Optional[dict] = None):
+    def __init__(self, settings: Optional[dict] = None, redis_controller=None):
         self.settings = settings or {}
+        self._redis_controller = redis_controller
         self.format: Optional[str] = None
         self.channels: Optional[int] = None
         self.sample_rate: Optional[int] = None
@@ -73,23 +77,17 @@ class AudioMonitor:
             return 0.0
 
     def _refresh_capture_gain_from_redis(self) -> None:
-        try:
-            import redis  # type: ignore
-        except ModuleNotFoundError:
+        if self._redis_controller is None:
             return
 
         try:
-            client = redis.StrictRedis(host="localhost", port=6379, db=0)
-            value = client.get(CAPTURE_GAIN_REDIS_KEY)
+            value = self._redis_controller.get_value(CAPTURE_GAIN_REDIS_KEY)
         except Exception as exc:
             logging.debug("Could not read %s from Redis: %s", CAPTURE_GAIN_REDIS_KEY, exc)
             return
 
-        if value in (None, b"", ""):
+        if value in (None, ""):
             return
-
-        if isinstance(value, bytes):
-            value = value.decode("utf-8", errors="replace")
 
         self.capture_gain_db = self._parse_capture_gain_db(value)
 
@@ -374,11 +372,11 @@ class AudioMonitor:
     def publish_mic_selection(self) -> None:
         if not self.can_record_audio or not self.device_alias:
             return
+        if self._redis_controller is None:
+            logging.debug("No shared Redis client available; skipping MIC_* publish.")
+            return
         try:
-            import redis  # type: ignore
-
-            client = redis.StrictRedis(host="localhost", port=6379, db=0)
-            client.mset({
+            self._redis_controller.r.mset({
                 "MIC_PCM_ALIAS": self.device_alias,
                 "MIC_FORMAT": self.format or "",
                 "MIC_CHANNELS": str(self.channels or ""),
@@ -386,22 +384,18 @@ class AudioMonitor:
                 "MIC_CARD_NAME": self.card_name or "",
             })
             logging.debug("Published MIC_* to Redis")
-        except ModuleNotFoundError:
-            logging.debug("Redis module not available; skipping MIC_* publish.")
         except Exception as exc:  # pragma: no cover - redis optional
             logging.debug("Failed to publish MIC_* to Redis: %s", exc)
 
     @staticmethod
-    def clear_mic_selection(reason: str = "") -> None:
+    def clear_mic_selection(reason: str = "", redis_controller=None) -> None:
+        if redis_controller is None:
+            logging.debug("No shared Redis client available; skipping MIC_* clear.")
+            return
         try:
-            import redis  # type: ignore
-
-            client = redis.StrictRedis(host="localhost", port=6379, db=0)
-            client.delete("MIC_PCM_ALIAS", "MIC_FORMAT", "MIC_CHANNELS", "MIC_RATE", "MIC_CARD_NAME")
+            redis_controller.r.delete("MIC_PCM_ALIAS", "MIC_FORMAT", "MIC_CHANNELS", "MIC_RATE", "MIC_CARD_NAME")
             if reason:
                 logging.debug("Cleared MIC_* from Redis: %s", reason)
-        except ModuleNotFoundError:
-            logging.debug("Redis module not available; skipping MIC_* clear.")
         except Exception as exc:  # pragma: no cover - redis optional
             logging.debug("Failed to clear MIC_* from Redis: %s", exc)
 
@@ -477,12 +471,13 @@ class AudioMonitor:
         return self.vu_levels[0], self.vu_levels[1] if len(self.vu_levels) >= 2 else 0
 
 class USBMonitor():
-    def __init__(self, ssd_monitor, settings: Optional[dict] = None):
+    def __init__(self, ssd_monitor, settings: Optional[dict] = None, redis_controller=None):
         self.context = pyudev.Context()
         self.monitor = pyudev.Monitor.from_netlink(self.context)
 
         self.ssd_monitor = ssd_monitor
         self.settings = settings or {}
+        self._redis_controller = redis_controller
 
         self.temp_sound_devices = []
         self.sound_timer = None
@@ -507,26 +502,20 @@ class USBMonitor():
         self.audio_prepare_lock = threading.Lock()
         self.audio_prepare_deferred = False
         
-        self.audio_monitor = AudioMonitor(settings=self.settings)
-        
+        self.audio_monitor = AudioMonitor(settings=self.settings, redis_controller=self._redis_controller)
+
         self.monitor.filter_by(subsystem='usb_storage')
         self.monitor_devices()
 
     def _is_recording_active(self) -> bool:
-        try:
-            import redis  # type: ignore
-        except ModuleNotFoundError:
+        if self._redis_controller is None:
             return False
 
         try:
-            client = redis.StrictRedis(host="localhost", port=6379, db=0)
-            value = client.get("is_recording")
+            value = self._redis_controller.get_value(ParameterKey.IS_RECORDING.value)
         except Exception as exc:
             logging.debug("Could not read is_recording from Redis while preparing audio monitor: %s", exc)
             return False
-
-        if isinstance(value, bytes):
-            value = value.decode("utf-8", errors="replace")
 
         return as_bool(value)
 
@@ -611,8 +600,11 @@ class USBMonitor():
             # Stop old monitor and create a fresh one bound to this mic
             with contextlib.suppress(Exception):
                 self.audio_monitor.stop()
-            AudioMonitor.clear_mic_selection("microphone changed; waiting for re-probe")
-            self.audio_monitor = AudioMonitor(settings=self.settings)
+            AudioMonitor.clear_mic_selection(
+                "microphone changed; waiting for re-probe",
+                redis_controller=self._redis_controller,
+            )
+            self.audio_monitor = AudioMonitor(settings=self.settings, redis_controller=self._redis_controller)
             self.audio_monitor.set_model_info(model, serial, card_num=card_num, card_name=card_name)
             self.current_mic_id = mic_id
             # Let ALSA settle briefly, then probe the current monitor config without owning capture.
@@ -699,7 +691,9 @@ class USBMonitor():
                 self.temp_sound_devices.clear()
                 self.usb_event.emit('mic_removed', device, model, serial)
                 self.audio_monitor.stop()
-                AudioMonitor.clear_mic_selection("microphone removed")
+                AudioMonitor.clear_mic_selection(
+                    "microphone removed", redis_controller=self._redis_controller
+                )
 
 
             elif self.usb_keyboard and self.usb_keyboard == device:

--- a/src/module/wifi_hotspot.py
+++ b/src/module/wifi_hotspot.py
@@ -25,7 +25,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Final, NamedTuple, Optional
 
-from module.config_loader import SettingsLoadError, load_settings
+from module.config_loader import SettingsLoadError, load_settings, DEFAULT_SETTINGS_PATH
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +41,7 @@ __all__ = [
 # ---------------------------------------------------------------------------
 DEFAULT_SSID:  Final[str] = "CinePi"
 DEFAULT_PASS:  Final[str] = "11111111"  # 8 chars → nmcli minimum
-SETTINGS_PATH: Final[Path] = Path("/home/pi/cinemate/settings.jsonc")
+SETTINGS_PATH: Final[Path] = Path(DEFAULT_SETTINGS_PATH)
 READY_STATES: Final[set[str]] = {"connected", "connected (externally)", "disconnected"}
 
 #: Root-owned runtime state. Created by the installer and, failing that, by the


### PR DESCRIPTION
B9's Pi-free commits. B9.1 (storage facts) and B9.4 (cross-repo formulas) are excluded — both want hardware.

**The first commit is a bug fix, not a cleanup.** `cinepi_multi.py`'s `Event.emit` had no `try/except` and no listener-list copy — F-204's exact defect, unfixed, in a fourth copy. It is live: `main.py:36` imports `CinePiManager` and `self.message.emit(line)` fans out cinepi-raw's subprocess output, so one raising subscriber silently stopped the log relay. `usb_monitor.py`'s copy had the same missing list copy by a different route. PI-014 confirmed this failure shape on hardware for the redis bus.

Then the duplication collapse, grouped by which *fact* is duplicated:

- **F-126** — four `_as_bool` implementations that disagreed: `_as_bool(2)` was `True` in `gpio_input` and `False` in the other three, and an arbitrary object was `True` there and `False` elsewhere. The canonical pair already existed at `config_loader.py:10-11` (`_TRUE_VALUES`/`_FALSE_VALUES` — the only version able to distinguish *explicitly false* from *unrecognised*).
- **F-105/F-106/F-015/F-028** — one Redis client; `ParameterKey` enforcement.
- **B9.5** — config defaults stated in several languages, now with checks.
- **F-127** — the four `class Event` definitions collapsed into one.
- **B9.7** — the web GUI's derived labels and DROP count.

Plan: `REMEDIATION-PLAN.md` §3 batch B9.

## Review notes

- This is the broadest diff in flight (26 files) and overlaps `settings_editor.py`, `template.html` and `cinepi_controller.py` with the B11 branches — worth landing early so the smaller branches rebase onto it rather than the reverse.
- Two B9.2 decisions should be visible in the code or the tests rather than implied: what a **number** means, and what an **unrecognised string** means. `_FALSE_VALUES` makes the second answerable rather than silent.
- F-221 records the recovery console's isolation as a strength to preserve — if any Redis client change is reachable from it, that one should have been left alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBku1dDuju5t762UogsJRq)_