### PR TITLE
Merge B11 — eleven field-reported defects

### DIFF
--- a/_test/test_boot_config_write.py
+++ b/_test/test_boot_config_write.py
@@ -1,0 +1,109 @@
+"""config.txt saves must not silently fail as User=pi (F-288).
+
+/boot/firmware is root-owned; the settings editor runs unprivileged, so a
+direct write there raises PermissionError before a byte is written. That
+case must fall back to staging the text somewhere pi-writable and handing
+it to the privileged helper cinemate-install.sh's configure_sudoers()
+grants -- and a failure in that fallback must not leave a staged file
+behind.
+"""
+
+import os
+import stat
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+sys.modules.setdefault("redis", types.SimpleNamespace(StrictRedis=object))
+
+from module.app import boot_config
+
+
+class WriteConfigTxtDirectTests(unittest.TestCase):
+    def setUp(self):
+        self.dir = Path(tempfile.mkdtemp())
+        self.dest = self.dir / "config.txt"
+        self.dest.write_text("original\n", encoding="utf-8")
+        self.patched = mock.patch.object(boot_config, "CONFIG_TXT_PATH", str(self.dest))
+        self.patched.start()
+        self.addCleanup(self.patched.stop)
+
+    def test_writes_directly_when_the_destination_is_writable(self):
+        boot_config.write_config_txt("new content\n")
+        self.assertEqual(self.dest.read_text(encoding="utf-8"), "new content\n")
+
+    def test_direct_write_leaves_no_temp_file_behind(self):
+        boot_config.write_config_txt("new content\n")
+        leftovers = list(self.dir.glob(".settings-editor-*"))
+        self.assertEqual(leftovers, [])
+
+
+class WriteConfigTxtFallbackTests(unittest.TestCase):
+    """Simulates the real /boot/firmware permission wall with a read-only
+    directory, so the fallback path exercises a genuine PermissionError
+    rather than a mocked one."""
+
+    def setUp(self):
+        self.root_dir = Path(tempfile.mkdtemp())
+        self.readonly_dir = self.root_dir / "firmware"
+        self.readonly_dir.mkdir()
+        self.dest = self.readonly_dir / "config.txt"
+        self.dest.write_text("original\n", encoding="utf-8")
+        self.readonly_dir.chmod(0o555)
+        self.addCleanup(self.readonly_dir.chmod, 0o755)
+
+        self.staging_dir = Path(tempfile.mkdtemp())
+        self.staged = self.staging_dir / "config.txt.staged"
+
+        self.patches = [
+            mock.patch.object(boot_config, "CONFIG_TXT_PATH", str(self.dest)),
+            mock.patch.object(boot_config, "STAGED_CONFIG_TXT_PATH", str(self.staged)),
+        ]
+        for p in self.patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+        if os.geteuid() == 0:
+            self.skipTest("root bypasses the read-only directory this test relies on")
+
+    def test_falls_back_to_the_helper_on_permission_denied(self):
+        def fake_helper(cmd, **kwargs):
+            # Stands in for cinemate-apply-config-txt: read the staged file,
+            # write it to dest (which the real helper can because it runs
+            # as root; here we bypass the chmod ourselves for the same
+            # effect).
+            self.readonly_dir.chmod(0o755)
+            self.dest.write_text(self.staged.read_text(encoding="utf-8"), encoding="utf-8")
+            self.readonly_dir.chmod(0o555)
+            return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        with mock.patch("subprocess.run", side_effect=fake_helper) as run:
+            boot_config.write_config_txt("staged via helper\n")
+
+        run.assert_called_once()
+        called_cmd = run.call_args.args[0]
+        self.assertEqual(called_cmd, ["sudo", "-n", boot_config.APPLY_CONFIG_TXT_HELPER])
+        self.readonly_dir.chmod(0o755)
+        self.assertEqual(self.dest.read_text(encoding="utf-8"), "staged via helper\n")
+
+    def test_a_failed_helper_raises_and_cleans_up_the_staged_file(self):
+        with mock.patch(
+            "subprocess.run",
+            return_value=types.SimpleNamespace(returncode=1, stdout="", stderr="sudo: a password is required"),
+        ):
+            with self.assertRaises(PermissionError):
+                boot_config.write_config_txt("should not land\n")
+
+        self.assertFalse(self.staged.exists())
+        self.readonly_dir.chmod(0o755)
+        self.assertEqual(self.dest.read_text(encoding="utf-8"), "original\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_test/test_cinepi_controller_resolution_gui.py
+++ b/_test/test_cinepi_controller_resolution_gui.py
@@ -108,6 +108,7 @@ class ResolutionGuiStateTests(unittest.TestCase):
         controller.update_steps = lambda: None
         controller._notify_resolution_change = controller.notifications.append
         controller._resolution_switching_timer = None
+        controller._resolution_switch_complete_callbacks = []
 
         def refresh_fps_max():
             controller.fps_max = 50
@@ -232,6 +233,55 @@ class ResolutionGuiStateTests(unittest.TestCase):
             controller.redis_controller.get_value(ParameterKey.RESOLUTION_SWITCHING.value),
             0,
         )
+
+    def test_raw_stream_ready_log_fires_switch_complete_not_switch_started(self):
+        # F-290: reload_stream must ride the completion signal, not the one
+        # that fires when the switch starts (the browser would reconnect to
+        # a stream cinepi-raw hasn't finished restarting yet).
+        controller = self.controller()
+        resolution_info = controller.sensor_detect.res_modes[1]
+        controller._publish_resolution_target_state(1, resolution_info, switching=True)
+        controller._resolution_switching_timer = mock.Mock()
+        complete_calls = []
+        controller.add_resolution_switch_complete_callback(lambda: complete_calls.append(1))
+
+        controller.handle_cinepi_raw_message(
+            "[2026-05-31 18:00:31.405] [event_loop] [info] Raw stream: 3856x2180 : 7712 : SRGGB16"
+        )
+
+        self.assertEqual(complete_calls, [1])
+
+    def test_nonmatching_raw_stream_log_does_not_fire_switch_complete(self):
+        controller = self.controller()
+        resolution_info = controller.sensor_detect.res_modes[1]
+        controller._publish_resolution_target_state(1, resolution_info, switching=True)
+        controller._resolution_switching_timer = mock.Mock()
+        complete_calls = []
+        controller.add_resolution_switch_complete_callback(lambda: complete_calls.append(1))
+
+        controller.handle_cinepi_raw_message(
+            "[2026-05-31 18:00:31.405] [event_loop] [info] Raw stream: 1928x1090 : 3904 : SRGGB16"
+        )
+
+        self.assertEqual(complete_calls, [])
+
+    def test_switch_complete_timer_fallback_fires_the_callback(self):
+        # The evidence path (handle_cinepi_raw_message) is the fast path;
+        # this is the fallback if that log line is never seen.
+        controller = self.controller()
+        resolution_info = controller.sensor_detect.res_modes[1]
+        complete_calls = []
+        controller.add_resolution_switch_complete_callback(lambda: complete_calls.append(1))
+
+        with mock.patch.object(cinepi_controller_module.threading, "Timer") as fake_timer_cls:
+            fake_timer = mock.Mock()
+            fake_timer_cls.return_value = fake_timer
+            controller._schedule_resolution_switch_complete(1, resolution_info)
+            complete_fn = fake_timer_cls.call_args.args[1]
+
+        self.assertEqual(complete_calls, [])  # not fired until the timer actually runs
+        complete_fn()
+        self.assertEqual(complete_calls, [1])
 
     def test_nonmatching_raw_stream_log_does_not_clear_resolution_switching(self):
         controller = self.controller()

--- a/_test/test_custom_modes_fps_override.py
+++ b/_test/test_custom_modes_fps_override.py
@@ -1,0 +1,127 @@
+"""custom_modes must be able to correct a detected fps_max, not just add to
+it (F-298). Before this fix, an entry whose dimensions matched an already-
+detected mode was appended as a second, duplicate mode instead of
+overriding the first -- so a sensor's advertised ceiling (an electrical
+property, not a measure of what this storage/CPU can sustain) could never
+actually be corrected downward from settings.jsonc.
+"""
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from module.config_loader import strip_jsonc
+from module.dynamic_resolution import choose_resolution
+from module.sensor_detect import SensorDetect
+
+
+IMX585_LIST_CAMERAS_OUTPUT = """
+0 : imx585 [3856x2180] (/base/soc/i2c0mux/i2c@1/imx585@1a)
+    Modes: 'SRGGB12_CSI2P' : 1928x1090 [87.00 fps - (0, 0)/3856x2180 crop]
+                              3856x2180 [40.00 fps - (0, 0)/3856x2180 crop]
+"""
+
+
+def _build_detector(custom_modes):
+    settings = json.loads(strip_jsonc(
+        (ROOT / "resources/settings/settings_default.jsonc").read_text(encoding="utf-8")
+    ))
+    rc = settings["image_capture"]
+    detector = SensorDetect.__new__(SensorDetect)
+    detector.settings = settings
+    detector.k_steps = rc["k_steps"]
+    detector.bit_depths = rc["bit_depths"]
+    detector.custom_modes = custom_modes
+    detector.hdr_modes = SensorDetect._hdr_whitelist(rc.get("hdr", {}))
+    detector.sensor_database_file = "resources/sensors.json"
+    detector.sensor_database = detector._load_sensor_database()
+    detector.packing_info = detector._packing_info_from_database()
+    return detector
+
+
+def _modes_by_resolution(detector):
+    base = detector._parse_cinepi_output(IMX585_LIST_CAMERAS_OUTPUT)
+    finalized = detector._finalize_modes(detector._merge_mode_lists(base, {}))
+    return {
+        (mode["width"], mode["height"]): mode
+        for mode in finalized["imx585"].values()
+    }, finalized["imx585"]
+
+
+class CustomModesFpsOverrideTests(unittest.TestCase):
+    def test_no_override_keeps_the_detected_ceiling(self):
+        by_res, _ = _modes_by_resolution(_build_detector({}))
+        self.assertEqual(by_res[(1928, 1090)]["fps_max"], 87.0)
+
+    def test_matching_custom_mode_overrides_fps_max_in_place(self):
+        detector = _build_detector({
+            "imx585": [{"width": 1928, "height": 1090, "bit_depth": 12, "fps_max": 60}],
+        })
+        by_res, indexed = _modes_by_resolution(detector)
+
+        self.assertEqual(by_res[(1928, 1090)]["fps_max"], 60)
+        # Overriding must not produce a duplicate -- one entry per resolution.
+        matching = [m for m in indexed.values() if (m["width"], m["height"]) == (1928, 1090)]
+        self.assertEqual(len(matching), 1)
+
+    def test_non_matching_custom_mode_still_appends(self):
+        detector = _build_detector({
+            "imx585": [{"width": 2028, "height": 1520, "bit_depth": 12, "fps_max": 30}],
+        })
+        by_res, _ = _modes_by_resolution(detector)
+
+        self.assertIn((2028, 1520), by_res)
+        self.assertEqual(by_res[(2028, 1520)]["fps_max"], 30)
+        # The detected modes are both still there, untouched.
+        self.assertEqual(by_res[(1928, 1090)]["fps_max"], 87.0)
+        self.assertEqual(by_res[(3856, 2180)]["fps_max"], 40)
+
+    def test_overriding_a_mode_lower_changes_which_mode_choose_resolution_picks(self):
+        """The actual point of F-298: the operator found by trial that this
+        storage can't sustain the sensor's advertised fps_max at its
+        largest mode, so they cap it lower in settings.jsonc.
+        choose_resolution() needs no change -- it still just looks at
+        fps_max, which the sensor_detect.py fix above now lets settings.jsonc
+        actually correct -- but the *selection* must consequently fall back
+        to a smaller mode it would previously have skipped, once the big
+        mode's capped fps_max can no longer sustain the request.
+
+        This exercises choose_resolution() directly with hand-built mode
+        dicts (same style as test_dynamic_resolution.py) rather than
+        routing through _finalize_modes()'s k_steps/bit_depths filtering,
+        which is orthogonal to this fix and would just be noise here.
+        """
+        # choose_resolution() never substitutes to a mode larger than
+        # desired_mode, so desired_mode must be the largest here for the
+        # two smaller modes to be valid fallback candidates at all.
+        modes_before_override = {
+            0: {"width": 3856, "height": 2180, "bit_depth": 12, "fps_max": 40},  # desired
+            1: {"width": 1928, "height": 1090, "bit_depth": 12, "fps_max": 87},  # gets capped
+            2: {"width": 964, "height": 545, "bit_depth": 12, "fps_max": 65},    # skipped before
+        }
+        before_choice = choose_resolution(
+            sensor_modes=modes_before_override, desired_mode=0, requested_fps=60,
+        )
+        self.assertIsNotNone(before_choice)
+        self.assertEqual(before_choice.mode, 1)  # 1928x1090 -- biggest eligible mode
+
+        # settings.jsonc now caps mode 1's real-world fps_max at 55 (< the
+        # sensor's advertised 87) -- exactly what the sensor_detect.py fix
+        # above lets a matching custom_modes entry do in place.
+        modes_after_override = dict(modes_before_override)
+        modes_after_override[1] = dict(modes_before_override[1], fps_max=55)
+
+        after_choice = choose_resolution(
+            sensor_modes=modes_after_override, desired_mode=0, requested_fps=60,
+        )
+        self.assertIsNotNone(after_choice)
+        self.assertEqual(after_choice.mode, 2)  # falls back to 964x545, skipped before
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_test/test_restart_cinemate.py
+++ b/_test/test_restart_cinemate.py
@@ -1,0 +1,69 @@
+"""Restarting Cinemate must not kill its own web server (F-291).
+
+os.execl() re-execs the process in place, but the Flask/SocketIO listening
+socket survives exec() (it isn't marked close-on-exec) -- confirmed by a
+standalone repro against real hardware (system-review/FINDINGS.md), the
+re-exec'd process failed to rebind its port and the web GUI stayed dead.
+
+restart_cinemate() now asks systemd to do a real restart instead, which
+tears the whole process down first -- routed through `systemd-run` rather
+than a direct `systemctl restart` because the direct form is a child of
+this process, so it lives in cinemate-autostart.service's own cgroup and
+gets killed by the unit's own stop signal (KillMode=control-group) before
+the restart job is even queued -- also confirmed on real hardware, exiting
+with returncode -2.
+"""
+
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+sys.modules.setdefault("redis", types.SimpleNamespace(StrictRedis=object))
+sys.modules.setdefault("smbus", types.SimpleNamespace(SMBus=object))
+
+from module.cinepi_controller import CinePiController
+
+
+class RestartCinemateTests(unittest.TestCase):
+    def controller(self):
+        return CinePiController.__new__(CinePiController)
+
+    def test_restarts_via_systemd_run_not_execl(self):
+        controller = self.controller()
+        with mock.patch("subprocess.run") as run, mock.patch("os.execl") as execl:
+            run.return_value = types.SimpleNamespace(returncode=0, stdout="", stderr="")
+            controller.restart_cinemate()
+
+        execl.assert_not_called()
+        run.assert_called_once()
+        cmd = run.call_args.args[0]
+        self.assertEqual(
+            cmd,
+            [
+                "sudo", "-n", "systemd-run", "--no-block", "--collect",
+                "--unit=cinemate-restart-trigger",
+                "--", "systemctl", "restart", "cinemate-autostart",
+            ],
+        )
+
+    def test_a_failed_restart_is_logged_not_raised(self):
+        controller = self.controller()
+        with mock.patch(
+            "subprocess.run",
+            return_value=types.SimpleNamespace(returncode=1, stdout="", stderr="sudo: a password is required"),
+        ):
+            controller.restart_cinemate()  # must not raise
+
+    def test_an_unavailable_sudo_binary_is_logged_not_raised(self):
+        controller = self.controller()
+        with mock.patch("subprocess.run", side_effect=OSError("sudo not found")):
+            controller.restart_cinemate()  # must not raise
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_test/test_sensor_modes_endpoint.py
+++ b/_test/test_sensor_modes_endpoint.py
@@ -1,0 +1,85 @@
+"""GET /settings-editor/api/sensor-modes -- the fps-ceiling override pane's
+data source (F-298). Detected vs effective fps_max must both be visible so
+the settings editor can show the sensor's own value as a placeholder next
+to an editable, possibly-overridden effective value.
+"""
+
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+sys.modules.setdefault("redis", types.SimpleNamespace(StrictRedis=object))
+
+import flask
+
+from module.app.settings_editor import settings_editor_bp
+
+
+class FakeSensorDetect:
+    def __init__(self, sensor_resolutions):
+        self.sensor_resolutions = sensor_resolutions
+
+
+def _make_app(sensor_detect):
+    app = flask.Flask(__name__)
+    app.register_blueprint(settings_editor_bp)
+    app.config["SENSOR_DETECT"] = sensor_detect
+    app.config["SETTINGS"] = {}
+    return app
+
+
+class SensorModesEndpointTests(unittest.TestCase):
+    def test_no_override_reports_the_same_value_twice(self):
+        app = _make_app(FakeSensorDetect({
+            "imx585": {0: {"width": 1928, "height": 1090, "bit_depth": 12, "fps_max": 87, "hdr": False}},
+        }))
+        res = app.test_client().get("/settings-editor/api/sensor-modes")
+        body = res.get_json()
+
+        self.assertTrue(body["ok"])
+        mode = body["sensors"]["imx585"][0]
+        self.assertEqual(mode["fps_max_detected"], 87)
+        self.assertEqual(mode["fps_max_effective"], 87)
+
+    def test_an_override_reports_both_values_distinctly(self):
+        app = _make_app(FakeSensorDetect({
+            "imx585": {0: {
+                "width": 1928, "height": 1090, "bit_depth": 12,
+                "fps_max": 60, "fps_max_detected": 87, "hdr": False,
+            }},
+        }))
+        res = app.test_client().get("/settings-editor/api/sensor-modes")
+        body = res.get_json()
+
+        mode = body["sensors"]["imx585"][0]
+        self.assertEqual(mode["fps_max_detected"], 87)
+        self.assertEqual(mode["fps_max_effective"], 60)
+
+    def test_no_sensor_detect_returns_empty_not_an_error(self):
+        app = _make_app(None)
+        res = app.test_client().get("/settings-editor/api/sensor-modes")
+        body = res.get_json()
+
+        self.assertTrue(body["ok"])
+        self.assertEqual(body["sensors"], {})
+
+    def test_modes_are_sorted_largest_first(self):
+        app = _make_app(FakeSensorDetect({
+            "imx585": {
+                0: {"width": 1928, "height": 1090, "bit_depth": 12, "fps_max": 87, "hdr": False},
+                1: {"width": 3856, "height": 2180, "bit_depth": 12, "fps_max": 40, "hdr": False},
+            },
+        }))
+        res = app.test_client().get("/settings-editor/api/sensor-modes")
+        body = res.get_json()
+
+        widths = [m["width"] for m in body["sensors"]["imx585"]]
+        self.assertEqual(widths, [3856, 1928])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cinemate-install.sh
+++ b/cinemate-install.sh
@@ -1323,6 +1323,41 @@ configure_hostname_and_i2c() {
     sudo usermod -aG i2c "$PI_USER"
     sudo modprobe i2c-dev || true
     ensure_line_in_root_file /etc/modules 'i2c-dev'
+    configure_etc_hosts
+    configure_mdns
+}
+
+# /etc/hosts is not rewritten from scratch -- only the 127.0.1.1 line (the
+# one hostnamectl doesn't touch) is fixed in place, or added if absent.
+# Idempotent: a re-run with the same TARGET_HOSTNAME leaves the file
+# byte-identical, so write_root_file's own no-op check skips the write.
+configure_etc_hosts() {
+    local hosts_file="/etc/hosts"
+    local desired_line="127.0.1.1	$TARGET_HOSTNAME"
+    local existing=""
+
+    log "Ensuring /etc/hosts has $desired_line"
+    if sudo test -f "$hosts_file"; then
+        existing="$(sudo cat "$hosts_file")"
+    fi
+
+    if printf '%s\n' "$existing" | grep -Eq '^127\.0\.1\.1[[:space:]]'; then
+        printf '%s\n' "$existing" \
+            | sed -E "s/^127\.0\.1\.1[[:space:]].*/$(printf '%s' "$desired_line" | sed 's/[&/\]/\\&/g')/" \
+            | write_root_file "$hosts_file" 644
+    else
+        { printf '%s\n' "$existing"; printf '%s\n' "$desired_line"; } | write_root_file "$hosts_file" 644
+    fi
+}
+
+# Nothing in this repo installed or enabled avahi so <hostname>.local only
+# ever resolved when the base image happened to ship it (F-289). Both
+# packages are idempotent to (re)install; systemctl enable --now is
+# idempotent too.
+configure_mdns() {
+    log "Installing avahi for $TARGET_HOSTNAME.local resolution"
+    sudo apt install -y avahi-daemon libnss-mdns
+    sudo systemctl enable --now avahi-daemon
 }
 
 configure_console_font() {
@@ -1544,6 +1579,43 @@ EOF
     detail "Added $PI_USER to audio group; re-login required for limits to take effect"
 }
 
