### PR TITLE
chore(B10.3-B10.5): shell correctness, standards hygiene, docs round two

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -63,11 +63,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
       - name: shellcheck
         run: |
           sudo apt-get update -qq && sudo apt-get install -y shellcheck
           find . -name '*.sh' -not -path './.git/*' -print0 \
             | xargs -0 shellcheck -f gcc
+
+      # F-195: compile-raw.sh and run_cinemate.sh are heredoc bodies inside
+      # cinemate-install.sh, written to the Pi at install time -- the sweep
+      # above only finds committed *.sh files, so these two never got any
+      # lint coverage. They're the two scripts a user actually invokes.
+      - name: shellcheck the scripts the installer generates
+        run: python3 tools/check_generated_scripts.py
 
   drift:
     name: contract drift

--- a/cinemate-install.sh
+++ b/cinemate-install.sh
@@ -873,7 +873,9 @@ if [[ "\$cr_mem_mb" -gt 0 && "\$cr_mem_mb" -lt 3000 && "\$cr_swap_lines" -le 1 ]
     if [[ -n "\$CR_ZRAM_DEV" ]] && sudo mkswap "\$CR_ZRAM_DEV" >/dev/null 2>&1 && sudo swapon -p 100 "\$CR_ZRAM_DEV" 2>/dev/null; then
         printf '[compile-raw] Low-RAM board (%s MB): added 4 GB zram build swap on %s (removed on exit)\n' "\$cr_mem_mb" "\$CR_ZRAM_DEV"
     else
-        [[ -n "\$CR_ZRAM_DEV" ]] && sudo zramctl --reset "\$CR_ZRAM_DEV" 2>/dev/null || true
+        if [[ -n "\$CR_ZRAM_DEV" ]]; then
+            sudo zramctl --reset "\$CR_ZRAM_DEV" 2>/dev/null || true
+        fi
         CR_ZRAM_DEV=""
         printf '[compile-raw] WARNING: could not set up zram build swap; low-RAM build may OOM\n'
     fi

--- a/docs/cli-user-guide.md
+++ b/docs/cli-user-guide.md
@@ -75,7 +75,7 @@ The Cinemate fork introduces several extra options:
 | ------------------ | ---------------------- | -------------------------- |
 | `--cam-port`  | `cam0` \| `cam1`   | Select which CSI camera port to use.                                                        |
 | `--hdmi-port` | `0` \| `1` \| `-1` | Choose the HDMI connector for the preview (`0` = HDMI-0, `1` = HDMI-1, `-1` = auto-detect). |
-| `--same-hdmi` | *(none)*           | Force both capture and controller GUI to share the same HDMI output.                        |
+| `--same-hdmi` | *(none)*           | Force preview and GUI to share the same HDMI output.                                        |
 
 !!! note ""
 

--- a/docs/web-gui.md
+++ b/docs/web-gui.md
@@ -1,8 +1,11 @@
 # Web GUI
 
-Cinemate includes a small Flask + Socket.IO web interface that mirrors the on-camera HDMI GUI
-([hardware-controls.md](hardware-controls.md)) in a browser: same field layout, same status
-badges, same live preview.
+Cinemate includes a small Flask + Socket.IO web interface that mirrors most of the on-camera
+HDMI GUI ([hardware-controls.md](hardware-controls.md)) in a browser: the status badges and live
+preview match, and most HDMI fields reach the page — but not all of them. The recording-integrity
+counts (frame count, frames-in-sync, missing-frame count, drop-frame flags) and a few host/label
+fields are HDMI-only today; run `tools/gui_field_extract.py` for the current, exact list rather
+than trusting a number here, since it moves as fields get added to either side.
 
 - the control UI listens on port `5000`, with the URL `http://cinepi.local:5000/`.
 - the clean MJPEG preview stream is available on port `8000` with the URL `http://cinepi.local:8000/stream`.

--- a/services/cinemate-autostart/cinemate-startup-failure.sh
+++ b/services/cinemate-autostart/cinemate-startup-failure.sh
@@ -9,11 +9,11 @@ case $- in
     *) return 0 2>/dev/null || exit 0 ;;
 esac
 
-if [[ "$(tty 2>/dev/null)" != "/dev/tty1" ]]; then
+if [ "$(tty 2>/dev/null)" != "/dev/tty1" ]; then
     return 0 2>/dev/null || exit 0
 fi
 
-if [[ -s "${failure_file}" ]]; then
+if [ -s "${failure_file}" ]; then
     printf '\033[2J\033[H'
     cat "${failure_file}"
     printf '\033[0m\033[?25h\n'

