### PR TITLE
feat(settings-editor): format the active RAW drive from the RAW pane

### DIFF
--- a/_test/test_settings_editor_format.py
+++ b/_test/test_settings_editor_format.py
@@ -1,0 +1,181 @@
+"""POST /settings-editor/api/raw/format -- the RAW pane's format-drive control.
+
+The dispatcher discards handler return values, so a successful dispatch says
+nothing about whether mkfs worked. These tests pin the endpoint's actual
+success test: what filesystem is mounted at the active root once the
+dispatch returns.
+"""
+
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+sys.modules.setdefault("redis", types.SimpleNamespace(StrictRedis=object))
+sys.modules.setdefault("smbus", types.SimpleNamespace(SMBus=object))
+
+# Same mechanism as test_web_api_blueprint.py: stub the parent package so the
+# `settings_editor` submodule resolves via __path__ without executing
+# module/app/__init__.py's flask_socketio import.
+_APP_PKG = types.ModuleType("module.app")
+_APP_PKG.__path__ = [str(ROOT / "src" / "module" / "app")]
+sys.modules.setdefault("module.app", _APP_PKG)
+
+from flask import Flask
+
+from module.app import raw_files
+from module.app.settings_editor import settings_editor_bp
+from module.cli_commands import CommandExecutor
+from module.redis_controller import ParameterKey
+
+
+class FakeRedis:
+    def __init__(self, values=None):
+        self.values = dict(values or {})
+
+    def get_value(self, key, default=None):
+        key = key.value if isinstance(key, ParameterKey) else key
+        return self.values.get(key, default)
+
+
+def make_app(redis_values=None, with_executor=True):
+    app = Flask(__name__)
+    app.testing = True
+    controller = mock.MagicMock()
+    command_executor = CommandExecutor(controller, mock.MagicMock()) if with_executor else None
+    if command_executor is not None:
+        app.config["COMMAND_EXECUTOR"] = command_executor
+    app.config["REDIS_CONTROLLER"] = FakeRedis(redis_values)
+    app.config["SETTINGS"] = {}
+    app.register_blueprint(settings_editor_bp)
+    return app, controller, command_executor
+
+
+def storage(filesystem, active=True):
+    """One mounted-drive summary shaped like raw_files.storage_summary()."""
+    return [{
+        "label": "RAW",
+        "active": active,
+        "total_bytes": 500 * 1000 ** 3,
+        "free_bytes": 500 * 1000 ** 3,
+        "filesystem": filesystem,
+        "device": "/dev/sda1",
+        "take_count": 0,
+    }]
+
+
+def post(app, filesystem):
+    return app.test_client().post("/settings-editor/api/raw/format", json={"filesystem": filesystem})
+
+
+class FormatValidationTests(unittest.TestCase):
+    def test_unsupported_filesystem_is_400_and_dispatches_nothing(self):
+        app, controller, _ = make_app()
+        res = post(app, "vfat")
+        self.assertEqual(res.status_code, 400)
+        self.assertFalse(res.get_json()["ok"])
+        controller.format_drive.assert_not_called()
+
+    def test_missing_filesystem_is_400(self):
+        app, controller, _ = make_app()
+        res = app.test_client().post("/settings-editor/api/raw/format", json={})
+        self.assertEqual(res.status_code, 400)
+        controller.format_drive.assert_not_called()
+
+    def test_refuses_while_recording_with_409(self):
+        app, controller, _ = make_app(redis_values={ParameterKey.IS_RECORDING.value: "1"})
+        res = post(app, "ext4")
+        self.assertEqual(res.status_code, 409)
+        self.assertIn("recording", res.get_json()["message"].lower())
+        controller.format_drive.assert_not_called()
+
+    def test_missing_command_executor_is_503(self):
+        app, controller, _ = make_app(with_executor=False)
+        res = post(app, "ext4")
+        self.assertEqual(res.status_code, 503)
+        controller.format_drive.assert_not_called()
+
+    def test_held_dispatch_lock_reports_busy_as_503(self):
+        app, controller, command_executor = make_app()
+        # Non-reentrant Lock, and the test client runs the request on this
+        # thread, so the handler's 2 s acquire times out and returns "busy".
+        self.assertTrue(command_executor._dispatch_lock.acquire())
+        try:
+            res = post(app, "ext4")
+        finally:
+            command_executor._dispatch_lock.release()
+        self.assertEqual(res.status_code, 503)
+        self.assertEqual(res.get_json()["message"], "busy")
+        controller.format_drive.assert_not_called()
+
+
+class FormatOutcomeTests(unittest.TestCase):
+    def test_requested_filesystem_mounted_is_success(self):
+        app, controller, _ = make_app()
+        with mock.patch.object(raw_files, "storage_summary", return_value=storage("ext4")):
+            res = post(app, "ext4")
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue(res.get_json()["ok"])
+        controller.format_drive.assert_called_once_with("ext4")
+
+    def test_old_filesystem_still_mounted_is_500(self):
+        app, controller, _ = make_app()
+        with mock.patch.object(raw_files, "storage_summary", return_value=storage("exfat")):
+            res = post(app, "ext4")
+        self.assertEqual(res.status_code, 500)
+        self.assertFalse(res.get_json()["ok"])
+        self.assertIn("exfat", res.get_json()["message"])
+        controller.format_drive.assert_called_once_with("ext4")
+
+    def test_no_remount_is_500(self):
+        app, _, _ = make_app()
+        with mock.patch.object(raw_files, "storage_summary", return_value=[]):
+            res = post(app, "ext4")
+        self.assertEqual(res.status_code, 500)
+        self.assertFalse(res.get_json()["ok"])
+        self.assertIn("did not remount", res.get_json()["message"])
+
+    def test_standby_only_mount_does_not_count_as_success(self):
+        app, _, _ = make_app()
+        with mock.patch.object(raw_files, "storage_summary",
+                               return_value=storage("ext4", active=False)):
+            res = post(app, "ext4")
+        self.assertEqual(res.status_code, 500)
+        self.assertFalse(res.get_json()["ok"])
+
+    def test_ntfs3_counts_as_ntfs(self):
+        app, controller, _ = make_app()
+        with mock.patch.object(raw_files, "storage_summary", return_value=storage("ntfs3")):
+            res = post(app, "ntfs")
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue(res.get_json()["ok"])
+        controller.format_drive.assert_called_once_with("ntfs")
+
+    def test_fuseblk_counts_as_ntfs(self):
+        app, _, _ = make_app()
+        with mock.patch.object(raw_files, "storage_summary", return_value=storage("fuseblk")):
+            res = post(app, "ntfs")
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue(res.get_json()["ok"])
+
+    def test_ntfs_alias_does_not_satisfy_an_ext4_request(self):
+        app, _, _ = make_app()
+        with mock.patch.object(raw_files, "storage_summary", return_value=storage("fuseblk")):
+            res = post(app, "ext4")
+        self.assertEqual(res.status_code, 500)
+        self.assertFalse(res.get_json()["ok"])
+
+    def test_filesystem_is_normalised_before_dispatch(self):
+        app, controller, _ = make_app()
+        with mock.patch.object(raw_files, "storage_summary", return_value=storage("exfat")):
+            res = post(app, "  ExFAT  ")
+        self.assertEqual(res.status_code, 200)
+        controller.format_drive.assert_called_once_with("exfat")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/module/app/settings_editor.py
+++ b/src/module/app/settings_editor.py
@@ -35,6 +35,7 @@ from module.config_loader import (
 )
 from module.app import boot_config, raw_files
 from module.jsonc_edit import apply_updates
