### PR TITLE
B11.3 + B11.4 + B11.6 · preview reload timing, a working Restart, raw pane buttons

### DIFF
--- a/_test/test_cinepi_controller_resolution_gui.py
+++ b/_test/test_cinepi_controller_resolution_gui.py
@@ -108,6 +108,7 @@ class ResolutionGuiStateTests(unittest.TestCase):
         controller.update_steps = lambda: None
         controller._notify_resolution_change = controller.notifications.append
         controller._resolution_switching_timer = None
+        controller._resolution_switch_complete_callbacks = []
 
         def refresh_fps_max():
             controller.fps_max = 50
@@ -232,6 +233,55 @@ class ResolutionGuiStateTests(unittest.TestCase):
             controller.redis_controller.get_value(ParameterKey.RESOLUTION_SWITCHING.value),
             0,
         )
+
+    def test_raw_stream_ready_log_fires_switch_complete_not_switch_started(self):
+        # F-290: reload_stream must ride the completion signal, not the one
+        # that fires when the switch starts (the browser would reconnect to
+        # a stream cinepi-raw hasn't finished restarting yet).
+        controller = self.controller()
+        resolution_info = controller.sensor_detect.res_modes[1]
+        controller._publish_resolution_target_state(1, resolution_info, switching=True)
+        controller._resolution_switching_timer = mock.Mock()
+        complete_calls = []
+        controller.add_resolution_switch_complete_callback(lambda: complete_calls.append(1))
+
+        controller.handle_cinepi_raw_message(
+            "[2026-05-31 18:00:31.405] [event_loop] [info] Raw stream: 3856x2180 : 7712 : SRGGB16"
+        )
+
+        self.assertEqual(complete_calls, [1])
+
+    def test_nonmatching_raw_stream_log_does_not_fire_switch_complete(self):
+        controller = self.controller()
+        resolution_info = controller.sensor_detect.res_modes[1]
+        controller._publish_resolution_target_state(1, resolution_info, switching=True)
+        controller._resolution_switching_timer = mock.Mock()
+        complete_calls = []
+        controller.add_resolution_switch_complete_callback(lambda: complete_calls.append(1))
+
+        controller.handle_cinepi_raw_message(
+            "[2026-05-31 18:00:31.405] [event_loop] [info] Raw stream: 1928x1090 : 3904 : SRGGB16"
+        )
+
+        self.assertEqual(complete_calls, [])
+
+    def test_switch_complete_timer_fallback_fires_the_callback(self):
+        # The evidence path (handle_cinepi_raw_message) is the fast path;
+        # this is the fallback if that log line is never seen.
+        controller = self.controller()
+        resolution_info = controller.sensor_detect.res_modes[1]
+        complete_calls = []
+        controller.add_resolution_switch_complete_callback(lambda: complete_calls.append(1))
+
+        with mock.patch.object(cinepi_controller_module.threading, "Timer") as fake_timer_cls:
+            fake_timer = mock.Mock()
+            fake_timer_cls.return_value = fake_timer
+            controller._schedule_resolution_switch_complete(1, resolution_info)
+            complete_fn = fake_timer_cls.call_args.args[1]
+
+        self.assertEqual(complete_calls, [])  # not fired until the timer actually runs
+        complete_fn()
+        self.assertEqual(complete_calls, [1])
 
     def test_nonmatching_raw_stream_log_does_not_clear_resolution_switching(self):
         controller = self.controller()