--- a/settings.schema.json
+++ b/settings.schema.json
@@ -493,7 +493,50 @@
           "type": "array"
         },
         "rotary_encoders": {
-          "type": "array"
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "type": "boolean"
+              },
+              "clk_pin": {
+                "type": "integer"
+              },
+              "dt_pin": {
+                "type": "integer"
+              },
+              "button_pin": {
+                "type": "integer"
+              },
+              "pull_up": {
+                "type": "boolean"
+              },
+              "debounce_time": {
+                "type": "number"
+              },
+              "button_actions": {
+                "type": "object",
+                "properties": {
+                  "press_action": { "$ref": "#/definitions/action" },
+                  "single_click_action": { "$ref": "#/definitions/action" },
+                  "double_click_action": { "$ref": "#/definitions/action" },
+                  "triple_click_action": { "$ref": "#/definitions/action" },
+                  "hold_action": { "$ref": "#/definitions/action" }
+                },
+                "additionalProperties": false
+              },
+              "encoder_actions": {
+                "type": "object",
+                "properties": {
+                  "rotate_clockwise": { "$ref": "#/definitions/action" },
+                  "rotate_counterclockwise": { "$ref": "#/definitions/action" }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
         },
         "combined_actions": {
           "type": "array"
@@ -526,7 +569,28 @@
               "default": false
             },
             "encoders": {
-              "type": "object"
+              "type": "object",
+              "description": "Keyed by dial index (\"0\"..\"3\").",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "setting_name": {
+                    "type": "string"
+                  },
+                  "button": {
+                    "type": "object",
+                    "properties": {
+                      "press_action": { "$ref": "#/definitions/action" },
+                      "single_click_action": { "$ref": "#/definitions/action" },
+                      "double_click_action": { "$ref": "#/definitions/action" },
+                      "triple_click_action": { "$ref": "#/definitions/action" },
+                      "hold_action": { "$ref": "#/definitions/action" }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
             }
           },
           "additionalProperties": false
@@ -635,6 +699,27 @@
     }
   },
   "definitions": {
+    "action": {
+      "description": "A gesture action: the string \"None\"/\"none\" for no action, or a controller method call.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "method": {
+              "type": "string"
+            },
+            "args": {
+              "type": "array"
+            }
+          },
+          "required": ["method"],
+          "additionalProperties": false
+        }
+      ]
+    },
     "cam_config": {
       "type": "object",
       "properties": {

--- a/src/main.py
+++ b/src/main.py
@@ -683,7 +683,6 @@ def run_application(args, log_queue):
     # Detect Raspberry Pi model
     pi_model = get_raspberry_pi_model()
     logging.info(f"Detected Raspberry Pi model: {pi_model}")
-    set
 
     # Start WiFi hotspot if configured
     start_hotspot(settings)

--- a/src/module/framebuffer.py
+++ b/src/module/framebuffer.py
@@ -95,16 +95,6 @@ class Framebuffer(object):
             self.stride = 0
             self.bits_per_pixel = 0
 
-    # def __init__(self, device_no: int):
-    #     self.path = f"/dev/fb{device_no}"
-    #     config_dir = f"/sys/class/graphics/fb{device_no}"
-    #     self.size = tuple(_read_and_convert_to_ints(
-    #         config_dir + "/virtual_size"))
-    #     self.stride = _read_and_convert_to_ints(config_dir + "/stride")[0]
-    #     self.bits_per_pixel = _read_and_convert_to_ints(
-    #         config_dir + "/bits_per_pixel")[0]
-    #     assert self.stride == self.bits_per_pixel // 8 * self.size[0]
-
     def __str__(self):
         args = (self.path, self.size, self.stride, self.bits_per_pixel)
         return "%s  size:%s  stride:%s  bits_per_pixel:%s" % args
@@ -169,26 +159,3 @@ def acquire_framebuffer(device_no: int):
         return None
 
     return fb
-
-# if __name__ == "__main__":
-#     import time
-#     from PIL import ImageDraw
-
-
-#     def TestFrameBuffer(i):
-#         fb = Framebuffer(i)
-#         print(fb)
-#         image = Image.new("RGBA", fb.size)
-#         draw = ImageDraw.Draw(image)
-#         draw.rectangle(((0, 0), fb.size), fill="green")
-#         draw.ellipse(((0, 0), fb.size), fill="blue", outline="red")
-#         draw.line(((0, 0), fb.size), fill="green", width=2)
-#         start = time.time()
-#         for i in range(5):
-#             fb.show(image)
-#         stop = time.time()
-#         print("fps: %.2f" % (10 / (stop - start)))
-
-
-#     for i in [0]:
-#         TestFrameBuffer(i)

--- a/tools/check_generated_scripts.py
+++ b/tools/check_generated_scripts.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Shellcheck the two scripts cinemate-install.sh writes to the Pi at install
+time (compile-raw.sh, run_cinemate.sh) -- F-195. They are heredoc bodies
+inside cinemate-install.sh, so the repo-wide `find . -name '*.sh'` sweep in
+checks.yml never sees them; this extracts each heredoc, applies bash's own
+unquoted-heredoc escaping rules (\\$, \\`, \\\\, and a trailing \\<newline>
+are the only specials -- everything else is literal), and shellchecks the
+result.
+
+Variables the heredocs reference (CINEPI_RAW_DIR, PYTHON_BIN, ...) come from
+cinemate-install.sh's own scope, not the extracted script's -- SC2154 (used
+but not assigned) is expected and suppressed per-file below rather than
+silenced repo-wide.
+"""
+
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALLER = REPO_ROOT / "cinemate-install.sh"
+
+# function name -> (target path the heredoc writes to, for a readable label)
+TARGETS = {
+    "write_compile_raw_script": "compile-raw.sh",
+    "configure_run_wrapper": "run_cinemate.sh",
+}
+
+HEREDOC_ESCAPES = re.compile(r"\\([$`\\\n])")
+
+
+def extract_heredoc(text: str, func_name: str) -> str:
+    lines = text.splitlines()
+    start = next(i for i, l in enumerate(lines) if l.startswith(f"{func_name}()"))
+    # Find the heredoc opener (<<EOF or <<'EOF') after the function start.
+    open_re = re.compile(r"<<-?\s*'?EOF'?\s*$")
+    body_start = next(
+        i for i in range(start, len(lines)) if open_re.search(lines[i])
+    )
+    quoted = "'EOF'" in lines[body_start]
+    body_end = next(
+        i for i in range(body_start + 1, len(lines)) if lines[i] == "EOF"
+    )
+    body = "\n".join(lines[body_start + 1 : body_end]) + "\n"
+    if not quoted:
+        body = HEREDOC_ESCAPES.sub(lambda m: "" if m.group(1) == "\n" else m.group(1), body)
+    return body
+
+
+def main() -> int:
+    text = INSTALLER.read_text()
+    failures = 0
+    with tempfile.TemporaryDirectory() as tmp:
+        paths = []
+        for func_name, label in TARGETS.items():
+            body = extract_heredoc(text, func_name)
+            path = Path(tmp) / label
+            path.write_text(body)
+            paths.append(path)
+
+        result = subprocess.run(
+            [
+                "shellcheck",
+                "-f",
+                "gcc",
+                "--exclude=SC2154",  # vars from cinemate-install.sh's own scope
+                *[str(p) for p in paths],
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.stdout:
+            print(result.stdout, end="")
+        if result.stderr:
+            print(result.stderr, end="", file=sys.stderr)
+        if result.returncode != 0:
+            failures += 1
+
+    if failures:
+        print(
+            f"check_generated_scripts: shellcheck found issues in "
+            f"{', '.join(TARGETS.values())} (extracted from cinemate-install.sh)",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"check_generated_scripts: {', '.join(TARGETS.values())} clean")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/docs_drift_check.py
+++ b/tools/docs_drift_check.py
@@ -203,7 +203,10 @@ def check_keys(repo: Path) -> list[str]:
         # cells like "width / height" and "lores_width / lores_height"
         for part in re.split(r"\s*/\s*", cell):
             part = part.strip().strip("`")
-            if re.fullmatch(r"[a-z][a-z0-9_]*", part):
+            # Almost every ParameterKey value is snake_case, but not all --
+            # FSCK_STATUS is upper-case (F-014), so this can't anchor on
+            # [a-z] alone without reporting a real doc row as undocumented.
+            if re.fullmatch(r"[a-zA-Z][a-zA-Z0-9_]*", part):
                 named.add(part)
 
     documented = named & values


### PR DESCRIPTION
Three of REMEDIATION-PLAN.md's B10 sub-batches, verified against the current tree rather than the plan (several items had already been fixed by earlier merges; a couple were genuinely still open).

**B10.3 — shell correctness.** F-176/F-175 (SC2155 exit-status masking, `echo "\n"`) were already fixed on `dev`. F-177 (`[[ ]]` in a profile.d script with no guaranteed bash) converted to POSIX `[ ]`. F-195 (the two scripts the shellcheck sweep can't see, because they're heredoc bodies written at install time) gets a new `tools/check_generated_scripts.py`, wired into CI. F-033 (cinepi-raw's `pkill -f` pattern) deliberately not touched — needs hardware to verify a fix doesn't break orphan cleanup.

**B10.4 — standards hygiene.** F-167: `rotary_encoders`/`quad_rotary_controller.encoders` had no item schema at all, so a typo'd structural key silently no-op'd — added real schemas built from the actual shapes in all three shipped settings files (verified all three still validate, plus two new typo-rejection tests passed by hand). F-021 (bare `set` no-op) and F-111 (two dead commented blocks in `framebuffer.py`) deleted. F-173/F-212 needed no change — already fixed. F-168/F-170 (the ~1000-call-site logging-idiom unification) deliberately deferred — too large to review carefully in this pass.

**B10.5 — docs round two.** F-014: the checker itself had a regex bug (case-sensitive, so the one all-uppercase key `FSCK_STATUS` false-positived as undocumented despite a real row existing) — fixed the checker, now correctly reports 86/86. F-248 rewritten to state the current field-coverage gap without a hardcoded number that'll drift again. F-229 aligns `cli-user-guide.md`'s `--same-hdmi` wording with cinepi-raw's own help text. F-265/F-266 already closed by the B13 PR, not duplicated here.

Full test suite (523 tests, 303 subtests) and `docs_drift_check.py --strict` both pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBku1dDuju5t762UogsJRq)_