+from module.redis_controller import ParameterKey
 from module.web_api_settings import web_api_settings
 
 logger = logging.getLogger(__name__)
@@ -481,3 +482,60 @@ def bulk_raw_action():
         results[name] = {"ok": ok, "message": message}
     all_ok = all(r["ok"] for r in results.values())
     return jsonify({"ok": all_ok, "results": results})
+
+
+# psutil reports the NTFS mount as ntfs, ntfs3 or fuseblk depending on which
+# driver took the volume; all three mean the mkfs.ntfs succeeded. ext4 and
+# exfat report literally.
+_FSTYPE_ALIASES = {
+    "ext4": ("ext4",),
+    "exfat": ("exfat",),
+    "ntfs": ("ntfs", "ntfs3", "fuseblk"),
+}
+
+
+@settings_editor_bp.route("/api/raw/format", methods=["POST"])
+def format_raw_drive():
+    body = request.get_json(silent=True) or {}
+    fs = str(body.get("filesystem") or "").strip().lower()
+    if fs not in _FSTYPE_ALIASES:
+        return jsonify({"ok": False, "message": "filesystem must be ext4, exfat or ntfs"}), 400
+
+    command_executor = current_app.config.get("COMMAND_EXECUTOR")
+    if command_executor is None:
+        return jsonify({"ok": False, "message": "Command dispatcher not available"}), 503
+
+    # Sequencing interlock, not a permissions gate: ssd_monitor's own guard
+    # only covers the buffer flush, and its unmount escalation runs
+    # `fuser -km` on the mount, which would kill a running writer mid-take.
+    redis_controller = current_app.config.get("REDIS_CONTROLLER")
+    if redis_controller is not None:
+        rec = str(redis_controller.get_value(ParameterKey.IS_RECORDING.value, "0") or "0").strip()
+        if rec == "1":
+            return jsonify({"ok": False, "message": "Refusing to format while recording"}), 409
+
+    logger.info("Dispatching 'format %s' from the settings editor", fs)
+    ok, message = command_executor.handle_received_data(f"format {fs}")
+    if not ok:
+        return jsonify({"ok": False, "message": message or "dispatch failed"}), (
+            503 if message == "busy" else 500
+        )
+
+    # The dispatcher discards handler return values, so a (True, "") here says
+    # only that `format` was dispatched -- never that mkfs worked. Verify
+    # against reality instead: format_drive() remounts before it returns, so
+    # the active mount's filesystem is the authoritative answer.
+    active = next((s for s in raw_files.storage_summary() if s.get("active")), None)
+    fstype = ((active or {}).get("filesystem") or "").lower()
+    if active and fstype in _FSTYPE_ALIASES[fs]:
+        return jsonify({"ok": True, "message": f"Formatted as {fs} and remounted."})
+    if active:
+        return jsonify({
+            "ok": False,
+            "message": f"Format may have failed — drive is mounted as {fstype or 'unknown'}. "
+                       "Check the cinemate log.",
+        }), 500
+    return jsonify({
+        "ok": False,
+        "message": "Format failed — drive did not remount. Check the cinemate log.",
+    }), 500