--- a/_test/test_restart_cinemate.py
+++ b/_test/test_restart_cinemate.py
@@ -1,0 +1,69 @@
+"""Restarting Cinemate must not kill its own web server (F-291).
+
+os.execl() re-execs the process in place, but the Flask/SocketIO listening
+socket survives exec() (it isn't marked close-on-exec) -- confirmed by a
+standalone repro against real hardware (system-review/FINDINGS.md), the
+re-exec'd process failed to rebind its port and the web GUI stayed dead.
+
+restart_cinemate() now asks systemd to do a real restart instead, which
+tears the whole process down first -- routed through `systemd-run` rather
+than a direct `systemctl restart` because the direct form is a child of
+this process, so it lives in cinemate-autostart.service's own cgroup and
+gets killed by the unit's own stop signal (KillMode=control-group) before
+the restart job is even queued -- also confirmed on real hardware, exiting
+with returncode -2.
+"""
+
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+sys.modules.setdefault("redis", types.SimpleNamespace(StrictRedis=object))
+sys.modules.setdefault("smbus", types.SimpleNamespace(SMBus=object))
+
+from module.cinepi_controller import CinePiController
+
+
+class RestartCinemateTests(unittest.TestCase):
+    def controller(self):
+        return CinePiController.__new__(CinePiController)
+
+    def test_restarts_via_systemd_run_not_execl(self):
+        controller = self.controller()
+        with mock.patch("subprocess.run") as run, mock.patch("os.execl") as execl:
+            run.return_value = types.SimpleNamespace(returncode=0, stdout="", stderr="")
+            controller.restart_cinemate()
+
+        execl.assert_not_called()
+        run.assert_called_once()
+        cmd = run.call_args.args[0]
+        self.assertEqual(
+            cmd,
+            [
+                "sudo", "-n", "systemd-run", "--no-block", "--collect",
+                "--unit=cinemate-restart-trigger",
+                "--", "systemctl", "restart", "cinemate-autostart",
+            ],
+        )
+
+    def test_a_failed_restart_is_logged_not_raised(self):
+        controller = self.controller()
+        with mock.patch(
+            "subprocess.run",
+            return_value=types.SimpleNamespace(returncode=1, stdout="", stderr="sudo: a password is required"),
+        ):
+            controller.restart_cinemate()  # must not raise
+
+    def test_an_unavailable_sudo_binary_is_logged_not_raised(self):
+        controller = self.controller()
+        with mock.patch("subprocess.run", side_effect=OSError("sudo not found")):
+            controller.restart_cinemate()  # must not raise
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cinemate-install.sh
+++ b/cinemate-install.sh
@@ -1559,6 +1559,7 @@ $PI_USER ALL=(ALL) NOPASSWD: $PI_HOME/run_cinemate.sh
 $PI_USER ALL=(ALL) NOPASSWD: $CINEMATE_DIR/src/main.py
 $PI_USER ALL=(ALL) NOPASSWD: /bin/mount, /bin/umount, /usr/bin/ntfs-3g
 $PI_USER ALL=(ALL) NOPASSWD: /sbin/mount.ext4
+$PI_USER ALL=(ALL) NOPASSWD: /usr/bin/systemd-run --no-block --collect --unit=cinemate-restart-trigger -- systemctl restart cinemate-autostart
 EOF
     sudo visudo -cf /etc/sudoers.d/pi_cinemate >/dev/null
     detail "sudoers validation passed"