+CONFIG_TXT_APPLY_HELPER="/usr/local/bin/cinemate-apply-config-txt"
+
+# The settings editor runs as $PI_USER, which cannot write into root-owned
+# /boot/firmware (F-288). This is the one narrow privileged step that lets
+# it anyway: it reads only a fixed, already-pi-written staging file and
+# copies it over config.txt, preserving that file's existing owner/mode
+# rather than assuming one. It takes no arguments -- the sudoers rule below
+# grants it with none, so a compromised or buggy caller cannot redirect it
+# at an arbitrary destination.
+configure_config_txt_apply_helper() {
+    log "Installing $CONFIG_TXT_APPLY_HELPER"
+    write_root_file "$CONFIG_TXT_APPLY_HELPER" 755 <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+STAGED="/home/pi/cinemate/.settings-editor-config-txt.staged"
+DEST="/boot/firmware/config.txt"
+
+if [[ ! -f "$STAGED" ]]; then
+    echo "cinemate-apply-config-txt: no staged file at $STAGED" >&2
+    exit 1
+fi
+
+OWNER="$(stat -c '%u:%g' "$DEST" 2>/dev/null || echo '0:0')"
+MODE="$(stat -c '%a' "$DEST" 2>/dev/null || echo '644')"
+
+TMP="$(mktemp "${DEST}.XXXXXX")"
+trap 'rm -f "$TMP"' EXIT
+cp "$STAGED" "$TMP"
+chown "$OWNER" "$TMP"
+chmod "$MODE" "$TMP"
+mv -f "$TMP" "$DEST"
+trap - EXIT
+rm -f "$STAGED"
+EOF
+}
+
 configure_sudoers() {
     log "Writing sudoers drop-ins"
     backup_file /etc/sudoers.d/pi_cinemate
@@ -1559,6 +1631,7 @@ $PI_USER ALL=(ALL) NOPASSWD: $PI_HOME/run_cinemate.sh
 $PI_USER ALL=(ALL) NOPASSWD: $CINEMATE_DIR/src/main.py
 $PI_USER ALL=(ALL) NOPASSWD: /bin/mount, /bin/umount, /usr/bin/ntfs-3g
 $PI_USER ALL=(ALL) NOPASSWD: /sbin/mount.ext4
+$PI_USER ALL=(ALL) NOPASSWD: $CONFIG_TXT_APPLY_HELPER
 EOF
     sudo visudo -cf /etc/sudoers.d/pi_cinemate >/dev/null
     detail "sudoers validation passed"
@@ -1952,6 +2025,7 @@ main() {
     section "Preparing runtime wrappers and permissions"
     configure_media_permissions
     configure_run_wrapper
+    configure_config_txt_apply_helper
     configure_sudoers
     configure_audio_rtprio
     configure_logrotate

--- a/cinemate-install.sh
+++ b/cinemate-install.sh
@@ -1559,6 +1559,7 @@ $PI_USER ALL=(ALL) NOPASSWD: $PI_HOME/run_cinemate.sh
 $PI_USER ALL=(ALL) NOPASSWD: $CINEMATE_DIR/src/main.py
 $PI_USER ALL=(ALL) NOPASSWD: /bin/mount, /bin/umount, /usr/bin/ntfs-3g
 $PI_USER ALL=(ALL) NOPASSWD: /sbin/mount.ext4
+$PI_USER ALL=(ALL) NOPASSWD: /usr/bin/systemd-run --no-block --collect --unit=cinemate-restart-trigger -- systemctl restart cinemate-autostart
 EOF
     sudo visudo -cf /etc/sudoers.d/pi_cinemate >/dev/null
     detail "sudoers validation passed"

--- a/settings.schema.json
+++ b/settings.schema.json
@@ -319,7 +319,26 @@
           }
         },
         "custom_modes": {
-          "type": "object"
+          "type": "object",
+          "description": "Per-camera-name list of mode overrides/additions (F-298). An entry whose width/height/bit_depth/hdr matches an already-detected mode overrides that mode's fps_max in place; a non-matching entry adds a brand-new mode.",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "width": { "type": "integer", "minimum": 1 },
+                "height": { "type": "integer", "minimum": 1 },
+                "bit_depth": { "type": "integer", "minimum": 1 },
+                "fps_max": { "type": "number", "minimum": 0 },
+                "hdr": { "type": "boolean", "default": false },
+                "aspect": { "type": "number", "minimum": 0 },
+                "gui_layout": { "type": "integer" },
+                "packing": { "type": "string" }
+              },
+              "required": ["width", "height", "bit_depth"],
+              "additionalProperties": false
+            }
+          }
         }
       },
       "additionalProperties": false