--- a/src/module/app/templates/settings_editor.html
+++ b/src/module/app/templates/settings_editor.html
@@ -622,6 +622,8 @@
   .storage-stats b{ color: var(--ink); font-variant-numeric: tabular-nums; font-weight:600; }
   .capacity-track{ height:8px; border-radius:999px; background: var(--panel-2); border:1px solid var(--line); overflow:hidden; }
   .capacity-fill{ height:100%; background: var(--accent); border-radius:999px 0 0 999px; }
+  .storage-format{ display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
+  .storage-format .btn:disabled, .storage-format select:disabled{ opacity:.5; cursor:default; }
 
   .clip-toolbar{
     display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap;
@@ -3388,8 +3390,55 @@
             '<span><b>' + s.take_count + '</b> takes</span>' +
           '</div>' +
         '</div>' +
-        '<div class="capacity-track"><div class="capacity-fill" style="width:' + pct + '%"></div></div>';
+        '<div class="capacity-track"><div class="capacity-fill" style="width:' + pct + '%"></div></div>' +
+        // Only the active drive: format_drive() targets the mounted /media/RAW
+        // device and cannot address a standby one.
+        (s.active
+          ? '<div class="storage-format">' +
+              '<select class="field-input" data-format-fs aria-label="Filesystem to format as">' +
+                '<option value="exfat" selected>exFAT</option>' +
+                '<option value="ext4">ext4</option>' +
+                '<option value="ntfs">NTFS</option>' +
+              '</select>' +
+              '<button class="btn btn-danger-outline" data-format-go>Format…</button>' +
+            '</div>' +
+            '<p class="card-help">Erases the whole drive. ext4 is the most robust for long recordings; ' +
+              'exFAT reads on any computer; NTFS works but is not recommended.</p>'
+          : '');
       wrap.appendChild(card);
+      // Cards are rebuilt with innerHTML on every refresh, so listeners are
+      // wired per render rather than delegated from a stable ancestor.
+      if (s.active) wireStorageFormat(card, s);
+    });
+  }
+
+  function wireStorageFormat(card, s){
+    var select = card.querySelector('[data-format-fs]');
+    var button = card.querySelector('[data-format-go]');
+    if (!select || !button) return;
+    button.addEventListener('click', function(){
+      var fs = select.value;
+      var message = 'Format ' + s.label + ' (' + (s.device || 'unknown device') + ', ' +
+        formatBytes(s.total_bytes) + ') as ' + fs + '? Every take on it is permanently erased.';
+      showConfirm(message, function(){
+        select.disabled = true;
+        button.disabled = true;
+        button.textContent = 'Formatting…';
+        showToast('Formatting — this can take a couple of minutes. Other commands will report busy until it finishes.');
+        fetch('/settings-editor/api/raw/format', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ filesystem: fs })
+        }).then(function(r){ return r.json(); }).then(function(res){
+          showToast(res.message);
+          // Refresh on failure too -- that re-renders the card and so
+          // re-enables the controls.
+          refreshRawPane();
+        }).catch(function(){
+          showToast('Connection lost — the format may still be running. Refresh in a minute.');
+          refreshRawPane();
+        });
+      }, null, { title: 'Format this drive?', okLabel: 'Format', danger: true });
     });
   }
 


