### PR TITLE
B11.7 · the web GUI scales at narrow widths instead of reflowing

### DIFF
--- a/src/module/app/templates/template.html
+++ b/src/module/app/templates/template.html
@@ -395,28 +395,24 @@
         }
         #toast.show { opacity: 1; }
 
-        /* ── narrow screens: rails become strips above/below the preview ── */
+        /* ── narrow screens: scale, don't reflow (B11.7 / F-297) ──────────
+           This used to restack #stage into rows and turn each .rail into a
+           horizontal strip above/below the preview at <=900px or portrait
+           -- the one thing that made the web GUI stop resembling the HDMI
+           GUI at narrow widths (simple_gui.py scales its whole 1920x1080
+           layout by a single disp_width/1920, disp_height/1080 ratio; it
+           never restacks). #stage's 3-column grid (left rail | preview |
+           right rail) and .rail's own column direction are the same at
+           every width now -- --gap/--box-size/--box-height/--value-size/
+           --label-size are already clamp()-based (top of this file), so
+           the rails and top-row text shrink smoothly as the viewport
+           narrows instead of the layout restructuring at a breakpoint.
+           minmax(0, 1fr) on #stage's center column absorbs whatever's left
+           for the preview once both rails have taken their (now small)
+           clamped width. Only genuinely orientation-neutral narrow-screen
+           tweaks remain here. */
         @media (max-width: 900px), (orientation: portrait) {
-            #stage {
-                grid-template-columns: minmax(0, 1fr);
-                grid-template-rows: auto minmax(0, 1fr) auto;
-            }
-            .rail {
-                flex-direction: row;
-                flex-wrap: wrap;
-                align-items: flex-start;
-                gap: calc(var(--gap) * 0.6);
-            }
-            .section { flex-direction: row; align-items: center; gap: 0.4em; }
-            .section + .section { margin-top: 0; }
-            .section .section-label { margin-bottom: 0; }
-            .section .boxes { flex-direction: row; }
-            .group.clip .value { max-width: 85vw; }
             #button-row { justify-content: center; }
-            /* margin-top:auto only means "push to the bottom" in a column
-               rail; in the row-wrapped mobile rail it would just tug the
-               meter into leftover cross-space unevenly, so drop it. */
-            #vu-meter { margin-top: 0; padding-top: 0; }
             .vu-track { height: clamp(50px, 12vh, 100px); }
         }
     </style>


### PR DESCRIPTION
The layout should adapt to whatever rectangle it is given: the top row stays the top row, and the left and right grey-box columns stay columns at any width, rather than collapsing into a single stacked flow.

This is the web GUI's half of ADR-001's harmonisation question — the HDMI GUI scales its regions, the web GUI reflowed them, which is why the two stopped resembling each other at narrow widths.

Plan: `REMEDIATION-PLAN.md` §3 batch B11, finding F-297.

## Review notes

- **F-296, the phone hamburger menu, is not closed by this** unless the failure was actually characterised. It was reported only as "does not really work" and filed `unverified` — does not open, opens behind content, wrong breakpoint are three different bugs. If it was not reproduced, say so and leave the finding open rather than assuming the scaling work covered it.
- Overlaps `template.html` with #143 (B9.7 touches the same file) — rebase after that lands.
- `docs/web-gui.md` describes the current layout; B13 should pick that up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBku1dDuju5t762UogsJRq)_