--- a/src/module/app/__init__.py
+++ b/src/module/app/__init__.py
@@ -19,6 +19,10 @@ def create_app(redis_controller, cinepi_controller, simple_gui, sensor_detect,
 
     if hasattr(cinepi_controller, 'add_resolution_change_callback'):
         def emit_resolution_change(sensor_mode):
+            # Fires when the switch *starts* -- lets the browser show a
+            # "switching..." state immediately. Must not carry reload_stream:
+            # cinepi-raw is still restarting at this point, so the preview
+            # <img> would reconnect to a stream that doesn't exist yet (F-290).
             socketio.emit('resolution_change', {
                 'sensor_mode': sensor_mode,
                 'resolution_switching': redis_controller.get_value(
@@ -26,9 +30,18 @@ def create_app(redis_controller, cinepi_controller, simple_gui, sensor_detect,
                     "0",
                 ),
             })
-            socketio.emit('reload_stream')
 
         cinepi_controller.add_resolution_change_callback(emit_resolution_change)
+
+    if hasattr(cinepi_controller, 'add_resolution_switch_complete_callback'):
+        def emit_reload_stream():
+            # Fires when the switch actually *completes* -- either evidence
+            # from cinepi-raw's own "Raw stream: WxH" log line, or (if that
+            # never arrives) the switching-hold fallback timer. Either way
+            # the new stream exists by the time this runs (F-290).
+            socketio.emit('reload_stream')
+
+        cinepi_controller.add_resolution_switch_complete_callback(emit_reload_stream)
 
     app.config['REDIS_CONTROLLER'] = redis_controller
     app.config['CINEPI_CONTROLLER'] = cinepi_controller

--- a/src/module/app/settings_editor.py
+++ b/src/module/app/settings_editor.py
@@ -34,6 +34,7 @@ from module.config_loader import (
 )
 from module.app import boot_config, raw_files
 from module.jsonc_edit import apply_updates
+from module.web_api_settings import web_api_settings
 
 logger = logging.getLogger(__name__)
 
@@ -124,7 +125,8 @@ def _public_method_names(obj) -> set[str]:
 
 @settings_editor_bp.route("/")
 def index():
-    return render_template("settings_editor.html")
+    settings = current_app.config["SETTINGS"]
+    return render_template("settings_editor.html", api_token=web_api_settings(settings).get("token") or "")
 
 
 @settings_editor_bp.route("/api/settings", methods=["GET"])

--- a/src/module/app/templates/settings_editor.html
+++ b/src/module/app/templates/settings_editor.html
@@ -619,7 +619,7 @@
   .bulk-bar{
     display:none; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap;
     padding: 10px 14px; border: 1px solid var(--accent); background: var(--accent-soft);
-    border-radius: var(--radius); margin-bottom: 10px; font-size: 13px;
+    border-radius: var(--radius); margin-top: 10px; font-size: 13px;
   }
   .bulk-bar.show{ display:flex; }
   .bulk-bar .actions{ display:flex; gap:8px; }
@@ -2056,6 +2056,11 @@
         <button class="btn btn-ghost" id="refreshClips" style="margin-left:auto">Refresh</button>
       </div>
 
+      <div class="cliplist" id="clipList"></div>
+      <p class="card-help" id="clipListFooter" style="margin-top:10px"></p>
+
+      <!-- F-295: below the list, not above -- these buttons act on the
+           selection the operator just made in the list above them. -->
       <div class="bulk-bar" id="bulkBar">
         <span id="bulkCount">0 selected</span>
         <span class="actions">
@@ -2063,9 +2068,6 @@
           <button class="btn btn-danger-outline" id="bulkDelete">Delete selected</button>
         </span>
       </div>
-
-      <div class="cliplist" id="clipList"></div>
-      <p class="card-help" id="clipListFooter" style="margin-top:10px"></p>
     </section>
 
     <!-- BOOT CONFIG -->
@@ -2237,6 +2239,17 @@
 (function(){
   "use strict";
   var reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  /* ---------- /api/v1/cmd -- same dispatcher as the CLI, serial and GPIO
+     paths (docs/web-api.md), matches template.html's cmd() ---------- */
+  var API_TOKEN = {{ api_token | tojson }};
+  function apiCmd(line){
+    var headers = { 'Content-Type': 'text/plain' };
+    if (API_TOKEN) { headers['X-Cinemate-Token'] = API_TOKEN; }
+    return fetch('/api/v1/cmd', { method: 'POST', headers: headers, body: line })
+      .then(function(res){ return res.text().then(function(body){ return { ok: res.ok, body: body.trim() }; }); })
+      .catch(function(err){ return { ok: false, body: err.message }; });
+  }
 
   /* ---------- state / dirty tracking ---------- */
   var dirtyEls = new Set();
@@ -3656,11 +3669,24 @@
     { t: '[cinemate] ready — iso 800 · 172.8° · 25 fps', cls: 'tag-ok' }
   ];
   restartBtn.addEventListener('click', function(){
-    runBootSequence({
-      btn: restartBtn, dot: statusDot, text: statusText, consoleEl: consoleEl, lines: bootLines,
-      busyText: 'Restarting Cinemate — <b class="din">please wait</b>',
-      readyText: 'Cinemate is running — <b class="din">READY</b>',
-      doneToast: 'Cinemate is back up'
+    // F-291: this used to only play the boot-sequence animation below and
+    // never actually asked the backend to restart anything. The animated
+    // lines are still a stylized "please wait" affordance, not a live log
+    // -- there is no streaming progress feed for this today -- but the
+    // restart itself is now real, gated on a successful /api/v1/cmd call.
+    restartBtn.disabled = true;
+    apiCmd('restart cinemate').then(function(result){
+      if (!result.ok) {
+        restartBtn.disabled = false;
+        showToast('Restart failed: ' + (result.body || 'unknown error'));
+        return;
+      }
+      runBootSequence({
+        btn: restartBtn, dot: statusDot, text: statusText, consoleEl: consoleEl, lines: bootLines,
+        busyText: 'Restarting Cinemate — <b class="din">please wait</b>',
+        readyText: 'Cinemate is running — <b class="din">READY</b>',
+        doneToast: 'Cinemate is back up'
+      });
     });
   });
 

--- a/src/module/cinepi_controller.py
+++ b/src/module/cinepi_controller.py
@@ -7,7 +7,6 @@ import json
 import subprocess
 from threading import Timer
 import psutil
-import sys
 
 from module.redis_controller import ParameterKey, encode_log_encode_request, decode_log_encode_request
 from module.sensor_detect import compute_frame_size_mb

--- a/src/module/cinepi_controller.py
+++ b/src/module/cinepi_controller.py
@@ -134,6 +134,7 @@ class CinePiController:
         self._storage_profile_restart_lock = threading.Lock()
         self._storage_profile_restart_active = False
         self._resolution_change_callbacks = []
+        self._resolution_switch_complete_callbacks = []
         self._resolution_change_pace_lock = threading.Lock()
         self._last_resolution_change_started_at = 0.0
         self._resolution_change_min_interval_s = 0.25
@@ -1099,12 +1100,31 @@ class CinePiController:
             return
         self._resolution_change_callbacks.append(callback)
 
+    def add_resolution_switch_complete_callback(self, callback) -> None:
+        if not callable(callback):
+            logging.warning("Ignoring non-callable resolution switch-complete callback.")
+            return
+        self._resolution_switch_complete_callbacks.append(callback)
+
     def _notify_resolution_change(self, sensor_mode) -> None:
         for callback in list(self._resolution_change_callbacks):
             try:
                 callback(sensor_mode)
             except Exception:
                 logging.exception("Resolution change callback failed.")
+
+    def _notify_resolution_switch_complete(self) -> None:
+        # Fires once the switch is actually over -- either handle_cinepi_raw_message
+        # saw evidence the new stream is up, or (if that message never arrived)
+        # the GUI_RESOLUTION_SWITCHING_HOLD_SECONDS fallback timer expired. This
+        # is deliberately a separate hook from _notify_resolution_change: that one
+        # fires when the switch *starts*, so the browser can show "switching..."
+        # immediately, well before there is a new stream to reconnect to (F-290).
+        for callback in list(self._resolution_switch_complete_callbacks):
+            try:
+                callback()
+            except Exception:
+                logging.exception("Resolution switch-complete callback failed.")
 
     def _pace_resolution_change(self, recording: bool) -> None:
         min_interval = (
@@ -1665,6 +1685,7 @@ class CinePiController:
                 )
             except Exception:
                 logging.exception("Failed to clear resolution switching state.")
+            self._notify_resolution_switch_complete()
 
         timer = threading.Timer(GUI_RESOLUTION_SWITCHING_HOLD_SECONDS, complete)
         timer.daemon = True
@@ -1695,6 +1716,7 @@ class CinePiController:
 
         self._cancel_resolution_switching_timer()
         self.redis_controller.set_value(ParameterKey.RESOLUTION_SWITCHING.value, 0)
+        self._notify_resolution_switch_complete()
 
     def _apply_resolution_mode(self, value, restore_user_fps=None, *, restart_process=False):
         try:
@@ -2376,11 +2398,60 @@ class CinePiController:
         self._active_storage_recorder_profile = self._current_storage_recorder_profile()
 
     def restart_cinemate(self):
-        """Restart the entire CineMate application."""
-        logging.info("Restarting CineMate application")
-        python = sys.executable
-        os.execl(python, python, *sys.argv)
-        
+        """Restart the entire CineMate application (F-291).
+
+        This used to os.execl() in place. Confirmed by a minimal repro under
+        F-291 (see system-review/FINDINGS.md): the Flask/SocketIO listening
+        socket is not closed by exec() (it isn't marked close-on-exec), so
+        the re-exec'd process failed to rebind its port -- "Address already
+        in use" -- and the web GUI stayed dead until an external `systemctl
+        restart`. sys.argv/sys.executable were both fine; the socket was the
+        actual bug. systemd already owns this unit's lifecycle and a real
+        restart tears the whole process down, closing every fd first, so it
+        goes through systemd instead.
+
+        A first version called `sudo systemctl restart --no-block
+        cinemate-autostart` directly -- also confirmed against real hardware
+        to be wrong: that subprocess is a child of *this* process, so it
+        lives in cinemate-autostart.service's own cgroup. The unit's
+        KillMode=control-group (systemd's default) means the SIGINT that
+        stops the old instance is swept across the whole cgroup, including
+        the very systemctl call requesting the restart -- it was observed
+        exiting -2 (killed) before the restart job was even queued, so
+        nothing ever started back up. Routing through `systemd-run` escapes
+        that cgroup: it hands the actual `systemctl restart` off to a fresh
+        transient unit of its own, which the SIGINT sweep can't touch.
+        --no-block on systemd-run itself means this call returns as soon as
+        that hand-off is queued, not once the restart finishes (see the
+        --no-block note below).
+
+        Both commands are exactly what cinemate-install.sh's
+        configure_sudoers() grants -- one narrow, argument-locked rule per
+        command, not a general privileged-exec grant.
+
+        --no-block: this call runs inside the very unit systemd is about to
+        stop. A blocking call would wait for that stop to finish, and that
+        stop is what kills the thread making this call.
+        """
+        logging.info("Restarting CineMate application via systemd")
+        try:
+            result = subprocess.run(
+                [
+                    "sudo", "-n", "systemd-run", "--no-block", "--collect",
+                    "--unit=cinemate-restart-trigger",
+                    "--", "systemctl", "restart", "cinemate-autostart",
+                ],
+                capture_output=True, text=True, timeout=10, check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            logging.error("Could not invoke systemd-run to restart cinemate-autostart: %s", exc)
+            return
+        if result.returncode != 0:
+            logging.error(
+                "systemd-run restart of cinemate-autostart exited %s: %s",
+                result.returncode, (result.stderr or result.stdout or "").strip(),
+            )
+
 
     def set_fps_double(self, value=None):
         target_double_state = not self.fps_double if value is None else value in (1, True)


### PR DESCRIPTION
Three of the smaller field-reported defects.

- **F-290** — the preview `<img>` was told to reconnect *before* the new stream existed. The client machinery was already correct (`template.html:914` re-attaches with a cache-buster); the emit rode `_notify_resolution_change` at `cinepi_controller.py:1749`, which fires at switch **initiation**, one line before `_schedule_resolution_switch_complete`. Moved to the completion path.
- **F-291** — "Restart Cinemate" did not restart. `os.execl(sys.executable, sys.executable, *sys.argv)` from a `threading.Timer` while the SocketIO server held listening sockets.
- **F-295** — raw pane: "download selected" and "delete selected" moved below the list they act on.

Plan: `REMEDIATION-PLAN.md` §3 batch B11, findings F-290/F-291/F-295.

## Review notes

- **F-291's root cause should be stated, not just fixed** — the finding was filed `unverified` with three candidates. If restarting now goes through systemd rather than re-execing in place, that is the more honest fix, but note F-283's lesson about this codebase driving systemd from inside its own stop path.
- For F-290, whether `_schedule_resolution_switch_complete` fires on a timer or on evidence the stream is serving decides whether a retry in `reloadStreams()` is also needed.
- Overlaps `settings_editor.py` and `cinemate-install.sh` with #142, and `cinepi_controller.py` with #143 — rebase after those land.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBku1dDuju5t762UogsJRq)_