### PR DESCRIPTION
Adds a **Format drive** control to the settings editor's RAW files pane, so a drive can be reformatted over Wi-Fi instead of only from the CLI.

Implements the operator-approved plan at `development/format-drive-raw-pane/PLAN.md` (ledger entry B14). The format backend (`SSDMonitor.format_drive` + the CLI `format` command) already existed and is unchanged — this is the web surface for it.

## What's here

Three files:

| File | Change |
|---|---|
| `src/module/app/settings_editor.py` | New `POST /settings-editor/api/raw/format` |
| `src/module/app/templates/settings_editor.html` | The control on the active storage card |
| `_test/test_settings_editor_format.py` | 13 new tests |

## Two decisions worth reading

**The endpoint verifies against reality, not against the dispatch result.** It routes `format <fs>` through `COMMAND_EXECUTOR.handle_received_data()` so it serialises against CLI, serial and `/api/v1/cmd` like every other command. But that executor discards handler return values — `format_drive` isn't in `parameters.REGISTRY`, so `_confirm_or_ok` returns `(True, "")` whether mkfs worked or not. The endpoint therefore inspects which filesystem is actually mounted at the active root once `format_drive()` has remounted. NTFS is accepted as any of `ntfs`/`ntfs3`/`fuseblk`, since the reported fstype depends on which driver took the volume.

**409 while recording is a sequencing interlock, not a permissions gate.** `ssd_monitor`'s own guard only covers the buffer flush, and its unmount escalation runs `fuser -km` on the mount — which would kill a running writer mid-take.

The are-you-sure step is the existing client-side danger modal, matching how the pane already deletes takes. `api.py`'s `DESTRUCTIVE_COMMANDS` gate is deliberately untouched: it governs headless IoT clients that have no confirm UI. No permission gate, config flag, or token on the new endpoint.

The control renders on the **active card only** — `format_drive()` targets the mounted `/media/RAW` device and cannot address a standby drive.

## Verification so far

- `python -m pytest _test/ -q -p no:randomly` → **508 passed, 303 subtests**. Baseline was 495, so 13 new and zero regressions.
- Blueprint imports clean; route registered; `node --check` passes on the template's script block; added JS is ES5, matching the file.
- Driven end-to-end in a browser against a throwaway harness with a faked active+standby drive: control renders on the active card only, exFAT preselected, confirm modal names label/device/size/filesystem, in-flight disabled state and toast fire, and both the 200 success and the 500 "mounted as the old fs" path produce the right toast with controls re-enabled afterwards.

No docs change: re-grepped `docs/`, and no page documents the settings editor's RAW pane (`docs/cli-commands.md` already covers the `format` command, which is unchanged).

## Pi verification — PASSED 2026-08-26

The destructive checklist was run by the operator on a scratch drive, against this branch delivered as a Python-only change (`git pull --ff-only` + cinemate restart, no rebuild). All six checks passed:

1. ✅ Format as exFAT, ext4 and NTFS from the browser → drive reformats and remounts, pane re-renders.
2. ✅ A take records on the freshly formatted drive and lists in the pane.
3. ✅ Format attempted while recording → 409, recording undisturbed.
4. ✅ CLI `set iso 800` during an in-flight format → `busy`, then normal dispatch once the format finishes. Confirmed to **recover**, not wedge — the accepted trade-off of routing through the shared dispatch lock.
5. ✅ CLI regression: `format exfat` from the CLI still works.
6. ✅ No mount fight with `storage-automount.service` observed via the browser path.

Not established by the run, and deliberately not claimed: which fstype string NTFS actually reported (the endpoint accepts `ntfs`/`ntfs3`/`fuseblk` precisely because it is driver-dependent), and how long a format held the dispatch lock in practice. No failure path was exercised on hardware, because nothing failed — the endpoint's mkfs-failure handling remains covered by unit tests only.

Recorded in `cinemate-handbook/lessons/hardware-log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