--- a/src/module/app/__init__.py
+++ b/src/module/app/__init__.py
@@ -19,6 +19,10 @@ def create_app(redis_controller, cinepi_controller, simple_gui, sensor_detect,
 
     if hasattr(cinepi_controller, 'add_resolution_change_callback'):
         def emit_resolution_change(sensor_mode):
+            # Fires when the switch *starts* -- lets the browser show a
+            # "switching..." state immediately. Must not carry reload_stream:
+            # cinepi-raw is still restarting at this point, so the preview
+            # <img> would reconnect to a stream that doesn't exist yet (F-290).
             socketio.emit('resolution_change', {
                 'sensor_mode': sensor_mode,
                 'resolution_switching': redis_controller.get_value(
@@ -26,9 +30,18 @@ def create_app(redis_controller, cinepi_controller, simple_gui, sensor_detect,
                     "0",
                 ),
             })
-            socketio.emit('reload_stream')
 
         cinepi_controller.add_resolution_change_callback(emit_resolution_change)
+
+    if hasattr(cinepi_controller, 'add_resolution_switch_complete_callback'):
+        def emit_reload_stream():
+            # Fires when the switch actually *completes* -- either evidence
+            # from cinepi-raw's own "Raw stream: WxH" log line, or (if that
+            # never arrives) the switching-hold fallback timer. Either way
+            # the new stream exists by the time this runs (F-290).
+            socketio.emit('reload_stream')
+
+        cinepi_controller.add_resolution_switch_complete_callback(emit_reload_stream)
 
     app.config['REDIS_CONTROLLER'] = redis_controller
     app.config['CINEPI_CONTROLLER'] = cinepi_controller

--- a/src/module/app/boot_config.py
+++ b/src/module/app/boot_config.py
@@ -19,10 +19,21 @@ to regenerate wholesale from a from-scratch template on every save.
 """
 from __future__ import annotations
 
+import os
 import re
+import subprocess
+import tempfile
 from pathlib import Path
 
 CONFIG_TXT_PATH = "/boot/firmware/config.txt"
+
+# /boot/firmware is root-owned; the settings editor runs as an unprivileged
+# user (F-288). STAGED_CONFIG_TXT_PATH is a fixed, pi-writable location the
+# privileged helper below reads from -- fixed so the sudoers rule installed
+# by configure_sudoers() can be scoped to one exact command with no
+# arguments, rather than a general "write anywhere as root" grant.
+STAGED_CONFIG_TXT_PATH = "/home/pi/cinemate/.settings-editor-config-txt.staged"
+APPLY_CONFIG_TXT_HELPER = "/usr/local/bin/cinemate-apply-config-txt"
 
 MANAGED_BEGIN = "# >>> cinemate-install >>>"
 MANAGED_END = "# <<< cinemate-install <<<"
@@ -208,3 +219,53 @@ def apply_config_txt_state(full_text: str, state: dict) -> str:
         )
 
     return full_text[:start] + new_block + full_text[end:]
+
+
+def _atomic_write(dest: Path, text: str) -> None:
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(dest.parent), prefix=".settings-editor-", suffix=dest.suffix + ".tmp",
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fp:
+            fp.write(text)
+        os.replace(tmp_path, dest)
+    except Exception:
+        os.unlink(tmp_path)
+        raise
+
+
+def write_config_txt(text: str) -> None:
+    """Atomically replace CONFIG_TXT_PATH with *text* (F-288).
+
+    /boot/firmware is root-owned and the settings editor runs as an
+    unprivileged user, so the direct write below only succeeds when this
+    process already has root (tests, or a root-run dev shell) -- on a real
+    install it raises PermissionError before writing a byte. Only that
+    specific failure falls back to staging the text somewhere pi-writable
+    and handing it to APPLY_CONFIG_TXT_HELPER, a narrowly-scoped privileged
+    helper installed by cinemate-install.sh's configure_sudoers(). Any other
+    OSError (full disk, missing directory) is left to surface directly
+    rather than being redirected into the harder-to-debug sudo path.
+    """
+    dest = Path(CONFIG_TXT_PATH)
+    try:
+        _atomic_write(dest, text)
+        return
+    except PermissionError:
+        pass
+
+    staged = Path(STAGED_CONFIG_TXT_PATH)
+    _atomic_write(staged, text)
+    try:
+        result = subprocess.run(
+            ["sudo", "-n", APPLY_CONFIG_TXT_HELPER],
+            capture_output=True, text=True, timeout=10, check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        staged.unlink(missing_ok=True)
+        raise PermissionError(f"could not invoke privileged helper: {exc}") from exc
+
+    if result.returncode != 0:
+        staged.unlink(missing_ok=True)
+        detail = (result.stderr or result.stdout or "").strip()
+        raise PermissionError(f"privileged helper exited {result.returncode}: {detail}")

--- a/src/module/app/settings_editor.py
+++ b/src/module/app/settings_editor.py
@@ -405,6 +405,40 @@ def get_actions():
     return jsonify({"ok": True, "actions": actions})
 
 
+@settings_editor_bp.route("/api/sensor-modes", methods=["GET"])
+def get_sensor_modes():
+    """Detected modes per camera model, for the fps-ceiling override pane
+    (F-298). sensor_detect.res_modes/sensor_resolutions already carry any
+    settings.jsonc custom_modes override merged in (that's the *effective*
+    fps_max cinepi-raw actually launches with); fps_max_detected is only
+    present on a mode _finalize_modes() overrode, and is what the sensor
+    itself reported before that override was applied -- see
+    sensor_detect.py's _finalize_modes(). Absent means "not overridden",
+    i.e. fps_max itself is the detected value.
+    """
+    sensor_detect = current_app.config.get("SENSOR_DETECT")
+    if sensor_detect is None:
+        return jsonify({"ok": True, "sensors": {}})
+
+    sensors = {}
+    for camera_name, modes in (sensor_detect.sensor_resolutions or {}).items():
+        entries = []
+        for mode in modes.values():
+            detected_fps = mode.get("fps_max_detected", mode.get("fps_max"))
+            entries.append({
+                "width": mode.get("width"),
+                "height": mode.get("height"),
+                "bit_depth": mode.get("bit_depth"),
+                "hdr": bool(mode.get("hdr", False)),
+                "fps_max_detected": detected_fps,
+                "fps_max_effective": mode.get("fps_max"),
+            })
+        entries.sort(key=lambda m: ((m["width"] or 0) * (m["height"] or 0), m["bit_depth"] or 0), reverse=True)
+        sensors[camera_name] = entries
+
+    return jsonify({"ok": True, "sensors": sensors})
+
+
 @settings_editor_bp.route("/api/raw/storage", methods=["GET"])
 def get_raw_storage():
     return jsonify({"ok": True, "storage": raw_files.storage_summary()})

--- a/src/module/app/settings_editor.py
+++ b/src/module/app/settings_editor.py
@@ -34,6 +34,7 @@ from module.config_loader import (
 )
 from module.app import boot_config, raw_files
 from module.jsonc_edit import apply_updates
+from module.web_api_settings import web_api_settings
 
 logger = logging.getLogger(__name__)
 
@@ -124,7 +125,8 @@ def _public_method_names(obj) -> set[str]:
 
 @settings_editor_bp.route("/")
 def index():
-    return render_template("settings_editor.html")
+    settings = current_app.config["SETTINGS"]
+    return render_template("settings_editor.html", api_token=web_api_settings(settings).get("token") or "")
 
 
 @settings_editor_bp.route("/api/settings", methods=["GET"])

--- a/src/module/app/settings_editor.py
+++ b/src/module/app/settings_editor.py
@@ -362,14 +362,7 @@ def put_config_txt():
         return jsonify({"ok": False, "message": str(exc)}), 400
 
     try:
-        fd, tmp_path = tempfile.mkstemp(dir=str(dest.parent), prefix=".settings-editor-", suffix=".config.txt.tmp")
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as fp:
-                fp.write(new_text)
-            os.replace(tmp_path, dest)
-        except Exception:
-            os.unlink(tmp_path)
-            raise
+        boot_config.write_config_txt(new_text)
     except OSError as exc:
         logger.exception("Failed to write %s", dest)
         return jsonify({"ok": False, "message": f"Could not write {dest}: {exc}"}), 500

--- a/src/module/app/templates/settings_editor.html
+++ b/src/module/app/templates/settings_editor.html
@@ -435,16 +435,16 @@
   /* ---------- Translated action rows (buttons / switches / encoders) ----------
      Exactly 3 direct children per .actionrow (pin-picker | gestures-wrap |
      view-raw link) — anything else breaks the 3-column auto-placement below.
-     Visual order reads command → action → GPIO (matching the rest of the
-     settings cards), via CSS `order` rather than reshuffling the DOM. */
+     Visual order reads GPIO → action → method (B11.5's column model), via
+     CSS `order` rather than reshuffling the DOM. */
   .actionrow{
-    display:grid; grid-template-columns: 1fr 140px auto; gap: 4px 16px;
+    display:grid; grid-template-columns: 140px 1fr auto; gap: 4px 16px;
     padding: 13px 16px; border-top: 1px solid var(--line); align-items:start;
   }
   .actionrow:first-child{ border-top:0; }
-  .actionrow > .gestures-wrap{ order: 1; }
-  .actionrow > .pin-picker, .actionrow > .pin-badge{ order: 2; }
-  .actionrow > .edit-json-link{ order: 3; }
+  .actionrow > .pin-picker, .actionrow > .pin-badge{ order: 1; }
+  .actionrow > .gestures-wrap{ order: 2; }
+  .actionrow > .edit-json-link, .actionrow > .row-remove{ order: 3; }
   .pin-badge{
     font-family:'DIN2014',sans-serif; font-weight:700; font-size: 11.5px; color: var(--ink);
     background: var(--panel-2); border:1px solid var(--line); border-radius: var(--radius);
@@ -454,6 +454,7 @@
 
   .pin-picker{ display:flex; flex-direction:column; gap:5px; align-items:stretch; align-self:start; }
   .pin-picker small{ font-weight:400; font-size:9px; letter-spacing:.06em; text-transform:uppercase; color:var(--muted); text-align:center; }
+  .pin-picker.pin-picker-multi{ gap:8px; }
   .gpio-select{
     font-family:'DIN2014',sans-serif; font-weight:700; font-size:11.5px; text-align:center;
     padding: 6px 22px 6px 8px; width:100%; min-width:0; box-sizing:border-box;
@@ -461,18 +462,31 @@
   .actionrow.unassigned .gestures{ opacity:.4; }
 
   .gestures-wrap{ display:flex; flex-direction:column; gap:8px; min-width:0; }
-  .gestures{ display:grid; grid-template-columns: 1fr 74px; gap: 9px 16px; align-items:center; }
-  .gestures-head{ display:grid; grid-template-columns: 1fr 74px; gap: 9px 16px; }
+  .gestures{ display:grid; grid-template-columns: 74px 1fr; gap: 9px 16px; align-items:center; }
+  .gestures-head{ display:grid; grid-template-columns: 74px 1fr; gap: 9px 16px; }
   .gestures-head span{
     font-family:'DIN2014',sans-serif; font-weight:700; font-size: 9px; text-transform:uppercase; letter-spacing:.07em; color: var(--muted); opacity:.75;
   }
   .gesture{ display:contents; }
-  /* Method-before-Action is done by swapping DOM order at init (see JS),
-     not CSS `order` — with .gesture as display:contents, `order` re-sorts
-     ALL grid items globally instead of preserving each gesture's own pair. */
+  /* .g-name (action name, e.g. "Press") then .action-slot (method picker) —
+     plain DOM order now that the grid tracks (74px name, 1fr method) match
+     that order; no JS reordering hack needed. */
   .gesture-add .add-gesture-select{ color: var(--muted); }
   .gesture .g-name{ font-family:'DIN2014',sans-serif; font-weight:700; font-size: 10.5px; text-transform:uppercase; letter-spacing:.05em; color: var(--muted); }
   .gesture .g-action{ color: var(--ink); }
+  .gesture-remove{
+    width:22px; height:22px; border-radius: var(--radius); border:1px solid var(--line); background: var(--panel-2);
+    color: var(--muted); display:flex; align-items:center; justify-content:center; cursor:pointer; flex:none; padding:0;
+    font-size:14px; line-height:1;
+  }
+  .gesture-remove:hover{ color: var(--danger, #c0392b); border-color: var(--danger, #c0392b); }
+  .row-remove{
+    align-self:start; background:none; border:none; color: var(--muted); cursor:pointer;
+    font-family:'DIN2014',sans-serif; font-weight:700; font-size: 11px; text-decoration: none;
+    border-bottom: 1px dashed var(--muted); padding:0;
+  }
+  .row-remove:hover{ color: var(--danger, #c0392b); border-color: var(--danger, #c0392b); }
+  .add-control-row{ display:flex; gap:8px; flex-wrap:wrap; margin-top:12px; }
 
   .action-picker{ display:flex; align-items:center; gap:6px; flex-wrap:wrap; min-width:0; }
   .action-method{ font-size:12.5px; padding:6px 20px 6px 8px; min-width:0; max-width: 220px; text-overflow: ellipsis; }
@@ -1722,130 +1736,28 @@
     </section>
     <section class="group" id="controls" data-page="settings">
       <header class="group-head">
-        <h2>Buttons &amp; switches</h2>
-        <p class="group-sub">What's wired to each GPIO pin, translated from the raw action list into plain gestures.</p>
+        <h2>GPIO in</h2>
+        <p class="group-sub">What's wired to each GPIO pin, translated from the raw action list into plain gestures. Every button, switch and rotary encoder in <code class="mono">hardware_controls</code> shows here — add as many as you're wired for.</p>
       </header>
-      <div class="card" id="hwControlsExtraWarning" hidden style="border-color: var(--warn, #c9a227); margin-bottom: 14px;">
-        <div class="card-main">
-          <label class="card-label">This file has more bindings than this page can edit</label>
-          <p class="card-help">Your real <code class="mono">hardware_controls</code> has more than 3 buttons, more than 2 two-way switches, or has three-way switches / rotary encoders / combined actions configured — this page only edits the first 3 buttons and first 2 switches. Saving is safe: anything this page doesn't show is passed through unchanged, not deleted. Edit the rest by hand in <code class="mono">settings.jsonc</code> for now.</p>
-        </div>
+      <div class="cards" id="controlsList"></div>
+      <div class="add-control-row">
+        <button class="btn btn-ghost" type="button" id="addButtonBtn">+ Add button</button>
+        <button class="btn btn-ghost" type="button" id="addSwitch2Btn">+ Add 2‑way switch</button>
+        <button class="btn btn-ghost" type="button" id="addSwitch3Btn">+ Add 3‑way switch</button>
+        <button class="btn btn-ghost" type="button" id="addRotaryBtn">+ Add rotary encoder</button>
       </div>
-      <div class="cards">
-        <div class="actionrow" data-search="button gpio 7 record" data-highlight-gpio="cfg-gpio-btn1">
-          <div class="pin-picker">
-            <select class="field-input gpio-select" id="cfg-gpio-btn1" data-role-label="the record button" data-initial="7" aria-label="GPIO pin for the record button"></select>
-            <small>button</small>
-          </div>
-          <div class="gestures-wrap">
-            <div class="gestures-head"><span>Method</span><span>Action</span></div>
-            <div class="gestures">
-              <div class="gesture"><span class="g-name">Press</span><span class="action-slot" id="act-btn1-press" data-method="rec"></span></div>
-              <div class="gesture gesture-add">
-                <span class="g-name">+ Add</span>
-                <span class="action-args">
-                  <select class="field-input add-gesture-select" data-prefix="act-btn1">
-                    <option value="" selected>Choose a gesture…</option>
-                    <option value="single">Single click</option>
-                    <option value="double">Double click</option>
-                    <option value="triple">Triple click</option>
-                    <option value="hold">Hold</option>
-                  </select>
-                </span>
-              </div>
-            </div>
-          </div>
-          <a class="edit-json-link" href="#" data-open-json>View raw</a>
-        </div>
-        <div class="actionrow" data-search="button gpio 10 record" data-highlight-gpio="cfg-gpio-btn2">
-          <div class="pin-picker">
-            <select class="field-input gpio-select" id="cfg-gpio-btn2" data-role-label="the second record button" data-initial="10" aria-label="GPIO pin for the second record button"></select>
-            <small>button</small>
-          </div>
-          <div class="gestures-wrap">
-            <div class="gestures-head"><span>Method</span><span>Action</span></div>
-            <div class="gestures">
-              <div class="gesture"><span class="g-name">Press</span><span class="action-slot" id="act-btn2-press" data-method="rec"></span></div>
-              <div class="gesture gesture-add">
-                <span class="g-name">+ Add</span>
-                <span class="action-args">
-                  <select class="field-input add-gesture-select" data-prefix="act-btn2">
-                    <option value="" selected>Choose a gesture…</option>
-                    <option value="single">Single click</option>
-                    <option value="double">Double click</option>
-                    <option value="triple">Triple click</option>
-                    <option value="hold">Hold</option>
-                  </select>
-                </span>
-              </div>
-            </div>
-          </div>
-          <a class="edit-json-link" href="#" data-open-json>View raw</a>
-        </div>
-        <div class="actionrow" data-search="button gpio 13 resolution restart reboot mount" data-highlight-gpio="cfg-gpio-btn3">
-          <div class="pin-picker">
-            <select class="field-input gpio-select" id="cfg-gpio-btn3" data-role-label="the multi‑function button" data-initial="13" aria-label="GPIO pin for the multi-function button"></select>
-            <small>button</small>
-          </div>
-          <div class="gestures-wrap">
-            <div class="gestures-head"><span>Method</span><span>Action</span></div>
-            <div class="gestures">
-              <div class="gesture"><span class="g-name">Single</span><span class="action-slot" id="act-btn3-single" data-method="set_resolution"></span></div>
-              <div class="gesture"><span class="g-name">Double</span><span class="action-slot" id="act-btn3-double" data-method="restart_cinemate"></span></div>
-              <div class="gesture"><span class="g-name">Triple</span><span class="action-slot" id="act-btn3-triple" data-method="reboot"></span></div>
-              <div class="gesture"><span class="g-name">Hold</span><span class="action-slot" id="act-btn3-hold" data-method="toggle_mount"></span></div>
-              <div class="gesture gesture-add">
-                <span class="g-name">+ Add</span>
-                <span class="action-args">
-                  <select class="field-input add-gesture-select" data-prefix="act-btn3">
-                    <option value="" selected>Choose a gesture…</option>
-                    <option value="press">Press</option>
-                  </select>
-                </span>
-              </div>
-            </div>
-          </div>
-          <a class="edit-json-link" href="#" data-open-json>View raw</a>
-        </div>
-        <div class="actionrow" data-search="two way switch gpio 24 zoom" data-highlight-gpio="cfg-gpio-sw1">
-          <div class="pin-picker">
-            <select class="field-input gpio-select" id="cfg-gpio-sw1" data-role-label="the zoom switch" data-initial="24" aria-label="GPIO pin for the zoom switch"></select>
-            <small>2‑way switch</small>
-          </div>
-          <div class="gestures-wrap">
-            <div class="gestures-head"><span>Method</span><span>Action</span></div>
-            <div class="gestures">
-              <div class="gesture"><span class="g-name">On</span><span class="action-slot" id="act-sw1-on" data-method="set_zoom" data-args="2"></span></div>
-              <div class="gesture"><span class="g-name">Off</span><span class="action-slot" id="act-sw1-off" data-method="set_zoom" data-args="1"></span></div>
-            </div>
-          </div>
-          <a class="edit-json-link" href="#" data-open-json>View raw</a>
-        </div>
-        <div class="actionrow" data-search="two way switch gpio 22 shutter sync" data-highlight-gpio="cfg-gpio-sw2">
-          <div class="pin-picker">
-            <select class="field-input gpio-select" id="cfg-gpio-sw2" data-role-label="the shutter‑sync switch" data-initial="22" aria-label="GPIO pin for the shutter-sync switch"></select>
-            <small>2‑way switch</small>
-          </div>
-          <div class="gestures-wrap">
-            <div class="gestures-head"><span>Method</span><span>Action</span></div>
-            <div class="gestures">
-              <div class="gesture"><span class="g-name">On</span><span class="action-slot" id="act-sw2-on" data-method="set_shutter_a_sync_mode" data-args="1"></span></div>
-              <div class="gesture"><span class="g-name">Off</span><span class="action-slot" id="act-sw2-off" data-method="set_shutter_a_sync_mode" data-args="0"></span></div>
-            </div>
-          </div>
-          <a class="edit-json-link" href="#" data-open-json>View raw</a>
-        </div>
+      <div class="cards" style="margin-top:14px">
         <div class="actionrow" data-search="quad rotary controller encoders iso shutter fps wb" data-highlight-text="quad_rotary_controller">
           <span class="pin-badge">Quad rotary<small>i²c encoders</small></span>
           <div class="gestures-wrap">
-            <div class="gestures-head"><span>Method</span><span>Action</span></div>
+            <div class="gestures-head"><span>Action</span><span>Method</span></div>
             <div class="gestures">
               <div class="gesture"><span class="g-name">Enc 0 · ISO</span><span class="action-slot" id="act-qr0-press" data-method="set_zoom"></span></div>
               <div class="gesture"><span class="g-name">Enc 0 hold</span><span class="action-slot" id="act-qr0-hold" data-method="safe_shutdown"></span></div>
               <div class="gesture gesture-add">
                 <span class="g-name">Enc 0 +</span>
                 <span class="action-args">
-                  <select class="field-input add-gesture-select" data-prefix="act-qr0">
+                  <select class="field-input add-gesture-select" data-prefix="act-qr0" data-removable="false">
                     <option value="" selected>Choose a gesture…</option>
                     <option value="single">Single click</option>
                     <option value="double">Double click</option>
@@ -1857,7 +1769,7 @@
               <div class="gesture gesture-add">
                 <span class="g-name">Enc 1 +</span>
                 <span class="action-args">
-                  <select class="field-input add-gesture-select" data-prefix="act-qr1">
+                  <select class="field-input add-gesture-select" data-prefix="act-qr1" data-removable="false">
                     <option value="" selected>Choose a gesture…</option>
                     <option value="single">Single click</option>
                     <option value="double">Double click</option>
@@ -1870,7 +1782,7 @@
               <div class="gesture gesture-add">
                 <span class="g-name">Enc 2 +</span>
                 <span class="action-args">
-                  <select class="field-input add-gesture-select" data-prefix="act-qr2">
+                  <select class="field-input add-gesture-select" data-prefix="act-qr2" data-removable="false">
                     <option value="" selected>Choose a gesture…</option>
                     <option value="single">Single click</option>
                     <option value="double">Double click</option>
@@ -1886,7 +1798,7 @@
               <div class="gesture gesture-add">
                 <span class="g-name">Enc 3 +</span>
                 <span class="action-args">
-                  <select class="field-input add-gesture-select" data-prefix="act-qr3">
+                  <select class="field-input add-gesture-select" data-prefix="act-qr3" data-removable="false">
                     <option value="" selected>Choose a gesture…</option>
                     <option value="press">Press</option>
                   </select>
@@ -1904,26 +1816,30 @@
     </section>
     <section class="group" id="gpio" data-page="settings">
       <header class="group-head">
-        <h2>Rec tally &amp; GPIO out</h2>
-        <p class="group-sub">Physical signals the camera drives while recording — tally lamps, a slate tone, a relay.</p>
+        <h2>GPIO out</h2>
+        <p class="group-sub">Physical signals the camera drives while recording — tally lamps, a slate tone, a relay. Add as many tally or tone pins as you're wired for.</p>
       </header>
-      <div class="cards">
-        <div class="card" data-search="rec out pin tally gpio 21">
+      <div class="cards" id="gpioOutList"></div>
+      <div class="add-control-row">
+        <button class="btn btn-ghost" type="button" id="addGpioOutBtn">+ Add pin</button>
+      </div>
+      <div class="cards" style="margin-top:14px">
+        <div class="card" data-search="rec tone pin slate beep gpio 18 frequency pitch">
           <div class="card-main">
-            <label class="card-label">Tally output pin</label>
-            <p class="card-help">GPIO pin driven high while recording — wire a tally light or LED here.</p>
-          </div>
-          <div class="card-control">
-            <select class="field-input gpio-select" id="cfg-gpio-tally" data-role-label="the tally output" data-initial="21" aria-label="GPIO pin for the tally output"></select>
-          </div>
-        </div>
-        <div class="card" data-search="rec tone pin slate beep gpio 18">
-          <div class="card-main">
-            <label class="card-label" for="f-tonefreq">Slate tone</label>
-            <p class="card-help">A short tone driven on GPIO 18 at record‑start, useful as an audible sync reference. Set its pitch and duty cycle.</p>
+            <label class="card-label" for="f-tonefreq">Slate tone pitch</label>
+            <p class="card-help">Frequency of the tone driven on any pin set to "REC tone" above, at record‑start — useful as an audible sync reference.</p>
           </div>
           <div class="card-control">
             <input class="field-input num-input" type="number" id="f-tonefreq" data-path="hardware_outputs.rec_tone.frequency_hz" data-type="number" data-original="1000" value="1000"> Hz
+          </div>
+        </div>
+        <div class="card" data-search="rec tone duty cycle pulse width">
+          <div class="card-main">
+            <label class="card-label" for="f-toneduty">Slate tone duty cycle</label>
+            <p class="card-help">Pulse width of the tone, in percent.</p>
+          </div>
+          <div class="card-control">
+            <input class="field-input num-input" type="number" min="1" max="99" id="f-toneduty" data-path="hardware_outputs.rec_tone.duty_cycle" data-type="number" data-original="50" value="50"> %
           </div>
         </div>
         <div class="card" data-search="rec tone relay drop frames">
@@ -2281,8 +2197,9 @@
     return parseInt(el.value, 10);
   }
   /* Reads whichever gesture slots actually exist for a given id prefix (e.g.
-     "act-btn1") — so buttons/encoders that gained an added gesture, or never
-     had one to begin with, both reconstruct correctly with no special-casing.
+     "act-qr0", or a dynamic control row's own "hwctl-N") — so buttons/
+     encoders that gained an added gesture, or never had one to begin with,
+     both reconstruct correctly with no special-casing.
      press_action is always present (a real key, "None" if there's no Press
      row); the click-variant keys only appear if that gesture row exists,
      matching how the real file omits keys it doesn't use. */
@@ -2294,20 +2211,321 @@
     });
     return obj;
   }
+  /* ---------- B11.5: dynamic GPIO IN rows (buttons / 2-way / 3-way switches /
+     rotary encoders) -- replaces the old fixed 3-button/2-switch slots and
+     the "more bindings than this page can edit" banner. Every row lives in
+     #controlsList and carries data-control-type + data-prefix; building and
+     populating both walk that list generically, so any count of any type
+     round-trips. combined_actions has no UI here (not part of the operator's
+     column model) and is passed through byte-for-byte from the last load. */
+  var CONTROL_ROW_SEQ = 0;
+  function nextControlPrefix(){ return 'hwctl-' + (++CONTROL_ROW_SEQ); }
+
+  function markControlsDirtyIfNeeded(){ markDirty(document.getElementById('controlsList'), true); }
+
+  function addGestureRemoveButton(gestureEl, slotEl, label){
+    var rm = document.createElement('button');
+    rm.type = 'button';
+    rm.className = 'gesture-remove';
+    rm.title = 'Remove this action';
+    rm.setAttribute('aria-label', 'Remove ' + label + ' action');
+    rm.textContent = '×';
+    rm.addEventListener('click', function(){
+      gestureEl.remove();
+      dirtyEls.delete(slotEl);
+      markControlsDirtyIfNeeded();
+      showToast(label + ' action removed');
+    });
+    gestureEl.appendChild(rm);
+  }
+
+  function makeGestureRow(prefix, gestureKey, label, action){
+    var g = document.createElement('div');
+    g.className = 'gesture';
+    var name = document.createElement('span');
+    name.className = 'g-name';
+    name.textContent = label;
+    var slot = document.createElement('span');
+    slot.className = 'action-slot';
+    slot.id = prefix + '-' + gestureKey;
+    g.appendChild(name);
+    g.appendChild(slot);
+    addGestureRemoveButton(g, slot, label);
+    applyActionToSlot(slot, action);
+    return g;
+  }
+
+  function makeAddGestureRow(prefix, remainingSpecs){
+    var addRow = document.createElement('div');
+    addRow.className = 'gesture gesture-add';
+    var label = document.createElement('span');
+    label.className = 'g-name';
+    label.textContent = '+ Add';
+    var wrap = document.createElement('span');
+    wrap.className = 'action-args';
+    var sel = document.createElement('select');
+    sel.className = 'field-input add-gesture-select';
+    sel.setAttribute('data-prefix', prefix);
+    var blank = document.createElement('option');
+    blank.value = ''; blank.textContent = 'Choose a gesture…'; blank.selected = true;
+    sel.appendChild(blank);
+    remainingSpecs.forEach(function(spec){
+      var opt = document.createElement('option');
+      opt.value = spec.key; opt.textContent = spec.label;
+      sel.appendChild(opt);
+    });
+    wrap.appendChild(sel);
+    addRow.appendChild(label);
+    addRow.appendChild(wrap);
+    if (remainingSpecs.length === 0) addRow.hidden = true;
+    return addRow;
+  }
+
+  /* Builds a .gestures block for a control row: one row per action already
+     present in `actionsByKey` (key -> action-or-"None"), plus a "+ Add" row
+     offering whichever gestures from `allSpecs` aren't shown yet. */
+  function buildGesturesBlock(prefix, allSpecs, actionsByKey){
+    var wrap = document.createElement('div');
+    wrap.className = 'gestures-wrap';
+    var head = document.createElement('div');
+    head.className = 'gestures-head';
+    head.innerHTML = '<span>Action</span><span>Method</span>';
+    var gestures = document.createElement('div');
+    gestures.className = 'gestures';
+    var present = {};
+    allSpecs.forEach(function(spec){
+      if (Object.prototype.hasOwnProperty.call(actionsByKey, spec.key)){
+        present[spec.key] = true;
+        gestures.appendChild(makeGestureRow(prefix, spec.key, spec.label, actionsByKey[spec.key]));
+      }
+    });
+    var remaining = allSpecs.filter(function(spec){ return !present[spec.key]; });
+    gestures.appendChild(makeAddGestureRow(prefix, remaining));
+    wrap.appendChild(head);
+    wrap.appendChild(gestures);
+    return wrap;
+  }
+
+  function makeRowRemoveButton(rowEl, label){
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'row-remove';
+    btn.textContent = 'Remove';
+    btn.setAttribute('aria-label', 'Remove ' + label);
+    btn.addEventListener('click', function(){
+      showConfirm('Remove ' + label + '? This deletes it from hardware_controls on the next save.', function(){
+        rowEl.remove();
+        markControlsDirtyIfNeeded();
+        refreshAllGpioSelects();
+        showToast(label + ' removed');
+      });
+    });
+    return btn;
+  }
+
+  var BUTTON_GESTURE_SPECS = [
+    { key: 'press', field: 'press_action', label: 'Press' },
+    { key: 'single', field: 'single_click_action', label: 'Single click' },
+    { key: 'double', field: 'double_click_action', label: 'Double click' },
+    { key: 'triple', field: 'triple_click_action', label: 'Triple click' },
+    { key: 'hold', field: 'hold_action', label: 'Hold' }
+  ];
+  var SWITCH2_GESTURE_SPECS = [
+    { key: 'on', field: 'state_on_action', label: 'On' },
+    { key: 'off', field: 'state_off_action', label: 'Off' }
+  ];
+  var SWITCH3_GESTURE_SPECS = [
+    { key: 's0', field: 'state_0_action', label: 'Position 1' },
+    { key: 's1', field: 'state_1_action', label: 'Position 2' },
+    { key: 's2', field: 'state_2_action', label: 'Position 3' }
+  ];
+  var ROTARY_GESTURE_SPECS = [
+    { key: 'rpress', field: '__press', label: 'Button press' },
+    { key: 'rhold', field: '__hold', label: 'Button hold' },
+    { key: 'cw', field: '__cw', label: 'Rotate CW' },
+    { key: 'ccw', field: '__ccw', label: 'Rotate CCW' }
+  ];
+
+  function actionsByFieldMap(specs, obj){
+    var out = {};
+    specs.forEach(function(spec){
+      if (Object.prototype.hasOwnProperty.call(obj, spec.field)) out[spec.key] = obj[spec.field];
+    });
+    return out;
+  }
+
+  function makeControlRow(type, prefix, pinPickerEl, gesturesEl, roleLabel, searchText){
+    var row = document.createElement('div');
+    row.className = 'actionrow';
+    row.setAttribute('data-control-type', type);
+    row.setAttribute('data-prefix', prefix);
+    row.setAttribute('data-search', searchText);
+    row.appendChild(pinPickerEl);
+    row.appendChild(gesturesEl);
+    row.appendChild(makeRowRemoveButton(row, roleLabel));
+    return row;
+  }
+
+  function makePinSelect(id, roleLabel, initialPin){
+    var sel = document.createElement('select');
+    sel.className = 'field-input gpio-select';
+    sel.id = id;
+    sel.setAttribute('data-role-label', roleLabel);
+    sel.setAttribute('data-initial', initialPin != null ? String(initialPin) : 'none');
+    sel.setAttribute('aria-label', 'GPIO pin for ' + roleLabel);
+    return sel;
+  }
+
+  function makeSingleGpioOutPinPicker(id, roleLabel, initialPin, typeLabel){
+    var wrap = document.createElement('div');
+    wrap.className = 'pin-picker';
+    var sel = makePinSelect(id, roleLabel, initialPin);
+    var small = document.createElement('small');
+    small.textContent = typeLabel;
+    wrap.appendChild(sel);
+    wrap.appendChild(small);
+    return { wrap: wrap, sel: sel };
+  }
+
+  function buildButtonRow(data){
+    var prefix = nextControlPrefix();
+    var pin = data ? data.pin : null;
+    var picker = makeSingleGpioOutPinPicker(prefix + '-pin', 'a button', pin, 'button').wrap;
+    var actions = data ? actionsByFieldMap(BUTTON_GESTURE_SPECS, data) : { press: 'None' };
+    var gestures = buildGesturesBlock(prefix, BUTTON_GESTURE_SPECS, actions);
+    var row = makeControlRow('button', prefix, picker, gestures, 'this button', 'button gpio');
+    // pull_up/debounce_time have no dedicated widget (not part of the
+    // operator's column model) but must still round-trip rather than
+    // silently resetting every button to pull_up=true on save.
+    row.setAttribute('data-pull-up', String(data && data.pull_up === false ? false : true));
+    row.setAttribute('data-debounce', String(data && data.debounce_time != null ? data.debounce_time : 0.1));
+    return row;
+  }
+
+  function buildSwitch2Row(data){
+    var prefix = nextControlPrefix();
+    var pin = data ? data.pin : null;
+    var picker = makeSingleGpioOutPinPicker(prefix + '-pin', 'a 2-way switch', pin, '2‑way switch').wrap;
+    var actions = data ? actionsByFieldMap(SWITCH2_GESTURE_SPECS, data) : { on: 'None', off: 'None' };
+    var gestures = buildGesturesBlock(prefix, SWITCH2_GESTURE_SPECS, actions);
+    return makeControlRow('switch2', prefix, picker, gestures, 'this 2-way switch', 'two way switch gpio');
+  }
+
+  function buildSwitch3Row(data){
+    var prefix = nextControlPrefix();
+    var pins = (data && data.pins) || [null, null, null];
+    var picker = document.createElement('div');
+    picker.className = 'pin-picker pin-picker-multi';
+    ['1', '2', '3'].forEach(function(label, i){
+      var sel = makePinSelect(prefix + '-pin' + i, 'a 3-way switch (position ' + label + ' pin)', pins[i]);
+      var small = document.createElement('small');
+      small.textContent = 'pin ' + label;
+      picker.appendChild(sel);
+      picker.appendChild(small);
+    });
+    var actions = data ? actionsByFieldMap(SWITCH3_GESTURE_SPECS, data) : { s0: 'None', s1: 'None', s2: 'None' };
+    var gestures = buildGesturesBlock(prefix, SWITCH3_GESTURE_SPECS, actions);
+    return makeControlRow('switch3', prefix, picker, gestures, 'this 3-way switch', 'three way switch gpio');
+  }
+
+  function buildRotaryRow(data){
+    var prefix = nextControlPrefix();
+    var picker = document.createElement('div');
+    picker.className = 'pin-picker pin-picker-multi';
+    [['clk', 'CLK', data && data.clk_pin], ['dt', 'DT', data && data.dt_pin], ['btnpin', 'BTN', data && data.button_pin]].forEach(function(spec){
+      var sel = makePinSelect(prefix + '-' + spec[0], 'a rotary encoder (' + spec[1] + ' pin)', spec[2]);
+      var small = document.createElement('small');
+      small.textContent = spec[1];
+      picker.appendChild(sel);
+      picker.appendChild(small);
+    });
+    var buttonActions = (data && data.button_actions) || {};
+    var encoderActions = (data && data.encoder_actions) || {};
+    var actions = data ? {
+      rpress: Object.prototype.hasOwnProperty.call(buttonActions, 'press_action') ? buttonActions.press_action : undefined,
+      rhold: Object.prototype.hasOwnProperty.call(buttonActions, 'hold_action') ? buttonActions.hold_action : undefined,
+      cw: Object.prototype.hasOwnProperty.call(encoderActions, 'rotate_clockwise') ? encoderActions.rotate_clockwise : undefined,
+      ccw: Object.prototype.hasOwnProperty.call(encoderActions, 'rotate_counterclockwise') ? encoderActions.rotate_counterclockwise : undefined
+    } : { rpress: 'None' };
+    Object.keys(actions).forEach(function(k){ if (actions[k] === undefined) delete actions[k]; });
+    var gestures = buildGesturesBlock(prefix, ROTARY_GESTURE_SPECS, actions);
+    return makeControlRow('rotary', prefix, picker, gestures, 'this rotary encoder', 'rotary encoder gpio clk dt');
+  }
+
+  /* data-original-method/args are left as applyActionToSlot() (inside
+     buildGesturesBlock -> makeGestureRow) already set them: matching the
+     loaded value when populating from settings.jsonc, or a fresh default
+     when building a brand-new row from the "+ Add ..." buttons -- either
+     way correct, so this must not stomp them back to "". */
+  function appendControlRow(rowEl){
+    document.getElementById('controlsList').appendChild(rowEl);
+    rowEl.querySelectorAll('.gpio-select').forEach(initGpioSelect);
+  }
+
+  document.getElementById('addButtonBtn').addEventListener('click', function(){
+    appendControlRow(buildButtonRow(null));
+    markControlsDirtyIfNeeded();
+  });
+  document.getElementById('addSwitch2Btn').addEventListener('click', function(){
+    appendControlRow(buildSwitch2Row(null));
+    markControlsDirtyIfNeeded();
+  });
+  document.getElementById('addSwitch3Btn').addEventListener('click', function(){
+    appendControlRow(buildSwitch3Row(null));
+    markControlsDirtyIfNeeded();
+  });
+  document.getElementById('addRotaryBtn').addEventListener('click', function(){
+    appendControlRow(buildRotaryRow(null));
+    markControlsDirtyIfNeeded();
+  });
+
   function buildHardwareControlsState(){
-    var buttons = [];
-    var b1 = gpioPinValue('cfg-gpio-btn1');
-    if (b1 != null) buttons.push(Object.assign({ pin: b1, pull_up: true, debounce_time: 0.1 }, buildButtonLikeObject('act-btn1')));
-    var b2 = gpioPinValue('cfg-gpio-btn2');
-    if (b2 != null) buttons.push(Object.assign({ pin: b2, pull_up: true, debounce_time: 0.1 }, buildButtonLikeObject('act-btn2')));
-    var b3 = gpioPinValue('cfg-gpio-btn3');
-    if (b3 != null) buttons.push(Object.assign({ pin: b3, pull_up: false, debounce_time: 0.1 }, buildButtonLikeObject('act-btn3')));
-    var switches = [];
-    var s1 = gpioPinValue('cfg-gpio-sw1');
-    if (s1 != null) switches.push({ pin: s1, state_on_action: actionFromSlot('act-sw1-on'), state_off_action: actionFromSlot('act-sw1-off') });
-    var s2 = gpioPinValue('cfg-gpio-sw2');
-    if (s2 != null) switches.push({ pin: s2, state_on_action: actionFromSlot('act-sw2-on'), state_off_action: actionFromSlot('act-sw2-off') });
-    return { buttons: buttons, two_way_switches: switches, three_way_switches: [], rotary_encoders: [], combined_actions: [] };
+    var buttons = [], two_way = [], three_way = [], rotary = [];
+    document.querySelectorAll('#controlsList [data-control-type]').forEach(function(row){
+      var type = row.getAttribute('data-control-type');
+      var prefix = row.getAttribute('data-prefix');
+      if (type === 'button'){
+        var pin = gpioPinValue(prefix + '-pin');
+        if (pin == null) return;
+        var pullUp = row.getAttribute('data-pull-up') !== 'false';
+        var debounce = parseFloat(row.getAttribute('data-debounce'));
+        if (isNaN(debounce)) debounce = 0.1;
+        buttons.push(Object.assign({ pin: pin, pull_up: pullUp, debounce_time: debounce }, buildButtonLikeObject(prefix)));
+      } else if (type === 'switch2'){
+        var pin2 = gpioPinValue(prefix + '-pin');
+        if (pin2 == null) return;
+        two_way.push({ pin: pin2, state_on_action: actionFromSlot(prefix + '-on'), state_off_action: actionFromSlot(prefix + '-off') });
+      } else if (type === 'switch3'){
+        var pins3 = [0, 1, 2].map(function(i){ return gpioPinValue(prefix + '-pin' + i); });
+        if (pins3.some(function(p){ return p == null; })) return;
+        three_way.push({
+          pins: pins3,
+          state_0_action: actionFromSlot(prefix + '-s0'),
+          state_1_action: actionFromSlot(prefix + '-s1'),
+          state_2_action: actionFromSlot(prefix + '-s2')
+        });
+      } else if (type === 'rotary'){
+        var clk = gpioPinValue(prefix + '-clk');
+        var dt = gpioPinValue(prefix + '-dt');
+        var btnPin = gpioPinValue(prefix + '-btnpin');
+        if (clk == null || dt == null) return;
+        var entry = {
+          enabled: true, clk_pin: clk, dt_pin: dt,
+          pull_up: true, debounce_time: 0.05,
+          button_actions: { press_action: actionFromSlot(prefix + '-rpress'), hold_action: actionFromSlot(prefix + '-rhold') },
+          encoder_actions: { rotate_clockwise: actionFromSlot(prefix + '-cw'), rotate_counterclockwise: actionFromSlot(prefix + '-ccw') }
+        };
+        if (btnPin != null) entry.button_pin = btnPin;
+        rotary.push(entry);
+      }
+    });
+    return {
+      buttons: buttons,
+      two_way_switches: two_way,
+      three_way_switches: three_way,
+      rotary_encoders: rotary,
+      combined_actions: (lastLoadedSettings && lastLoadedSettings.hardware_controls && lastLoadedSettings.hardware_controls.combined_actions) || []
+    };
   }
   function buildQuadRotaryState(){
     return {
@@ -2339,6 +2557,7 @@
     state.hardware_controls = buildHardwareControlsState();
     if (!state.input_peripherals) state.input_peripherals = {};
     state.input_peripherals.quad_rotary_controller = buildQuadRotaryState();
+    applyGpioOutToState(state);
     return state;
   }
 
@@ -2657,18 +2876,23 @@
     container.setAttribute('data-chip-original', JSON.stringify(arr.map(String)));
   }
 
-  /* Buttons/switches/quad-rotary: the mockup's UI only edits 3 fixed
-     buttons + 2 fixed two-way switches (buildHardwareControlsState() always
-     returns empty three_way_switches/rotary_encoders/combined_actions,
-     since it has no widgets for them). A real settings.jsonc can have more
-     of any of these. Populating for display is fine either way, but SAVING
-     must never let an un-editable field silently disappear -- see the save
-     handler below, which passes those through from lastLoadedSettings
-     rather than trusting buildHardwareControlsState()/buildQuadRotaryState()
-     for anything this page doesn't actually expose a widget for. */
+  /* Buttons/switches/rotary encoders (B11.5): #controlsList is fully
+     dynamic, built and read generically by control type and prefix (see
+     buildHardwareControlsState() and populateHardwareControlsAndQuadRotary()
+     above), so any count of any type round-trips -- no fixed slots, no
+     ceiling, nothing silently dropped on save. quad_rotary_controller keeps
+     its own fixed 4-encoder UI (unrelated to F-292/293/294) and is likewise
+     built fresh by buildQuadRotaryState() every save now. combined_actions
+     has no UI on this page and is the one thing still passed through from
+     lastLoadedSettings -- see buildHardwareControlsState(). */
   function applyActionToSlot(slot, action){
     if (!slot) return;
-    var method = 'rec', args = '';
+    // "None" (or absent) must stay distinguishable from a real action once
+    // it round-trips -- defaulting to 'rec' here silently turned a gesture
+    // with no action configured into "start/stop recording" on save
+    // (caught by a full save round-trip test against a button whose
+    // press_action is "None"; see system-review/FINDINGS.md B11.5 notes).
+    var method = '', args = '';
     if (action && typeof action === 'object' && action.method){
       method = action.method;
       if (Array.isArray(action.args)) args = action.args.join(' ');
@@ -2690,29 +2914,13 @@
 
   function populateHardwareControlsAndQuadRotary(settings){
     var hw = (settings && settings.hardware_controls) || {};
-    var buttons = hw.buttons || [];
-    var switches = hw.two_way_switches || [];
 
-    function setPin(id, pin){
-      var el = document.getElementById(id);
-      if (el) el.value = (pin === undefined || pin === null) ? 'none' : String(pin);
-    }
-    setPin('cfg-gpio-btn1', buttons[0] && buttons[0].pin);
-    setPin('cfg-gpio-btn2', buttons[1] && buttons[1].pin);
-    setPin('cfg-gpio-btn3', buttons[2] && buttons[2].pin);
-    setPin('cfg-gpio-sw1', switches[0] && switches[0].pin);
-    setPin('cfg-gpio-sw2', switches[1] && switches[1].pin);
-    if (buttons[0]) populateButtonLike('act-btn1', buttons[0]);
-    if (buttons[1]) populateButtonLike('act-btn2', buttons[1]);
-    if (buttons[2]) populateButtonLike('act-btn3', buttons[2]);
-    if (switches[0]){
-      applyActionToSlot(document.getElementById('act-sw1-on'), switches[0].state_on_action);
-      applyActionToSlot(document.getElementById('act-sw1-off'), switches[0].state_off_action);
-    }
-    if (switches[1]){
-      applyActionToSlot(document.getElementById('act-sw2-on'), switches[1].state_on_action);
-      applyActionToSlot(document.getElementById('act-sw2-off'), switches[1].state_off_action);
-    }
+    var list = document.getElementById('controlsList');
+    list.innerHTML = '';
+    (hw.buttons || []).forEach(function(b){ appendControlRow(buildButtonRow(b)); });
+    (hw.two_way_switches || []).forEach(function(s){ appendControlRow(buildSwitch2Row(s)); });
+    (hw.three_way_switches || []).forEach(function(s){ appendControlRow(buildSwitch3Row(s)); });
+    (hw.rotary_encoders || []).forEach(function(r){ appendControlRow(buildRotaryRow(r)); });
 
     var qr = (settings && settings.input_peripherals && settings.input_peripherals.quad_rotary_controller) || {};
     var enc = qr.encoders || {};
@@ -2720,12 +2928,106 @@
       if (enc[idx] && enc[idx].button) populateButtonLike('act-qr' + idx, enc[idx].button);
     });
 
-    var extra = buttons.length > 3 || switches.length > 2 ||
-      (hw.three_way_switches && hw.three_way_switches.length) ||
-      (hw.rotary_encoders && hw.rotary_encoders.length) ||
-      (hw.combined_actions && hw.combined_actions.length);
-    var warn = document.getElementById('hwControlsExtraWarning');
-    if (warn) warn.hidden = !extra;
+    populateGpioOut(settings);
+  }
+
+  /* ---------- B11.5: dynamic GPIO OUT rows (rec_out_pin[] "REC tally" +
+     rec_tone.pin[] "REC tone") -- replaces the single fixed tally-pin select,
+     which had no data-path and so was silently dropped (reset to the
+     defaults in config_loader.py) on every save regardless of what page the
+     operator was actually editing. Adding a second tally/tone pin was
+     impossible for the same reason: there was nowhere to put it. */
+  function buildGpioOutRow(pin, method){
+    var prefix = nextControlPrefix();
+    var row = document.createElement('div');
+    row.className = 'actionrow';
+    row.setAttribute('data-control-type', 'gpio-out');
+    row.setAttribute('data-prefix', prefix);
+    row.setAttribute('data-search', 'gpio out tally tone rec');
+    var picker = makeSingleGpioOutPinPicker(prefix + '-pin', 'a GPIO output', pin, 'output').wrap;
+    var gesturesWrap = document.createElement('div');
+    gesturesWrap.className = 'gestures-wrap';
+    var head = document.createElement('div');
+    head.className = 'gestures-head';
+    head.innerHTML = '<span>Trigger</span><span>Method</span>';
+    var gestures = document.createElement('div');
+    gestures.className = 'gestures';
+    var g = document.createElement('div');
+    g.className = 'gesture';
+    var name = document.createElement('span');
+    name.className = 'g-name';
+    name.textContent = 'While rec';
+    var methodSel = document.createElement('select');
+    methodSel.className = 'field-input gpio-out-method';
+    methodSel.id = prefix + '-method';
+    methodSel.setAttribute('aria-label', 'What this output pin drives');
+    ['tally', 'tone'].forEach(function(v){
+      var opt = document.createElement('option');
+      opt.value = v; opt.textContent = v === 'tally' ? 'REC tally' : 'REC tone';
+      if (v === method) opt.selected = true;
+      methodSel.appendChild(opt);
+    });
+    methodSel.addEventListener('change', markControlsDirtyIfNeeded);
+    g.appendChild(name);
+    g.appendChild(methodSel);
+    gestures.appendChild(g);
+    gesturesWrap.appendChild(head);
+    gesturesWrap.appendChild(gestures);
+    row.appendChild(picker);
+    row.appendChild(gesturesWrap);
+    row.appendChild(makeRowRemoveButton(row, 'this output pin'));
+    return row;
+  }
+
+  function populateGpioOut(settings){
+    var out = (settings && settings.hardware_outputs) || {};
+    var list = document.getElementById('gpioOutList');
+    list.innerHTML = '';
+    (out.rec_out_pin || []).forEach(function(pin){
+      var row = buildGpioOutRow(pin, 'tally');
+      list.appendChild(row);
+      row.querySelectorAll('.gpio-select').forEach(initGpioSelect);
+    });
+    ((out.rec_tone && out.rec_tone.pin) || []).forEach(function(pin){
+      var row = buildGpioOutRow(pin, 'tone');
+      list.appendChild(row);
+      row.querySelectorAll('.gpio-select').forEach(initGpioSelect);
+    });
+  }
+
+  document.getElementById('addGpioOutBtn').addEventListener('click', function(){
+    var row = buildGpioOutRow(null, 'tally');
+    document.getElementById('gpioOutList').appendChild(row);
+    row.querySelectorAll('.gpio-select').forEach(initGpioSelect);
+    markControlsDirtyIfNeeded();
+  });
+
+  /* Called after buildState()'s generic [data-path] walk already populated
+     state.hardware_outputs.rec_tone.{frequency_hz,duty_cycle,relay_drop_frames}
+     -- adds rec_out_pin[] and rec_tone.pin[] (read from #gpioOutList, which
+     has no data-path since each row is a dynamic pin+method pair, not a
+     single field) into that same object rather than replacing it.
+     pwm_pin has no UI anywhere on this page; preserved from the last real
+     load so it doesn't default-reset (config_loader.py's setdefault) on
+     every unrelated save the way rec_out_pin/rec_tone.pin used to. */
+  function applyGpioOutToState(state){
+    state.hardware_outputs = state.hardware_outputs || {};
+    var recOutPins = [], tonePins = [];
+    document.querySelectorAll('#gpioOutList [data-control-type="gpio-out"]').forEach(function(row){
+      var prefix = row.getAttribute('data-prefix');
+      var pin = gpioPinValue(prefix + '-pin');
+      if (pin == null) return;
+      var methodEl = document.getElementById(prefix + '-method');
+      if (methodEl && methodEl.value === 'tone') tonePins.push(pin);
+      else recOutPins.push(pin);
+    });
+    state.hardware_outputs.rec_out_pin = recOutPins;
+    state.hardware_outputs.rec_tone = state.hardware_outputs.rec_tone || {};
+    state.hardware_outputs.rec_tone.pin = tonePins;
+    var prevOutputs = lastLoadedSettings && lastLoadedSettings.hardware_outputs;
+    if (prevOutputs && prevOutputs.pwm_pin !== undefined && state.hardware_outputs.pwm_pin === undefined){
+      state.hardware_outputs.pwm_pin = prevOutputs.pwm_pin;
+    }
   }
 
   function clearSettingsDirtyState(){
@@ -2815,20 +3117,14 @@
       return;
     }
 
-    // settings.jsonc: build the payload from the fields this page actually
-    // edits, but pass hardware_controls / quad_rotary_controller through
-    // from the last real load rather than buildHardwareControlsState()/
-    // buildQuadRotaryState() -- see populateHardwareControlsAndQuadRotary()
-    // above for why: this page only has widgets for 3 buttons + 2 switches,
-    // and silently dropping a real file's 4th button or its rotary_encoders
-    // on save would be a correctness bug, not a mockup gap.
+    // settings.jsonc: buildState() now builds hardware_controls and
+    // quad_rotary_controller fresh from #controlsList/the quad-rotary
+    // widgets (B11.5 -- the GPIO IN pane represents every button, switch,
+    // three-way switch and rotary encoder, so there's no longer a subset
+    // this page can't express). combined_actions has no UI here, so
+    // buildHardwareControlsState() carries it through from the last real
+    // load rather than dropping it.
     var payload = buildState();
-    if (lastLoadedSettings){
-      payload.hardware_controls = lastLoadedSettings.hardware_controls;
-      if (!payload.input_peripherals) payload.input_peripherals = {};
-      payload.input_peripherals.quad_rotary_controller =
-        lastLoadedSettings.input_peripherals && lastLoadedSettings.input_peripherals.quad_rotary_controller;
-    }
 
     fetch('/settings-editor/api/settings', {
       method: 'PUT', headers: { 'Content-Type': 'application/json' },
@@ -3232,11 +3528,14 @@
     select.innerHTML = html;
   }
   function refreshAllGpioSelects(){ document.querySelectorAll('.gpio-select').forEach(renderGpioOptions); }
-  document.querySelectorAll('.gpio-select').forEach(function(sel){
+  /* One-time setup for a .gpio-select -- called for every pin picker present
+     at load, and again for each one a dynamically-added control row creates
+     (B11.5), so newly-added buttons/switches/rotary encoders get the exact
+     same conflict-aware options + confirm-to-remap behavior as the ones the
+     page started with. */
+  function initGpioSelect(sel){
     sel.setAttribute('data-prev-value', sel.getAttribute('data-initial') || 'none');
-  });
-  refreshAllGpioSelects();
-  document.querySelectorAll('.gpio-select').forEach(function(sel){
+    renderGpioOptions(sel);
     sel.addEventListener('change', function(){
       var next = sel.value;
       var prev = sel.getAttribute('data-prev-value');
@@ -3255,7 +3554,8 @@
         sel.value = prev;
       });
     });
-  });
+  }
+  document.querySelectorAll('.gpio-select').forEach(initGpioSelect);
 
   /* ---------- button/switch/rotary action pickers, sourced from cli_commands.py ---------- */
   var ACTION_METHODS = [
@@ -3314,6 +3614,10 @@
     var sel = document.createElement('select');
     sel.className = 'field-input action-method';
     sel.setAttribute('aria-label', 'Method');
+    var none = document.createElement('option');
+    none.value = ''; none.textContent = 'No action';
+    if (!currentMethod) none.selected = true;
+    sel.appendChild(none);
     var groups = {};
     var order = [];
     ACTION_METHODS.forEach(function(m){
@@ -3332,10 +3636,10 @@
       });
       sel.appendChild(og);
     });
-    if (!ACTION_METHOD_MAP[currentMethod]){
+    if (currentMethod && !ACTION_METHOD_MAP[currentMethod]){
       var custom = document.createElement('option');
       custom.value = currentMethod; custom.textContent = currentMethod + ' (custom)'; custom.selected = true;
-      sel.insertBefore(custom, sel.firstChild);
+      sel.insertBefore(custom, sel.firstChild.nextSibling);
     }
     return sel;
   }
@@ -3378,7 +3682,7 @@
   function actionListIcon(){ return '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8 6h13M8 12h13M8 18h13"/><circle cx="3" cy="6" r="1"/><circle cx="3" cy="12" r="1"/><circle cx="3" cy="18" r="1"/></svg>'; }
 
   function renderActionSlot(slot){
-    var method = slot.getAttribute('data-method') || 'rec';
+    var method = slot.getAttribute('data-method') || '';
     var args = slot.getAttribute('data-args') || '';
     slot.innerHTML = '';
     var picker = document.createElement('span');
@@ -3444,52 +3748,56 @@
     var origArgs = slot.getAttribute('data-original-args') || '';
     markDirty(slot, curMethod !== origMethod || curArgs !== origArgs);
   }
-  /* Method reads before Action (left-to-right) — swap each gesture's own
-     pair in the DOM so display:contents lays them into the grid in that
-     order, without disturbing any other gesture's pair. */
-  document.querySelectorAll('.gesture').forEach(function(g){
-    var name = g.querySelector('.g-name');
-    var value = g.querySelector('.action-slot, .action-args');
-    if (name && value) g.insertBefore(value, name);
-  });
   document.querySelectorAll('.action-slot').forEach(function(slot){
     slot.setAttribute('data-original-method', slot.getAttribute('data-method') || '');
     slot.setAttribute('data-original-args', slot.getAttribute('data-args') || '');
     renderActionSlot(slot);
   });
 
-  /* ---------- "+ Add" a second (or third…) gesture onto a button/encoder ---------- */
-  var GESTURE_LABELS = { press: 'Press', single: 'Single', double: 'Double', triple: 'Triple', hold: 'Hold' };
-  document.querySelectorAll('.add-gesture-select').forEach(function(sel){
-    sel.addEventListener('change', function(){
-      if (!sel.value) return;
-      var gestureKey = sel.value;
-      var prefix = sel.getAttribute('data-prefix');
-      var addRow = sel.closest('.gesture-add');
-      var gestures = addRow.closest('.gestures');
-      var newGesture = document.createElement('div');
-      newGesture.className = 'gesture';
-      var nameSpan = document.createElement('span');
-      nameSpan.className = 'g-name';
-      nameSpan.textContent = GESTURE_LABELS[gestureKey];
-      var slotSpan = document.createElement('span');
-      slotSpan.className = 'action-slot';
-      slotSpan.id = prefix + '-' + gestureKey;
-      slotSpan.setAttribute('data-method', 'rec');
-      slotSpan.setAttribute('data-original-method', '');
-      slotSpan.setAttribute('data-original-args', '');
-      newGesture.appendChild(slotSpan);
-      newGesture.appendChild(nameSpan);
-      gestures.insertBefore(newGesture, addRow);
-      renderActionSlot(slotSpan);
-      checkActionDirty(slotSpan);
-      showToast(GESTURE_LABELS[gestureKey] + ' action added');
+  /* ---------- "+ Add" a second (or third…) gesture onto a button/switch/
+     encoder (B11.5) — event-delegated on #app so it covers quad-rotary's
+     static rows and every dynamically-added control row the same way,
+     with no separate wiring needed per row. .g-name (74px) then
+     .action-slot (1fr) is the DOM order the CSS grid tracks expect. */
+  var GESTURE_LABELS = {
+    press: 'Press', single: 'Single', double: 'Double', triple: 'Triple', hold: 'Hold',
+    on: 'On', off: 'Off',
+    s0: 'Position 1', s1: 'Position 2', s2: 'Position 3',
+    rpress: 'Button press', rhold: 'Button hold', cw: 'Rotate CW', ccw: 'Rotate CCW'
+  };
+  document.getElementById('app').addEventListener('change', function(e){
+    var sel = e.target.closest('.add-gesture-select');
+    if (!sel || !sel.value) return;
+    var gestureKey = sel.value;
+    var prefix = sel.getAttribute('data-prefix');
+    var addRow = sel.closest('.gesture-add');
+    var gestures = addRow.closest('.gestures');
+    var newGesture = document.createElement('div');
+    newGesture.className = 'gesture';
+    var nameSpan = document.createElement('span');
+    nameSpan.className = 'g-name';
+    nameSpan.textContent = GESTURE_LABELS[gestureKey] || gestureKey;
+    var slotSpan = document.createElement('span');
+    slotSpan.className = 'action-slot';
+    slotSpan.id = prefix + '-' + gestureKey;
+    slotSpan.setAttribute('data-method', '');
+    slotSpan.setAttribute('data-original-method', '');
+    slotSpan.setAttribute('data-original-args', '');
+    newGesture.appendChild(nameSpan);
+    newGesture.appendChild(slotSpan);
+    if (sel.getAttribute('data-removable') !== 'false'){
+      addGestureRemoveButton(newGesture, slotSpan, GESTURE_LABELS[gestureKey] || gestureKey);
+    }
+    gestures.insertBefore(newGesture, addRow);
+    renderActionSlot(slotSpan);
+    checkActionDirty(slotSpan);
+    markControlsDirtyIfNeeded(sel);
+    showToast((GESTURE_LABELS[gestureKey] || gestureKey) + ' action added');
 
-      var chosenOpt = sel.querySelector('option[value="' + gestureKey + '"]');
-      if (chosenOpt) chosenOpt.remove();
-      sel.value = '';
-      if (sel.options.length <= 1) addRow.remove();
-    });
+    var chosenOpt = sel.querySelector('option[value="' + gestureKey + '"]');
+    if (chosenOpt) chosenOpt.remove();
+    sel.value = '';
+    if (sel.options.length <= 1) addRow.remove();
   });
 
   /* ---------- mobile rail ---------- */
@@ -3575,38 +3883,6 @@
     updateGroupVisibility();
     if (typeof updateBulkBar === 'function') updateBulkBar();
   });
-
-  /* ---------- live view ---------- */
-  document.getElementById('liveIsoSelect').addEventListener('change', function(){ document.getElementById('liveIso').textContent = this.value; });
-  document.getElementById('liveShutterSelect').addEventListener('change', function(){ document.getElementById('liveShutter').textContent = this.value + '°'; });
-  document.getElementById('liveFpsSelect').addEventListener('change', function(){ document.getElementById('liveFps').textContent = this.value; });
-  document.getElementById('liveWbSelect').addEventListener('change', function(){ document.getElementById('liveWb').textContent = this.value + ' K'; });
-  (function(){
-    var recBtn = document.getElementById('liveRecBtn');
-    var recLabel = document.getElementById('liveRecLabel');
-    var tally = document.getElementById('liveTally');
-    var recTimeEl = document.getElementById('liveRecTime');
-    var timer = null, seconds = 0;
-    recBtn.addEventListener('click', function(){
-      var recording = recBtn.classList.toggle('recording');
-      tally.classList.toggle('on', recording);
-      recLabel.textContent = recording ? 'Stop' : 'Record';
-      if (recording){
-        seconds = 0;
-        recTimeEl.textContent = '00:00';
-        timer = setInterval(function(){
-          seconds++;
-          var m = String(Math.floor(seconds / 60)).padStart(2, '0');
-          var s = String(seconds % 60).padStart(2, '0');
-          recTimeEl.textContent = m + ':' + s;
-        }, 1000);
-        showToast('Recording started');
-      } else {
-        clearInterval(timer);
-        showToast('Recording stopped — take saved');
-      }
-    });
-  })();
 
   /* ---------- boot sequence engine (shared by Cinemate restart & Pi reboot) ---------- */
   function runBootSequence(opts){

--- a/src/module/app/templates/settings_editor.html
+++ b/src/module/app/templates/settings_editor.html
@@ -876,6 +876,7 @@
       <a href="#steps" data-nav>Value steps</a>
       <a href="#pots" data-nav>Pots &amp; free mode</a>
       <a href="#resolution" data-nav>Resolution &amp; sensor</a>
+      <a href="#fpsceilings" data-nav>Per-mode fps ceilings</a>
     </div>
     <div class="rail-group" data-page="settings">
       <div class="rail-title eyebrow">Recording</div>
@@ -1590,6 +1591,13 @@
           </div>
         </div>
       </div>
+    </section>
+    <section class="group" id="fpsceilings" data-page="settings">
+      <header class="group-head">
+        <h2>Per-mode fps ceilings</h2>
+        <p class="group-sub">A mode's advertised fps_max is an electrical property of the sensor, not a guarantee this storage/CPU can sustain it. Leave a field blank to keep using the detected value; fill one in only for a mode you've found a lower real-world ceiling for by trial. Raising above the detected value is allowed but logged as a warning -- the sensor never reported it.</p>
+      </header>
+      <div class="cards" id="fpsCeilingsList"><p class="card-help">Loading detected modes…</p></div>
     </section>
     <section class="group" id="audio" data-page="settings">
       <header class="group-head">
@@ -2339,7 +2347,123 @@
     state.hardware_controls = buildHardwareControlsState();
     if (!state.input_peripherals) state.input_peripherals = {};
     state.input_peripherals.quad_rotary_controller = buildQuadRotaryState();
+    if (!state.image_capture) state.image_capture = {};
+    state.image_capture.custom_modes = buildCustomModesState();
     return state;
+  }
+
+  /* ---------- B11.8: per-mode fps ceiling overrides ------------------
+     image_capture.custom_modes is sparse -- only modes the operator has
+     actually typed a value for get an entry, so nothing goes stale when
+     the sensor changes (F-298). A row with a blank field, or one whose
+     value matches the detected fps_max exactly, means "no override": its
+     entry (if any) is dropped rather than written out redundantly.
+     Any pre-existing custom_modes entry that does NOT match one of the
+     modes this pane lists (a genuinely new, undetected mode someone added
+     by hand) is left completely untouched -- same reasoning as B11.5's
+     hardware_controls fix: a pane must never silently drop what it
+     doesn't itself represent. */
+  function renderFpsCeilings(sensors){
+    var list = document.getElementById('fpsCeilingsList');
+    list.innerHTML = '';
+    var customModes = (lastLoadedSettings && lastLoadedSettings.image_capture
+      && lastLoadedSettings.image_capture.custom_modes) || {};
+    var any = false;
+    Object.keys(sensors).forEach(function(camera){
+      (sensors[camera] || []).forEach(function(mode){
+        any = true;
+        var override = (customModes[camera] || []).find(function(entry){
+          return Number(entry.width) === mode.width && Number(entry.height) === mode.height
+            && Number(entry.bit_depth) === mode.bit_depth && !!entry.hdr === !!mode.hdr;
+        });
+
+        var row = document.createElement('div');
+        row.className = 'card';
+        row.setAttribute('data-fps-row', '1');
+        row.setAttribute('data-camera', camera);
+        row.setAttribute('data-width', mode.width);
+        row.setAttribute('data-height', mode.height);
+        row.setAttribute('data-bit-depth', mode.bit_depth);
+        row.setAttribute('data-hdr', mode.hdr ? 'true' : 'false');
+        row.setAttribute('data-detected', mode.fps_max_detected);
+        row.setAttribute('data-search', 'fps ceiling ' + camera + ' ' + mode.width + ' ' + mode.height);
+
+        var main = document.createElement('div');
+        main.className = 'card-main';
+        var label = document.createElement('label');
+        label.className = 'card-label';
+        label.textContent = camera + ' ' + mode.width + '×' + mode.height + ' · ' + mode.bit_depth + '-bit' + (mode.hdr ? ' HDR' : '');
+        var help = document.createElement('p');
+        help.className = 'card-help';
+        help.textContent = 'Sensor reports ' + mode.fps_max_detected + ' fps.';
+        main.appendChild(label);
+        main.appendChild(help);
+
+        var control = document.createElement('div');
+        control.className = 'card-control';
+        var input = document.createElement('input');
+        input.type = 'number';
+        input.className = 'field-input num-input fps-ceiling-input';
+        input.placeholder = String(mode.fps_max_detected);
+        input.min = '0';
+        input.step = 'any';
+        if (override) input.value = override.fps_max;
+        input.addEventListener('change', function(){ markDirty(input, true); });
+        control.appendChild(input);
+        var unit = document.createTextNode(' fps');
+        control.appendChild(unit);
+
+        row.appendChild(main);
+        row.appendChild(control);
+        list.appendChild(row);
+      });
+    });
+    if (!any) list.innerHTML = '<p class="card-help">No detected sensor modes yet -- reconnect the camera or check cinepi-raw --list-cameras.</p>';
+  }
+
+  function loadFpsCeilings(){
+    return fetch('/settings-editor/api/sensor-modes').then(function(r){ return r.json(); }).then(function(res){
+      if (!res.ok) return;
+      renderFpsCeilings(res.sensors || {});
+    }).catch(function(){ /* non-fatal -- the rest of the page still works */ });
+  }
+
+  function buildCustomModesState(){
+    var out = {};
+    var customModes = (lastLoadedSettings && lastLoadedSettings.image_capture
+      && lastLoadedSettings.image_capture.custom_modes) || {};
+    // Start from every existing entry, so a genuinely custom (undetected)
+    // mode this pane has no row for survives untouched.
+    Object.keys(customModes).forEach(function(camera){
+      out[camera] = (customModes[camera] || []).slice();
+    });
+
+    document.querySelectorAll('#fpsCeilingsList [data-fps-row]').forEach(function(row){
+      var camera = row.getAttribute('data-camera');
+      var w = parseInt(row.getAttribute('data-width'), 10);
+      var h = parseInt(row.getAttribute('data-height'), 10);
+      var bd = parseInt(row.getAttribute('data-bit-depth'), 10);
+      var hdr = row.getAttribute('data-hdr') === 'true';
+      var detected = parseFloat(row.getAttribute('data-detected'));
+      var input = row.querySelector('.fps-ceiling-input');
+      var raw = (input.value || '').trim();
+
+      out[camera] = (out[camera] || []).filter(function(entry){
+        return !(Number(entry.width) === w && Number(entry.height) === h
+          && Number(entry.bit_depth) === bd && !!entry.hdr === hdr);
+      });
+
+      if (raw === '') return; // blank -- use the detected value, no entry
+      var val = parseFloat(raw);
+      if (isNaN(val) || val === detected) return; // matches detected -- redundant, no entry
+
+      var entry = { width: w, height: h, bit_depth: bd, fps_max: val };
+      if (hdr) entry.hdr = true;
+      out[camera].push(entry);
+    });
+
+    Object.keys(out).forEach(function(camera){ if (out[camera].length === 0) delete out[camera]; });
+    return out;
   }
 
   /* ---------- config.txt reconstruction ---------- */
@@ -2758,6 +2882,7 @@
       if (!res.ok){ showToast('Could not load settings.jsonc: ' + res.message); return; }
       populateSettingsForm(res.settings);
       if (res.source === 'stock') showToast('No settings.jsonc on this Pi yet — showing stock defaults');
+      loadFpsCeilings();
     }).catch(function(err){ showToast('Could not reach the server: ' + err); });
   }
 
@@ -3575,38 +3700,6 @@
     updateGroupVisibility();
     if (typeof updateBulkBar === 'function') updateBulkBar();
   });
-
-  /* ---------- live view ---------- */
-  document.getElementById('liveIsoSelect').addEventListener('change', function(){ document.getElementById('liveIso').textContent = this.value; });
-  document.getElementById('liveShutterSelect').addEventListener('change', function(){ document.getElementById('liveShutter').textContent = this.value + '°'; });
-  document.getElementById('liveFpsSelect').addEventListener('change', function(){ document.getElementById('liveFps').textContent = this.value; });
-  document.getElementById('liveWbSelect').addEventListener('change', function(){ document.getElementById('liveWb').textContent = this.value + ' K'; });
-  (function(){
-    var recBtn = document.getElementById('liveRecBtn');
-    var recLabel = document.getElementById('liveRecLabel');
-    var tally = document.getElementById('liveTally');
-    var recTimeEl = document.getElementById('liveRecTime');
-    var timer = null, seconds = 0;
-    recBtn.addEventListener('click', function(){
-      var recording = recBtn.classList.toggle('recording');
-      tally.classList.toggle('on', recording);
-      recLabel.textContent = recording ? 'Stop' : 'Record';
-      if (recording){
-        seconds = 0;
-        recTimeEl.textContent = '00:00';
-        timer = setInterval(function(){
-          seconds++;
-          var m = String(Math.floor(seconds / 60)).padStart(2, '0');
-          var s = String(seconds % 60).padStart(2, '0');
-          recTimeEl.textContent = m + ':' + s;
-        }, 1000);
-        showToast('Recording started');
-      } else {
-        clearInterval(timer);
-        showToast('Recording stopped — take saved');
-      }
-    });
-  })();
 
   /* ---------- boot sequence engine (shared by Cinemate restart & Pi reboot) ---------- */
   function runBootSequence(opts){

--- a/src/module/app/templates/settings_editor.html
+++ b/src/module/app/templates/settings_editor.html
@@ -619,7 +619,7 @@
   .bulk-bar{
     display:none; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap;
     padding: 10px 14px; border: 1px solid var(--accent); background: var(--accent-soft);
-    border-radius: var(--radius); margin-bottom: 10px; font-size: 13px;
+    border-radius: var(--radius); margin-top: 10px; font-size: 13px;
   }
   .bulk-bar.show{ display:flex; }
   .bulk-bar .actions{ display:flex; gap:8px; }
@@ -2056,6 +2056,11 @@
         <button class="btn btn-ghost" id="refreshClips" style="margin-left:auto">Refresh</button>
       </div>
 
+      <div class="cliplist" id="clipList"></div>
+      <p class="card-help" id="clipListFooter" style="margin-top:10px"></p>
+
+      <!-- F-295: below the list, not above -- these buttons act on the
+           selection the operator just made in the list above them. -->
       <div class="bulk-bar" id="bulkBar">
         <span id="bulkCount">0 selected</span>
         <span class="actions">
@@ -2063,9 +2068,6 @@
           <button class="btn btn-danger-outline" id="bulkDelete">Delete selected</button>
         </span>
       </div>
-
-      <div class="cliplist" id="clipList"></div>
-      <p class="card-help" id="clipListFooter" style="margin-top:10px"></p>
     </section>
 
     <!-- BOOT CONFIG -->
@@ -2237,6 +2239,17 @@
 (function(){
   "use strict";
   var reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  /* ---------- /api/v1/cmd -- same dispatcher as the CLI, serial and GPIO
+     paths (docs/web-api.md), matches template.html's cmd() ---------- */
+  var API_TOKEN = {{ api_token | tojson }};
+  function apiCmd(line){
+    var headers = { 'Content-Type': 'text/plain' };
+    if (API_TOKEN) { headers['X-Cinemate-Token'] = API_TOKEN; }
+    return fetch('/api/v1/cmd', { method: 'POST', headers: headers, body: line })
+      .then(function(res){ return res.text().then(function(body){ return { ok: res.ok, body: body.trim() }; }); })
+      .catch(function(err){ return { ok: false, body: err.message }; });
+  }
 
   /* ---------- state / dirty tracking ---------- */
   var dirtyEls = new Set();
@@ -3656,11 +3669,24 @@
     { t: '[cinemate] ready — iso 800 · 172.8° · 25 fps', cls: 'tag-ok' }
   ];
   restartBtn.addEventListener('click', function(){
-    runBootSequence({
-      btn: restartBtn, dot: statusDot, text: statusText, consoleEl: consoleEl, lines: bootLines,
-      busyText: 'Restarting Cinemate — <b class="din">please wait</b>',
-      readyText: 'Cinemate is running — <b class="din">READY</b>',
-      doneToast: 'Cinemate is back up'
+    // F-291: this used to only play the boot-sequence animation below and
+    // never actually asked the backend to restart anything. The animated
+    // lines are still a stylized "please wait" affordance, not a live log
+    // -- there is no streaming progress feed for this today -- but the
+    // restart itself is now real, gated on a successful /api/v1/cmd call.
+    restartBtn.disabled = true;
+    apiCmd('restart cinemate').then(function(result){
+      if (!result.ok) {
+        restartBtn.disabled = false;
+        showToast('Restart failed: ' + (result.body || 'unknown error'));
+        return;
+      }
+      runBootSequence({
+        btn: restartBtn, dot: statusDot, text: statusText, consoleEl: consoleEl, lines: bootLines,
+        busyText: 'Restarting Cinemate — <b class="din">please wait</b>',
+        readyText: 'Cinemate is running — <b class="din">READY</b>',
+        doneToast: 'Cinemate is back up'
+      });
     });
   });
 

--- a/src/module/app/templates/template.html
+++ b/src/module/app/templates/template.html
@@ -395,28 +395,24 @@
         }
         #toast.show { opacity: 1; }
 
-        /* ── narrow screens: rails become strips above/below the preview ── */
+        /* ── narrow screens: scale, don't reflow (B11.7 / F-297) ──────────
+           This used to restack #stage into rows and turn each .rail into a
+           horizontal strip above/below the preview at <=900px or portrait
+           -- the one thing that made the web GUI stop resembling the HDMI
+           GUI at narrow widths (simple_gui.py scales its whole 1920x1080
+           layout by a single disp_width/1920, disp_height/1080 ratio; it
+           never restacks). #stage's 3-column grid (left rail | preview |
+           right rail) and .rail's own column direction are the same at
+           every width now -- --gap/--box-size/--box-height/--value-size/
+           --label-size are already clamp()-based (top of this file), so
+           the rails and top-row text shrink smoothly as the viewport
+           narrows instead of the layout restructuring at a breakpoint.
+           minmax(0, 1fr) on #stage's center column absorbs whatever's left
+           for the preview once both rails have taken their (now small)
+           clamped width. Only genuinely orientation-neutral narrow-screen
+           tweaks remain here. */
         @media (max-width: 900px), (orientation: portrait) {
-            #stage {
-                grid-template-columns: minmax(0, 1fr);
-                grid-template-rows: auto minmax(0, 1fr) auto;
-            }
-            .rail {
-                flex-direction: row;
-                flex-wrap: wrap;
-                align-items: flex-start;
-                gap: calc(var(--gap) * 0.6);
-            }
-            .section { flex-direction: row; align-items: center; gap: 0.4em; }
-            .section + .section { margin-top: 0; }
-            .section .section-label { margin-bottom: 0; }
-            .section .boxes { flex-direction: row; }
-            .group.clip .value { max-width: 85vw; }
             #button-row { justify-content: center; }
-            /* margin-top:auto only means "push to the bottom" in a column
-               rail; in the row-wrapped mobile rail it would just tug the
-               meter into leftover cross-space unevenly, so drop it. */
-            #vu-meter { margin-top: 0; padding-top: 0; }
             .vu-track { height: clamp(50px, 12vh, 100px); }
         }
     </style>

--- a/src/module/cinepi_controller.py
+++ b/src/module/cinepi_controller.py
@@ -134,6 +134,7 @@ class CinePiController:
         self._storage_profile_restart_lock = threading.Lock()
         self._storage_profile_restart_active = False
         self._resolution_change_callbacks = []
+        self._resolution_switch_complete_callbacks = []
         self._resolution_change_pace_lock = threading.Lock()
         self._last_resolution_change_started_at = 0.0
         self._resolution_change_min_interval_s = 0.25
@@ -1099,12 +1100,31 @@ class CinePiController:
             return
         self._resolution_change_callbacks.append(callback)
 
+    def add_resolution_switch_complete_callback(self, callback) -> None:
+        if not callable(callback):
+            logging.warning("Ignoring non-callable resolution switch-complete callback.")
+            return
+        self._resolution_switch_complete_callbacks.append(callback)
+
     def _notify_resolution_change(self, sensor_mode) -> None:
         for callback in list(self._resolution_change_callbacks):
             try:
                 callback(sensor_mode)
             except Exception:
                 logging.exception("Resolution change callback failed.")
+
+    def _notify_resolution_switch_complete(self) -> None:
+        # Fires once the switch is actually over -- either handle_cinepi_raw_message
+        # saw evidence the new stream is up, or (if that message never arrived)
+        # the GUI_RESOLUTION_SWITCHING_HOLD_SECONDS fallback timer expired. This
+        # is deliberately a separate hook from _notify_resolution_change: that one
+        # fires when the switch *starts*, so the browser can show "switching..."
+        # immediately, well before there is a new stream to reconnect to (F-290).
+        for callback in list(self._resolution_switch_complete_callbacks):
+            try:
+                callback()
+            except Exception:
+                logging.exception("Resolution switch-complete callback failed.")
 
     def _pace_resolution_change(self, recording: bool) -> None:
         min_interval = (
@@ -1665,6 +1685,7 @@ class CinePiController:
                 )
             except Exception:
                 logging.exception("Failed to clear resolution switching state.")
+            self._notify_resolution_switch_complete()
 
         timer = threading.Timer(GUI_RESOLUTION_SWITCHING_HOLD_SECONDS, complete)
         timer.daemon = True
@@ -1695,6 +1716,7 @@ class CinePiController:
 
         self._cancel_resolution_switching_timer()
         self.redis_controller.set_value(ParameterKey.RESOLUTION_SWITCHING.value, 0)
+        self._notify_resolution_switch_complete()
 
     def _apply_resolution_mode(self, value, restore_user_fps=None, *, restart_process=False):
         try:
@@ -2376,11 +2398,60 @@ class CinePiController:
         self._active_storage_recorder_profile = self._current_storage_recorder_profile()
 
     def restart_cinemate(self):
-        """Restart the entire CineMate application."""
-        logging.info("Restarting CineMate application")
-        python = sys.executable
-        os.execl(python, python, *sys.argv)
-        
+        """Restart the entire CineMate application (F-291).
+
+        This used to os.execl() in place. Confirmed by a minimal repro under
+        F-291 (see system-review/FINDINGS.md): the Flask/SocketIO listening
+        socket is not closed by exec() (it isn't marked close-on-exec), so
+        the re-exec'd process failed to rebind its port -- "Address already
+        in use" -- and the web GUI stayed dead until an external `systemctl
+        restart`. sys.argv/sys.executable were both fine; the socket was the
+        actual bug. systemd already owns this unit's lifecycle and a real
+        restart tears the whole process down, closing every fd first, so it
+        goes through systemd instead.
+
+        A first version called `sudo systemctl restart --no-block
+        cinemate-autostart` directly -- also confirmed against real hardware
+        to be wrong: that subprocess is a child of *this* process, so it
+        lives in cinemate-autostart.service's own cgroup. The unit's
+        KillMode=control-group (systemd's default) means the SIGINT that
+        stops the old instance is swept across the whole cgroup, including
+        the very systemctl call requesting the restart -- it was observed
+        exiting -2 (killed) before the restart job was even queued, so
+        nothing ever started back up. Routing through `systemd-run` escapes
+        that cgroup: it hands the actual `systemctl restart` off to a fresh
+        transient unit of its own, which the SIGINT sweep can't touch.
+        --no-block on systemd-run itself means this call returns as soon as
+        that hand-off is queued, not once the restart finishes (see the
+        --no-block note below).
+
+        Both commands are exactly what cinemate-install.sh's
+        configure_sudoers() grants -- one narrow, argument-locked rule per
+        command, not a general privileged-exec grant.
+
+        --no-block: this call runs inside the very unit systemd is about to
+        stop. A blocking call would wait for that stop to finish, and that
+        stop is what kills the thread making this call.
+        """
+        logging.info("Restarting CineMate application via systemd")
+        try:
+            result = subprocess.run(
+                [
+                    "sudo", "-n", "systemd-run", "--no-block", "--collect",
+                    "--unit=cinemate-restart-trigger",
+                    "--", "systemctl", "restart", "cinemate-autostart",
+                ],
+                capture_output=True, text=True, timeout=10, check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            logging.error("Could not invoke systemd-run to restart cinemate-autostart: %s", exc)
+            return
+        if result.returncode != 0:
+            logging.error(
+                "systemd-run restart of cinemate-autostart exited %s: %s",
+                result.returncode, (result.stderr or result.stdout or "").strip(),
+            )
+
 
     def set_fps_double(self, value=None):
         target_double_state = not self.fps_double if value is None else value in (1, True)

--- a/src/module/sensor_detect.py
+++ b/src/module/sensor_detect.py
@@ -371,14 +371,54 @@ class SensorDetect:
         self,
         sensors: Dict[str, List[Dict]],
     ) -> Dict[str, Dict[int, Dict]]:
-        """Add custom modes, apply the settings.jsonc filters, order and index."""
-        # ── add any user-defined custom modes ──────────────────────
+        """Add custom modes, apply the settings.jsonc filters, order and index.
+
+        F-298: a custom_modes entry whose (width, height, bit_depth, hdr)
+        matches an already-detected mode overrides that mode's fps_max in
+        place -- the sensor's advertised ceiling is an electrical property
+        and says nothing about what this storage/CPU actually sustain, so
+        it needs to be correctable, not just addable-to. Only fps_max is
+        overridable this way; the rest of the detected mode (packing,
+        gui_layout, aspect) is left alone. A non-matching entry still
+        appends a brand-new mode exactly as before -- this only changes
+        what happens when the dimensions already exist.
+        """
+        # ── add or correct user-defined custom modes ─────────────────
         for cam, extras in self.custom_modes.items():
             sensors.setdefault(cam, [])
             for extra in extras:
                 w, h = int(extra["width"]), int(extra["height"])
                 bd   = int(extra["bit_depth"])
                 fps  = extra.get("fps_max")
+                hdr_flag = bool(extra.get("hdr", False))
+                existing = next(
+                    (
+                        m for m in sensors[cam]
+                        if int(m.get("width") or 0) == w
+                        and int(m.get("height") or 0) == h
+                        and int(m.get("bit_depth") or 0) == bd
+                        and bool(m.get("hdr")) == hdr_flag
+                    ),
+                    None,
+                )
+                if existing is not None:
+                    if fps is not None:
+                        detected_fps = existing.get("fps_max")
+                        if detected_fps is not None and fps > detected_fps:
+                            logging.warning(
+                                "custom_modes override for %s %dx%d (%d-bit%s) raises "
+                                "fps_max from the detected %s to %s -- the sensor did "
+                                "not report this; if storage/CPU can't actually sustain "
+                                "it, lower the value instead of raising it.",
+                                cam, w, h, bd, " HDR" if hdr_flag else "",
+                                detected_fps, fps,
+                            )
+                        # Stash the sensor's own value before overwriting it --
+                        # the settings editor shows this as the "detected"
+                        # placeholder next to the editable effective value.
+                        existing.setdefault("fps_max_detected", detected_fps)
+                        existing["fps_max"] = fps
+                    continue
                 sensors[cam].append(
                     self._mode_from_metadata_or_detected(
                         camera_name=cam,
@@ -386,7 +426,7 @@ class SensorDetect:
                         height=h,
                         bit_depth=bd,
                         fps_max=fps,
-                        hdr=bool(extra.get("hdr", False)),
+                        hdr=hdr_flag,
                         extra=extra,
                     )
                 )


### PR DESCRIPTION
## Summary

Merges all five B11 branches into `dev` in one PR, per request. Each was independently reviewable/mergeable on its own; combined here because they were requested merged together.

- `fix/b11-config-and-mdns` — B11.1 (config.txt save) + B11.2 (mDNS)
- `feature/b11-gui-fixes` — B11.3 (preview reconnect) + B11.4 (Restart Cinemate) + B11.6 (raw pane buttons)
- `feature/b11-gpio-panes-rebuild` — B11.5 (GPIO in/out panes, no ceiling)
- `feature/b11-web-gui-scaling` — B11.7 (scale not reflow)
- `feature/b11-fps-ceiling-override` — B11.8 (per-mode fps ceilings)

Two merge conflicts, both resolved by keeping both sides (independent additions to the same sudoers block / the same `buildState()` function):
- `cinemate-install.sh`: both B11.1 and B11.4 add their own sudoers `NOPASSWD` line to the same block.
- `settings_editor.html`: both B11.5 and B11.8 add their own line to `buildState()`.

Two branches (B11.5, B11.8) independently found and fixed the same pre-existing dead-code bug (a `document.getElementById('liveIsoSelect')` call on an element that doesn't exist anywhere in the page, throwing on every load in every browser and silently breaking the save button, GPIO pin pickers, and search — see F-312 in `system-review/FINDINGS.md`). Both deletions are identical, so the merge just keeps it deleted once.

Full per-item outcome/root-cause narrative is in each branch's own commit message and in `system-review/FINDINGS.md` (F-307..F-313, pushed to `claude/cinemate-system-review-kickoff-cilicc`).

## Test plan
- [x] `pytest _test/` — 450 passed, 244 subtests passed
- [x] `shellcheck cinemate-install.sh` — clean
- [x] `tools/docs_drift_check.py --strict` — clean
- [x] `tools/gui_field_extract.py --max-unresolved 0` — clean
- [x] Node+jsdom round-trip harness (not committed, no JS test tooling in this repo yet) re-run against the fully merged `settings_editor.html`: 33 checks, all passing
- [x] B11.1/B11.2/B11.4 verified against real hardware (192.168.2.6) prior to merge; not re-verified live post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)