### PR TITLE
Sensor link frequencies from the database, not from Python

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -94,6 +94,9 @@ jobs:
       - name: Every offered action resolves on the controller
         run: python3 tools/gui_field_extract.py --repo . --max-unresolved 0
 
+      - name: Link frequencies live only in the sensor database
+        run: python3 tools/link_frequency_drift_check.py --repo . --strict
+
       # Needs both repositories: the key contract spans them.
       - name: Check out cinepi-raw
         run: |

--- a/_test/test_boot_config_link_frequency.py
+++ b/_test/test_boot_config_link_frequency.py
@@ -8,10 +8,11 @@ boot or streams faster than the receiver can hold, and both look like "the
 camera stopped working" hours later. So the write path validates against the
 list the driver actually vouches for, and the read path round-trips it.
 
-Only imx585 has this menu. imx283's driver supports two frequencies but its
-overlay exposes no parameter; imx477 accepts any multiple of 3 MHz with no
-upper bound (nothing to offer); imx296 has no link-frequencies property at
-all. See the constants block in boot_config.py.
+Which values each sensor takes, and whether it gets a menu at all, comes from
+resources/sensors.json -- so these tests double as assertions about the
+database. imx585 and imx283 have menus; imx296 and imx519 have fixed links;
+imx477's values are recorded but its menu is gated off until the 750 MHz
+hardware gate passes.
 """
 
 import sys
@@ -26,12 +27,17 @@ sys.modules.setdefault("redis", types.SimpleNamespace(StrictRedis=object))
 sys.modules.setdefault("psutil", types.SimpleNamespace())
 
 from module.app.boot_config import (
-    IMX585_DEFAULT_LINK_FREQUENCY,
-    IMX585_LINK_FREQUENCIES,
     apply_config_txt_state,
+    link_frequency_options,
     overlay_line_for,
     parse_config_txt,
+    sensor_database,
+    supports_link_frequency,
 )
+from module.sensor_database import link_frequency_default
+
+IMX585_DEFAULT_LINK_FREQUENCY = link_frequency_default(sensor_database(), "imx585")
+IMX585_LINK_FREQUENCIES = [o["hz"] for o in link_frequency_options("imx585")]
 
 
 def config_txt(*camera_lines: str) -> str:
@@ -60,12 +66,27 @@ BASE = {"cam0_sensor": "imx585", "cam1_sensor": "none", "i2c": True, "audio": Tr
 class LinkFrequencyMenuTests(unittest.TestCase):
     def test_the_offered_values_match_the_driver(self):
         # will127534/imx585-v4l2-driver link_freqs[], minus 1188000000, which
-        # the README reports as frame-dropping on the Pi 5.
+        # the README reports as frame-dropping on the Pi 5. Sourced from
+        # resources/sensors.json, so this asserts the database is right.
         self.assertEqual(IMX585_LINK_FREQUENCIES, [
             297000000, 360000000, 445500000, 594000000, 720000000, 891000000, 1039500000,
         ])
         self.assertNotIn(1188000000, IMX585_LINK_FREQUENCIES)
         self.assertIn(IMX585_DEFAULT_LINK_FREQUENCY, IMX585_LINK_FREQUENCIES)
+
+    def test_imx283_offers_its_two_values_with_720_as_both_default_and_ceiling(self):
+        # The overlay parameter for these landed in the driver fork at
+        # 257c9cf; before that only the endpoint's 720 MHz was reachable.
+        self.assertTrue(supports_link_frequency("imx283"))
+        self.assertEqual([o["hz"] for o in link_frequency_options("imx283")],
+                         [360000000, 720000000])
+        self.assertEqual(link_frequency_default(sensor_database(), "imx283"), 720000000)
+
+    def test_sensors_with_no_menu_are_reported_as_such(self):
+        # imx296/imx519 have fixed links. imx477's values are recorded but its
+        # menu is gated off until the 750 MHz hardware gate passes.
+        for model in ("imx296", "imx519", "imx477"):
+            self.assertFalse(supports_link_frequency(model), model)
 
 
 class OverlayLineTests(unittest.TestCase):
@@ -90,9 +111,14 @@ class OverlayLineTests(unittest.TestCase):
             "dtoverlay=imx585,cam1,mono,link-frequency=891000000",
         )
 
-    def test_sensors_without_the_parameter_never_get_one(self):
-        for model in ("imx477", "imx296", "imx283"):
+    def test_sensors_without_a_menu_never_get_the_parameter(self):
+        for model in ("imx477", "imx296"):
             self.assertEqual(overlay_line_for(model, "cam0", 891000000), f"dtoverlay={model},cam0")
+
+    def test_imx283_gets_the_parameter_only_below_its_default(self):
+        self.assertEqual(overlay_line_for("imx283", "cam0", 360000000),
+                         "dtoverlay=imx283,cam0,link-frequency=360000000")
+        self.assertEqual(overlay_line_for("imx283", "cam0", 720000000), "dtoverlay=imx283,cam0")
 
 
 class RoundTripTests(unittest.TestCase):
@@ -154,10 +180,19 @@ class ValidationTests(unittest.TestCase):
     def test_asking_for_one_on_a_sensor_that_has_none_is_refused(self):
         with self.assertRaises(ValueError) as caught:
             apply_config_txt_state(
-                config_txt("dtoverlay=imx477,cam0"),
-                {**BASE, "cam0_sensor": "imx477", "cam0_link_frequency": 891000000},
+                config_txt("dtoverlay=imx296,cam0"),
+                {**BASE, "cam0_sensor": "imx296", "cam0_link_frequency": 891000000},
             )
         self.assertIn("no selectable link frequency", str(caught.exception))
+
+    def test_an_imx585_value_is_refused_on_imx283(self):
+        # The two menus barely overlap; a stale pick must not ride along.
+        with self.assertRaises(ValueError) as caught:
+            apply_config_txt_state(
+                config_txt("dtoverlay=imx283,cam0"),
+                {**BASE, "cam0_sensor": "imx283", "cam0_link_frequency": 1039500000},
+            )
+        self.assertIn("not a supported imx283 link frequency", str(caught.exception))
 
     def test_a_stale_frequency_on_an_emptied_port_does_not_fail_the_save(self):
         # Pick imx585 + 891, then set the port to none: the form can still be

--- a/_test/test_sensor_database.py
+++ b/_test/test_sensor_database.py
@@ -306,5 +306,83 @@ class SensorDatabaseTests(unittest.TestCase):
         self.assertEqual(twins, {10, 12})
 
 
+class LinkFrequencyBlockTests(unittest.TestCase):
+    """resources/sensors.json is the only place link frequencies are written
+    down now, so its shape is worth asserting directly. A wrong value here is
+    silent on the Pi: the sensor either refuses to probe or outruns the
+    receiver, and both surface much later as "the camera stopped working"."""
+
+    @classmethod
+    def setUpClass(cls):
+        from module.sensor_database import load_sensor_database
+        cls.db = load_sensor_database()
+        cls.sensors = cls.db["sensors"]
+
+    def test_every_sensor_records_its_link_frequency(self):
+        # Absence would read as "capability unknown". Every sensor Cinemate
+        # supports has a known answer, including the fixed-link ones.
+        for name, entry in self.sensors.items():
+            self.assertIn("link_frequency", entry, name)
+
+    def test_each_block_is_internally_consistent(self):
+        for name, entry in self.sensors.items():
+            block = entry["link_frequency"]
+            values = [o["hz"] for o in block["options"]]
+            with self.subTest(sensor=name):
+                self.assertTrue(values, "options must not be empty")
+                self.assertEqual(values, sorted(values), "options should be ascending")
+                self.assertEqual(len(values), len(set(values)), "duplicate hz")
+                self.assertIn(block["default_hz"], values, "default_hz must be an option")
+                self.assertIsInstance(block["lanes"], int)
+                self.assertIsInstance(block["selectable"], bool)
+                for option in block["options"]:
+                    self.assertIsInstance(option["hz"], int)
+                    self.assertIsInstance(option["mbps_per_lane"], int)
+
+    def test_excluded_values_are_not_also_offered(self):
+        # imx585's 1188 MHz drops frames on a Pi 5. Listing it in both places
+        # would put it in the menu anyway.
+        for name, entry in self.sensors.items():
+            block = entry["link_frequency"]
+            offered = {o["hz"] for o in block.get("options", [])}
+            for excluded in block.get("excluded", []):
+                with self.subTest(sensor=name, hz=excluded["hz"]):
+                    self.assertNotIn(excluded["hz"], offered)
+                    self.assertTrue(excluded.get("reason"), "an exclusion needs a reason")
+
+    def test_imx585_offers_the_seven_driver_values(self):
+        block = self.sensors["imx585"]["link_frequency"]
+        self.assertEqual([o["hz"] for o in block["options"]], [
+            297000000, 360000000, 445500000, 594000000, 720000000, 891000000, 1039500000,
+        ])
+        self.assertEqual(block["default_hz"], 720000000)
+        self.assertEqual([e["hz"] for e in block["excluded"]], [1188000000])
+
+    def test_imx283_records_the_closed_faster_link_question(self):
+        # The "explore a faster MIPI link for higher fps" TODO is answered:
+        # 720 MHz is both default and ceiling. Record it so it isn't reopened.
+        block = self.sensors["imx283"]["link_frequency"]
+        self.assertEqual([o["hz"] for o in block["options"]], [360000000, 720000000])
+        self.assertEqual(block["default_hz"], 720000000)
+        self.assertEqual(max(o["hz"] for o in block["options"]), block["default_hz"])
+        self.assertIn("infeasible", block["notes"])
+
+    def test_fixed_link_sensors_are_flagged_unselectable(self):
+        for name in ("imx296", "imx519"):
+            block = self.sensors[name]["link_frequency"]
+            with self.subTest(sensor=name):
+                self.assertFalse(block["selectable"])
+                self.assertEqual(len(block["options"]), 1)
+                self.assertTrue(block.get("notes"))
+
+    def test_imx477_data_is_present_but_its_menu_is_gated_off(self):
+        block = self.sensors["imx477"]["link_frequency"]
+        self.assertEqual(block["default_hz"], 450000000)
+        self.assertFalse(block["menu_enabled"])
+        # The driver takes any ~3 MHz multiple, so these are curated presets
+        # rather than a list it vouches for -- record the step so that stays clear.
+        self.assertEqual(block["arbitrary"]["step_hz"], 3000000)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/docs/overclocking.md
+++ b/docs/overclocking.md
@@ -64,46 +64,76 @@ sudo reboot
 
 To go back to stock, re-comment the line and reboot.
 
-## Link frequency (imx585)
+## Link frequency
 
-Raising the RP1 clock lifts the *receiver's* ceiling. The sensor still has to
-be told to send faster, and on the imx585 that is a separate setting: the
-CSI-2 link frequency, a parameter on the sensor's own overlay line.
+Two different ceilings, and you need both raised:
 
-With the overclock on, the Boot config pane shows a **link frequency** menu
-per port. Each port has its own — cam0 and cam1 are independent.
+| Raises | Setting |
+|---|---|
+| What the **sensor sends** | CSI-2 link frequency, a parameter on the sensor's overlay line |
+| What the **receiver takes** | the RP1 overclock on this page |
 
-| Value | Mbps/lane | 4K 12-bit, 4 lanes | 2 lanes |
-|---|---|---|---|
-| 297 MHz | 594 | 20.8 fps | 10.4 fps |
-| 360 MHz | 720 | 25.0 fps | 12.5 fps |
-| 445.5 MHz | 891 | 30.0 fps | 15.0 fps |
-| 594 MHz | 1188 | 41.7 fps | 20.8 fps |
-| **720 MHz** (default) | 1440 | 50.0 fps | 25.0 fps |
-| 891 MHz | 1782 | 60.0 fps | 30.0 fps |
-| 1039.5 MHz | 2079 | 75.0 fps | 37.5 fps |
-
-Halve again for ClearHDR; double for 2×2 binned 1080p. Values and rates come
-from [will127534/imx585-v4l2-driver](https://github.com/will127534/imx585-v4l2-driver).
-
-Anything above 720 MHz only pays off with the overclock active — a stock RP1
-tops out near 43.8 fps at 4K no matter what the sensor sends. Cinemate writes
-the parameter only when it differs from the default:
+A stock RP1 tops out near 43.8 fps at 4K no matter what the sensor is told to
+do, which is why the link-frequency menus appear once the overclock is on.
+Each port has its own — cam0 and cam1 are independent. Cinemate writes the
+parameter only when it differs from the sensor's default:
 
 ```
 dtoverlay=imx585,cam0,link-frequency=1039500000
 ```
 
-The driver also defines 1188 MHz (2376 Mbps/lane). Cinemate does not offer it
-— the Pi 4 cannot use it and the Pi 5 drops frames.
+Per-sensor values live in `resources/sensors.json`. That file is the source of
+truth — the menu, the validation and the tables below all read from it. See
+[Sensors](sensors.md) for the full per-sensor tables.
 
-!!! info "Only the imx585 has this menu"
-    The other supported sensors cannot offer one. The imx283 driver accepts
-    360 and 720 MHz but its overlay exposes no `link-frequency` parameter.
-    The imx477 driver accepts *any* exact multiple of 3 MHz with no upper
-    bound, so there is no list it actually vouches for — only its 450 MHz
-    default is proven. The imx296 has no link-frequency property at all; it
-    derives its own MIPI timing.
+### imx585
+
+| Value | Mbps/lane | 4K 12-bit, 4 lanes |
+|---|---|---|
+| 297 MHz | 594 | 20.8 fps |
+| 360 MHz | 720 | 25.0 fps |
+| 445.5 MHz | 891 | 30.0 fps |
+| 594 MHz | 1188 | 41.7 fps |
+| **720 MHz** (default) | 1440 | 50.0 fps |
+| 891 MHz | 1782 | 60.0 fps |
+| 1039.5 MHz | 2079 | 75.0 fps |
+
+Halve for 2-lane, halve again for ClearHDR, double for 2×2 binned. Figures
+come from [will127534/imx585-v4l2-driver](https://github.com/will127534/imx585-v4l2-driver)
+and are advisory until measured on this stack. The driver also defines
+1188 MHz (2376 Mbps/lane); Cinemate does not offer it — the Pi 4 cannot use it
+and the Pi 5 drops frames.
+
+### imx283
+
+360 MHz (720 Mbps/lane) and **720 MHz** (1440 Mbps/lane, default). Sony ships
+exactly two register sequences and the driver rejects anything else.
+
+!!! note "720 MHz is already the ceiling here"
+    The only selectable alternative is *slower*. This closes the standing
+    question of whether a faster link would lift the 4K modes past their
+    44/41 fps: it would, but no faster link exists. More frame rate on the
+    imx283 means a lower bit depth, not a faster link.
+
+    Selecting a non-default value needs the `link-frequency` overlay
+    parameter, which exists only in `Tiramisioux/imx283-v4l2-driver` `6.12.y`
+    at `257c9cf` or later. An older overlay rejects the unknown parameter and
+    the camera will not enumerate at all — re-run the installer first.
+
+### The others
+
+| Sensor | Link | Menu |
+|---|---|---|
+| imx477 | 450 MHz default; since kernel 6.12.49 the driver computes PLL settings for any ~3 MHz multiple | **not yet** — values recorded, menu held back pending hardware verification |
+| imx296 | fixed 594 MHz, 1 lane; the 60 fps cap is readout-limited, not link-limited | no |
+| imx519 | fixed 408 MHz; the driver rejects anything else at probe | no |
+
+### Receiver ceilings
+
+| Receiver | Spec | Observed |
+|---|---|---|
+| Pi 5 / CM5 (RP1) | 1.5 Gbps/lane | 1782 Mbps/lane fine, 2079 works, 2376 drops frames. Separate drain limit: 380 MPix/s stock, 580 with the overclock |
+| Pi 4 / CM4 (Unicam) | none published | ~1.4 Gbps/lane; SDRAM-bandwidth-limited; 2376 fails |
 
 !!! note "The mode list does not tell you whether the overclock is on"
     `minPixelProcessingTime` is compiled into libcamera unconditionally on

--- a/docs/sensors.md
+++ b/docs/sensors.md
@@ -93,6 +93,43 @@ Resolutions above are the modes currently defined in `resources/sensors.json`; t
 
 IMX477 is not a hardware limitation — its 12-bit modes would work the same way — it needs sensor-aware spec selection on the `cinepi-raw` side that hasn't been built yet.
 
+## CSI-2 link frequency
+
+The link frequency sets how fast the sensor pushes pixels down the MIPI lanes,
+and so what frame rate a mode can reach. Where it is selectable, Cinemate
+offers it per port in the settings editor's Boot config pane — see
+[Overclocking the Pi](overclocking.md), because on a Pi 5 the receiver has to
+be overclocked before the higher rates buy anything.
+
+`resources/sensors.json` is the source of truth for the values below.
+
+| Sensor | Lanes | Default | Selectable | Values |
+|--------|-------|---------|------------|--------|
+| IMX585 | 4 | 720 MHz | **yes** | 297 / 360 / 445.5 / 594 / 720 / 891 / 1039.5 MHz |
+| IMX283 | 4 | 720 MHz | **yes** | 360 / 720 MHz — 720 is also the ceiling |
+| IMX477 | 2 | 450 MHz | not yet | driver computes any ~3 MHz multiple (kernel ≥ 6.12.49) |
+| IMX296 | 1 | 594 MHz | no | fixed |
+| IMX519 | 2 | 408 MHz | no | fixed |
+
+**IMX585** carries per-value frame rates in
+[Overclocking the Pi](overclocking.md#imx585). 1188 MHz exists in the driver
+and is deliberately not offered: frame drops on Pi 5, unsupported on Pi 4.
+
+**IMX283**'s two values are the only two Sony ships register sequences for.
+720 MHz is both the default and the silicon ceiling, so the only selectable
+alternative is slower. The 4K modes' 44/41 fps are the link ceiling at those
+bit depths — more frame rate means a lower bit depth, not a faster link.
+Selecting the non-default value needs the `link-frequency` overlay parameter
+added in `Tiramisioux/imx283-v4l2-driver` `6.12.y` at `257c9cf`.
+
+**IMX477** is not a hardware limitation. Its driver accepts any exact multiple
+of 3 MHz and RPi's own testing found ~909 MHz stable, but it vouches for no
+upper bound, so Cinemate keeps the menu hidden until the values are verified
+on this stack.
+
+**IMX296**'s 60 fps cap is readout-limited, not link-limited; a faster link
+would buy nothing.
+
 ## Sensor size, crop factor and film-format equivalents
 
 Each mode reads out a physical area of the sensor. Binned modes keep the full field of view. Cropped modes use a smaller area, so the same lens frames tighter.

--- a/resources/sensors.json
+++ b/resources/sensors.json
@@ -5,7 +5,9 @@
       "display_name": "IMX477",
       "common_name": "Raspberry Pi HQ Camera",
       "packing": "U",
-      "packing_by_platform": { "pi4": "P" },
+      "packing_by_platform": {
+        "pi4": "P"
+      },
       "aliases": [],
       "modes": [
         {
@@ -32,14 +34,56 @@
           "bit_depth": 10,
           "max_fps": 120
         }
-      ]
+      ],
+      "link_frequency": {
+        "lanes": 2,
+        "selectable": true,
+        "menu_enabled": false,
+        "default_hz": 450000000,
+        "options": [
+          {
+            "hz": 450000000,
+            "mbps_per_lane": 900
+          },
+          {
+            "hz": 750000000,
+            "mbps_per_lane": 1500,
+            "pi5_spec_limit": true
+          },
+          {
+            "hz": 909000000,
+            "mbps_per_lane": 1818,
+            "experimental": true,
+            "over_rp1_spec": true
+          }
+        ],
+        "arbitrary": {
+          "step_hz": 3000000,
+          "min_kernel": "6.12.49"
+        },
+        "by_platform": {
+          "pi4": {
+            "max_hz": 500000000,
+            "confidence": "suggested"
+          },
+          "pi5": {
+            "max_hz": 909000000,
+            "confidence": "probable"
+          }
+        },
+        "notes": "menu_enabled is false until Gate 2 measures 750 MHz on this stack; enabling it is an operator decision. Since kernel 6.12.49 the driver computes PLL settings for any ~3 MHz multiple passed via the overlay parameter, so these are curated presets, not the driver's own list -- it vouches for no upper bound, which is why a menu rather than a free field. 750 MHz is the Pi 5 RP1 spec limit and officially sanctioned. RPi's own testing found ~909 MHz stable and white/corrupt frames from ~939 MHz in binned modes."
+      }
     },
     "imx296": {
       "display_name": "IMX296",
       "common_name": "Raspberry Pi Global Shutter Camera",
       "packing": "U",
-      "packing_by_platform": { "pi4": "P" },
-      "aliases": ["imx296_mono"],
+      "packing_by_platform": {
+        "pi4": "P"
+      },
+      "aliases": [
+        "imx296_mono"
+      ],
       "modes": [
         {
           "mode": 0,
@@ -49,18 +93,43 @@
           "bit_depth": 10,
           "max_fps": 60
         }
-      ]
+      ],
+      "link_frequency": {
+        "lanes": 1,
+        "selectable": false,
+        "default_hz": 594000000,
+        "options": [
+          {
+            "hz": 594000000,
+            "mbps_per_lane": 1188
+          }
+        ],
+        "notes": "Fixed. The sensor derives its own MIPI timing internally (the PLL lands between 1122 and 1198 Mbps) and there is no register knob or overlay parameter. The 60 fps cap is readout-limited, not link-limited, so a faster link would buy nothing."
+      }
     },
     "imx585": {
       "display_name": "IMX585",
       "common_name": "Starlight Eye",
       "packing": "U",
-      "aliases": ["imx585_mono"],
+      "aliases": [
+        "imx585_mono"
+      ],
       "log_encode": {
         "black_level_16bit": 3200,
         "targets": {
-          "16": { "valid": [10, 12], "default": 12 },
-          "12": { "valid": [10], "default": 10 }
+          "16": {
+            "valid": [
+              10,
+              12
+            ],
+            "default": 12
+          },
+          "12": {
+            "valid": [
+              10
+            ],
+            "default": 10
+          }
         }
       },
       "modes": [
@@ -80,7 +149,65 @@
           "bit_depth": 12,
           "max_fps": 40
         }
-      ]
+      ],
+      "link_frequency": {
+        "lanes": 4,
+        "selectable": true,
+        "default_hz": 720000000,
+        "options": [
+          {
+            "hz": 297000000,
+            "mbps_per_lane": 594,
+            "fps_4k12_4lane": 20.8
+          },
+          {
+            "hz": 360000000,
+            "mbps_per_lane": 720,
+            "fps_4k12_4lane": 25.0
+          },
+          {
+            "hz": 445500000,
+            "mbps_per_lane": 891,
+            "fps_4k12_4lane": 30.0
+          },
+          {
+            "hz": 594000000,
+            "mbps_per_lane": 1188,
+            "fps_4k12_4lane": 41.7
+          },
+          {
+            "hz": 720000000,
+            "mbps_per_lane": 1440,
+            "fps_4k12_4lane": 50.0
+          },
+          {
+            "hz": 891000000,
+            "mbps_per_lane": 1782,
+            "fps_4k12_4lane": 60.0,
+            "over_rp1_spec": true
+          },
+          {
+            "hz": 1039500000,
+            "mbps_per_lane": 2079,
+            "fps_4k12_4lane": 75.0,
+            "over_rp1_spec": true
+          }
+        ],
+        "excluded": [
+          {
+            "hz": 1188000000,
+            "mbps_per_lane": 2376,
+            "reason": "frame drops on Pi 5, unsupported on Pi 4"
+          }
+        ],
+        "by_platform": {
+          "pi4": {
+            "max_hz": 891000000,
+            "confidence": "probable"
+          }
+        },
+        "notes": "fps figures are from the will127534 driver README, 4K 12-bit 4-lane; advisory until measured on this stack (Gate 1). ClearHDR halves them; 2x2 binned doubles them. 891 and 1039.5 MHz exceed the RP1 1.5 Gbps/lane spec by 19% and 39% but are proven on Pi 5."
+      }
     },
     "imx283": {
       "display_name": "IMX283",
@@ -90,7 +217,12 @@
       "log_encode": {
         "black_level_16bit": 3200,
         "targets": {
-          "12": { "valid": [10], "default": 10 }
+          "12": {
+            "valid": [
+              10
+            ],
+            "default": 10
+          }
         }
       },
       "modes": [
@@ -142,14 +274,42 @@
           "bit_depth": 10,
           "max_fps": 44
         }
-      ]
+      ],
+      "link_frequency": {
+        "lanes": 4,
+        "selectable": true,
+        "default_hz": 720000000,
+        "options": [
+          {
+            "hz": 360000000,
+            "mbps_per_lane": 720
+          },
+          {
+            "hz": 720000000,
+            "mbps_per_lane": 1440
+          }
+        ],
+        "notes": "Sony ships exactly two register sequences (mipi_data_rate_1440Mbps / _720Mbps); no other value exists in the driver, which rejects anything else at probe. 720 MHz is both the default and the silicon ceiling, so the only selectable alternative is SLOWER. This closes the long-standing 'faster link for higher fps' TODO as infeasible: the 4K modes' 44/41 fps are the link ceiling at those bit depths, and more fps means lower bit depth, not a faster link. Selecting a non-default value needs the link-frequency overlay parameter, which exists only in Tiramisioux/imx283-v4l2-driver 6.12.y at 257c9cf or later -- an older overlay rejects the unknown parameter and the camera will not enumerate."
+      }
     },
     "imx519": {
       "display_name": "IMX519",
       "common_name": "IMX519",
       "packing": "P",
       "aliases": [],
-      "modes": []
+      "modes": [],
+      "link_frequency": {
+        "lanes": 2,
+        "selectable": false,
+        "default_hz": 408000000,
+        "options": [
+          {
+            "hz": 408000000,
+            "mbps_per_lane": 816
+          }
+        ],
+        "notes": "Fixed. The driver hard-rejects any other value at probe, and no community overclock precedent was found."
+      }
     }
   }
 }

--- a/src/module/app/boot_config.py
+++ b/src/module/app/boot_config.py
@@ -30,6 +30,13 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+from module.sensor_database import (
+    link_frequency_block,
+    link_frequency_default,
+    link_frequency_is_selectable,
+    load_sensor_database,
+)
+
 CONFIG_TXT_PATH = "/boot/firmware/config.txt"
 
 # /boot/firmware is root-owned; the settings editor runs as an unprivileged
@@ -61,46 +68,63 @@ RP1_OVERCLOCK_LINE = "dtoverlay=rp1-overclock"
 # CSI-2 link frequency, settable per port as a dtoverlay parameter:
 #   dtoverlay=imx585,cam0,link-frequency=1039500000
 #
-# imx585 only. The other three sensors cannot offer this menu:
-#   imx283  driver accepts 360/720 MHz, but its overlay exposes no
-#           link-frequency override -- would need a patch to the driver fork
-#   imx477  imx477_check_link_freq() accepts *any* exact multiple of 3 MHz
-#           with no upper bound, so there is no list to offer that the driver
-#           would actually vouch for. Only its 450 MHz default is proven.
-#   imx296  no link-frequencies property at all; the sensor derives its own
-#           MIPI timing (1122-1198 Mbps)
+# Which values each sensor accepts, which is default, and whether a menu is
+# offered at all now live in resources/sensors.json's link_frequency block --
+# not here. That file is the one place this is written down, and the values
+# reach the settings editor's JavaScript from it too, rather than being
+# restated there by hand.
 #
-# Values and frame rates from will127534/imx585-v4l2-driver's README, which
-# match link_freqs[] in the driver the installer builds. The driver also
-# defines 1188000000, deliberately not offered: the README reports the Pi 4
-# cannot do it and the Pi 5 drops frames.
-#
-# Anything above the 720 MHz default needs the RP1 overclock to be useful --
-# a stock RP1 caps out around 43.8 fps at 4K no matter what the sensor sends.
-# fps figures are the README's 4K 12-bit 4-lane column; halve for 2-lane, and
-# again for ClearHDR. They are shipped to the settings editor rather than
-# restated in JavaScript -- the ACTION_METHODS catalogue already demonstrates
-# what a second hand-maintained copy costs.
-IMX585_DEFAULT_LINK_FREQUENCY = 720000000
-IMX585_LINK_FREQUENCY_TABLE = [
-    {"hz": 297000000, "mbps_per_lane": 594, "fps_4k_4lane": 20.8},
-    {"hz": 360000000, "mbps_per_lane": 720, "fps_4k_4lane": 25.0},
-    {"hz": 445500000, "mbps_per_lane": 891, "fps_4k_4lane": 30.0},
-    {"hz": 594000000, "mbps_per_lane": 1188, "fps_4k_4lane": 41.7},
-    {"hz": 720000000, "mbps_per_lane": 1440, "fps_4k_4lane": 50.0},
-    {"hz": 891000000, "mbps_per_lane": 1782, "fps_4k_4lane": 60.0},
-    {"hz": 1039500000, "mbps_per_lane": 2079, "fps_4k_4lane": 75.0},
-]
-IMX585_LINK_FREQUENCIES = [entry["hz"] for entry in IMX585_LINK_FREQUENCY_TABLE]
-LINK_FREQUENCY_MODELS = ("imx585", "imx585_mono")
-
+# Raising the link frequency raises what the *sensor sends*. The RP1 overclock
+# raises what the *receiver takes*. Both are needed: a stock RP1 caps out
+# around 43.8 fps at 4K no matter what the sensor is told to do.
 _LINK_FREQUENCY_TOKEN = "link-frequency="
 
 _DTOVERLAY_LINE_RE = re.compile(r"^(#?)dtoverlay=(\S+)\s*$", re.MULTILINE)
 
+_database_cache: dict | None = None
+
+
+def sensor_database() -> dict:
+    """Cached sensors.json. Cached because parse/apply run per request and the
+    file only changes on an install."""
+    global _database_cache
+    if _database_cache is None:
+        _database_cache = load_sensor_database()
+    return _database_cache
+
+
+def reset_database_cache() -> None:
+    """Drop the cache. For tests that point at a different database."""
+    global _database_cache
+    _database_cache = None
+
 
 def supports_link_frequency(model: str) -> bool:
-    return model in LINK_FREQUENCY_MODELS
+    """Whether to offer this model a link-frequency menu. False covers both
+    'the overlay has no such parameter' and 'the values are recorded but the
+    menu is held back pending hardware verification'."""
+    return link_frequency_is_selectable(sensor_database(), model)
+
+
+def link_frequency_options(model: str) -> list[dict]:
+    return list(link_frequency_block(sensor_database(), model).get("options", []))
+
+
+def link_frequency_menus() -> dict[str, dict]:
+    """Every model that gets a menu, shaped for the settings editor.
+
+    Keyed by the model string the editor's <select> uses, so imx585_mono gets
+    its own entry rather than the page having to know it shares imx585's
+    silicon."""
+    menus = {}
+    for model in SENSOR_MODELS:
+        if model == "none" or not supports_link_frequency(model):
+            continue
+        menus[model] = {
+            "default_hz": link_frequency_default(sensor_database(), model),
+            "options": link_frequency_options(model),
+        }
+    return menus
 
 
 def is_rpi2712_platform() -> bool:
@@ -126,10 +150,11 @@ def overlay_line_for(model: str, port: str, link_frequency: int | None = None) -
     base = model[:-len("_mono")] if model.endswith("_mono") else model
     mono_suffix = ",mono" if model == "imx585_mono" else ""
     link_suffix = ""
+    default_hz = link_frequency_default(sensor_database(), model)
     if (
         supports_link_frequency(model)
         and link_frequency is not None
-        and link_frequency != IMX585_DEFAULT_LINK_FREQUENCY
+        and link_frequency != default_hz
     ):
         link_suffix = f",{_LINK_FREQUENCY_TOKEN}{link_frequency}"
     return f"dtoverlay={base},{port}{mono_suffix}{link_suffix}"
@@ -180,8 +205,9 @@ def default_config_state() -> dict:
         "audio": True,
         "rp1_overclock": False,
         "rp1_available": is_rpi2712_platform(),
-        "link_frequencies": IMX585_LINK_FREQUENCY_TABLE,
-        "link_frequency_default": IMX585_DEFAULT_LINK_FREQUENCY,
+        # Per-model menus, straight from the database, so the page never
+        # carries its own copy of the values.
+        "link_frequency_menus": link_frequency_menus(),
     }
 
 
@@ -244,8 +270,9 @@ def parse_config_txt(full_text: str) -> dict:
         "audio": _line_on(_TOGGLE_LINES["audio"]),
         "rp1_overclock": _line_on(RP1_OVERCLOCK_LINE),
         "rp1_available": rp1_present,
-        "link_frequencies": IMX585_LINK_FREQUENCY_TABLE,
-        "link_frequency_default": IMX585_DEFAULT_LINK_FREQUENCY,
+        # Per-model menus, straight from the database, so the page never
+        # carries its own copy of the values.
+        "link_frequency_menus": link_frequency_menus(),
     }
 
 
@@ -298,13 +325,14 @@ def _validated_link_frequency(value, model: str, port: str) -> int | None:
     if not supports_link_frequency(model):
         raise ValueError(
             f"{port} is set to {model}, which has no selectable link frequency. "
-            f"Only {' / '.join(LINK_FREQUENCY_MODELS)} does."
+            f"See its link_frequency block in resources/sensors.json for why."
         )
 
-    if frequency not in IMX585_LINK_FREQUENCIES:
-        allowed = ", ".join(str(f) for f in IMX585_LINK_FREQUENCIES)
+    allowed = [option["hz"] for option in link_frequency_options(model)]
+    if frequency not in allowed:
         raise ValueError(
-            f"{frequency} is not a supported imx585 link frequency. Supported: {allowed}."
+            f"{frequency} is not a supported {model} link frequency. "
+            f"Supported: {', '.join(str(f) for f in allowed)}."
         )
 
     return frequency

--- a/src/module/app/templates/settings_editor.html
+++ b/src/module/app/templates/settings_editor.html
@@ -2792,13 +2792,20 @@
   /* ---------- config.txt reconstruction ---------- */
   var CFG_SENSOR_LABELS = { imx477: 'IMX477', imx296: 'IMX296', imx283: 'IMX283', imx585: 'IMX585', imx585_mono: 'IMX585 mono', none: 'none' };
   function cfgSensorLabel(value){ return CFG_SENSOR_LABELS[value] || value; }
-  /* The link-frequency menu and its Mbps/fps figures come from the API
-     (boot_config.IMX585_LINK_FREQUENCY_TABLE), not from a second copy kept
-     here by hand. Only the default is seeded, so the control still renders
-     sensibly if the fetch hasn't landed yet. */
-  var cfgLinkFreqTable = [];
-  var cfgLinkFreqDefault = 720000000;
-  function cfgSupportsLinkFreq(sensor){ return sensor === 'imx585' || sensor === 'imx585_mono'; }
+  /* Link-frequency menus come from resources/sensors.json by way of the API
+     (boot_config.link_frequency_menus()). Nothing about which values exist,
+     which is default, or which sensors get a menu at all is written down
+     here -- a sensor absent from this object simply has no menu, which is
+     also how a sensor whose menu is gated off pending hardware tests
+     (imx477) arrives. */
+  var cfgLinkFreqMenus = {};
+  function cfgSupportsLinkFreq(sensor){
+    return Object.prototype.hasOwnProperty.call(cfgLinkFreqMenus, sensor);
+  }
+  function cfgLinkFreqDefaultFor(sensor){
+    var menu = cfgLinkFreqMenus[sensor];
+    return menu ? menu.default_hz : null;
+  }
   function cfgLinkFreqOf(port){
     var sel = document.getElementById('cfg-' + port + '-link-freq');
     if (!sel || !sel.value) return null;
@@ -2810,30 +2817,41 @@
     var line = 'dtoverlay=' + value.replace('_mono', '') + ',' + port + (value === 'imx585_mono' ? ',mono' : '');
     /* The overlay's own default is this same value, so writing it would put a
        number in config.txt that reads as a choice when it isn't. */
-    if (cfgSupportsLinkFreq(value) && linkFreq && linkFreq !== cfgLinkFreqDefault) {
+    if (cfgSupportsLinkFreq(value) && linkFreq && linkFreq !== cfgLinkFreqDefaultFor(value)) {
       line += ',link-frequency=' + linkFreq;
     }
     return line;
   }
-  function cfgLinkFreqLabel(entry){
+  function cfgLinkFreqLabel(entry, defaultHz){
     var mhz = entry.hz / 1000000;
     /* 445.5 and 1039.5 are the only fractional ones; don't print "720.0". */
-    var mhzText = (mhz % 1 === 0 ? mhz.toFixed(0) : mhz.toFixed(1)) + ' MHz';
-    var label = mhzText + ' · ' + entry.mbps_per_lane + ' Mbps/lane · up to ' + entry.fps_4k_4lane + ' fps at 4K';
-    return entry.hz === cfgLinkFreqDefault ? label + ' (default)' : label;
+    var label = (mhz % 1 === 0 ? mhz.toFixed(0) : mhz.toFixed(1)) + ' MHz';
+    if (entry.mbps_per_lane) label += ' · ' + entry.mbps_per_lane + ' Mbps/lane';
+    /* Only imx585 has published per-frequency frame rates. Don't invent a
+       figure for a sensor whose driver README never gave one. */
+    if (entry.fps_4k12_4lane) label += ' · up to ' + entry.fps_4k12_4lane + ' fps at 4K';
+    if (entry.hz === defaultHz) label += ' (default)';
+    if (entry.over_rp1_spec) label += ' — over RP1 spec';
+    return label;
   }
   function cfgFillLinkFreqOptions(port){
     var sel = document.getElementById('cfg-' + port + '-link-freq');
-    if (!sel || !cfgLinkFreqTable.length) return;
+    if (!sel) return;
+    var sensor = document.getElementById('cfg-' + port + '-sensor').value;
+    var menu = cfgLinkFreqMenus[sensor];
+    if (!menu || !menu.options || !menu.options.length) return;
     var previous = sel.value;
     sel.innerHTML = '';
-    cfgLinkFreqTable.forEach(function(entry){
+    menu.options.forEach(function(entry){
       var opt = document.createElement('option');
       opt.value = String(entry.hz);
-      opt.textContent = cfgLinkFreqLabel(entry);
+      opt.textContent = cfgLinkFreqLabel(entry, menu.default_hz);
       sel.appendChild(opt);
     });
-    if (previous) sel.value = previous;
+    /* Keep the previous pick only if this sensor actually offers it -- the
+       two menus do not overlap much, and a stale value would be submitted. */
+    var keeps = previous && menu.options.some(function(e){ return String(e.hz) === previous; });
+    sel.value = keeps ? previous : String(menu.default_hz);
   }
   /* Shown when the overclock is on -- that is when the higher rates buy
      anything -- and also whenever a non-default rate is already configured,
@@ -2848,8 +2866,9 @@
       if (!card) return;
       var sensor = document.getElementById('cfg-' + port + '-sensor').value;
       var sel = document.getElementById('cfg-' + port + '-link-freq');
-      var chosen = sel && sel.value ? Number(sel.value) : cfgLinkFreqDefault;
-      var nonDefault = chosen !== cfgLinkFreqDefault;
+      var defaultHz = cfgLinkFreqDefaultFor(sensor);
+      var chosen = sel && sel.value ? Number(sel.value) : defaultHz;
+      var nonDefault = defaultHz !== null && chosen !== defaultHz;
       card.hidden = !cfgSupportsLinkFreq(sensor) || (!rp1 && !nonDefault);
       if (warn) warn.hidden = rp1 || !nonDefault;
     });
@@ -3373,14 +3392,18 @@
     rp1Card = rp1Card && rp1Card.closest('.card');
     if (rp1Card) rp1Card.hidden = (config.rp1_available === false);
 
-    if (Array.isArray(config.link_frequencies) && config.link_frequencies.length) {
-      cfgLinkFreqTable = config.link_frequencies;
+    if (config.link_frequency_menus && typeof config.link_frequency_menus === 'object') {
+      cfgLinkFreqMenus = config.link_frequency_menus;
     }
-    if (config.link_frequency_default) cfgLinkFreqDefault = config.link_frequency_default;
     ['cam0', 'cam1'].forEach(function(port){
       cfgFillLinkFreqOptions(port);
       var sel = document.getElementById('cfg-' + port + '-link-freq');
-      if (sel) sel.value = String(config[port + '_link_frequency'] || cfgLinkFreqDefault);
+      if (!sel) return;
+      var stored = config[port + '_link_frequency'];
+      /* null means "the overlay default" -- resolve it per sensor rather than
+         leaving the select on whatever happened to be first. */
+      var want = String(stored || cfgLinkFreqDefaultFor(config[port + '_sensor']) || '');
+      if (want) sel.value = want;
     });
     cfgSyncLinkFreqCards();
     configDirty = !!markDirtyAfter;
@@ -3765,8 +3788,16 @@
 
   /* ---------- boot config controls ---------- */
   function markConfigDirty(){ configDirty = true; updateDirtyPill(); }
-  document.getElementById('cfg-cam0-sensor').addEventListener('change', function(){ markConfigDirty(); cfgSyncLinkFreqCards(); if (activeDrawerTab === 'config') refreshDrawer(); });
-  document.getElementById('cfg-cam1-sensor').addEventListener('change', function(){ markConfigDirty(); cfgSyncLinkFreqCards(); if (activeDrawerTab === 'config') refreshDrawer(); });
+  /* Refill before syncing: each sensor has its own menu, so switching sensor
+     has to rebuild the options, not just decide whether to show them. */
+  ['cam0', 'cam1'].forEach(function(port){
+    document.getElementById('cfg-' + port + '-sensor').addEventListener('change', function(){
+      markConfigDirty();
+      cfgFillLinkFreqOptions(port);
+      cfgSyncLinkFreqCards();
+      if (activeDrawerTab === 'config') refreshDrawer();
+    });
+  });
   ['cam0', 'cam1'].forEach(function(port){
     var sel = document.getElementById('cfg-' + port + '-link-freq');
     if (!sel) return;

--- a/src/module/sensor_database.py
+++ b/src/module/sensor_database.py
@@ -1,0 +1,154 @@
+"""One loader for resources/sensors.json.
+
+SensorDetect used to own the only reader. boot_config needs the same file now
+that the link-frequency menu comes from the database rather than a table
+hardcoded in Python, and a second loader would be a second set of fallback
+rules to keep in step -- exactly the drift this database exists to prevent.
+
+Stdlib only, and no import of anything under module/ that pulls in redis:
+boot_config is imported by the settings editor blueprint, which has to work
+with no camera attached and no Redis running.
+
+A missing capability block means "this sensor does not support it", the same
+convention log_encode uses. A *malformed* one is different: it means someone
+edited the database and got it wrong, so it warns rather than passing
+silently as an absence.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+DEFAULT_SENSOR_DATABASE_FILE = "resources/sensors.json"
+
+logger = logging.getLogger(__name__)
+
+_EMPTY: dict[str, Any] = {"schema_version": 1, "sensors": {}}
+
+
+def repo_root() -> Path:
+    # src/module/sensor_database.py -> repo root
+    return Path(__file__).resolve().parents[2]
+
+
+def resolve_database_path(path_value: str | None = None) -> Path:
+    path = Path(path_value or DEFAULT_SENSOR_DATABASE_FILE)
+    return path if path.is_absolute() else repo_root() / path
+
+
+def load_sensor_database(path_value: str | None = None) -> dict[str, Any]:
+    """Parse the database, or return an empty one after warning.
+
+    sensors.json is strict JSON -- a single `//` comment takes the whole file
+    down. Returning empty rather than raising keeps a broken database from
+    stopping Cinemate from booting, but it must be loud: silently running with
+    no sensor metadata looks like "this sensor has no capabilities".
+    """
+    path = resolve_database_path(path_value)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        logger.warning("Sensor database unavailable (%s): %s", path, exc)
+        return dict(_EMPTY)
+    except json.JSONDecodeError as exc:
+        logger.warning("Sensor database is invalid JSON (%s): %s", path, exc)
+        return dict(_EMPTY)
+
+    if not isinstance(data.get("sensors"), dict):
+        logger.warning("Sensor database %s has no sensors object", path)
+        return dict(_EMPTY)
+    return data
+
+
+def base_model(model: str) -> str:
+    """'imx585_mono' -> 'imx585'. The database keys on the silicon, and the
+    mono variant is the same die with a different CFA."""
+    return model[:-len("_mono")] if model.endswith("_mono") else model
+
+
+def sensor_entry(database: dict[str, Any], model: str) -> dict[str, Any]:
+    sensors = database.get("sensors", {})
+    entry = sensors.get(base_model(model))
+    return entry if isinstance(entry, dict) else {}
+
+
+def link_frequency_block(database: dict[str, Any], model: str) -> dict[str, Any]:
+    """The sensor's link_frequency capability block, or {} if it has none.
+
+    Warns on a block that is present but the wrong shape -- that is a database
+    edit that went wrong, and treating it as "unsupported" would hide it.
+    """
+    entry = sensor_entry(database, model)
+    if "link_frequency" not in entry:
+        return {}
+
+    block = entry["link_frequency"]
+    if not isinstance(block, dict):
+        logger.warning("link_frequency for %s is %s, expected an object", model, type(block).__name__)
+        return {}
+
+    options = block.get("options")
+    if not isinstance(options, list) or not options:
+        logger.warning("link_frequency for %s has no options list", model)
+        return {}
+    if any(not isinstance(o, dict) or not isinstance(o.get("hz"), int) for o in options):
+        logger.warning("link_frequency for %s has an option with no integer hz", model)
+        return {}
+
+    default_hz = block.get("default_hz")
+    if not isinstance(default_hz, int):
+        logger.warning("link_frequency for %s has no integer default_hz", model)
+        return {}
+    if default_hz not in [o["hz"] for o in options]:
+        logger.warning("link_frequency default_hz %s for %s is not among its options", default_hz, model)
+        return {}
+
+    return block
+
+
+def link_frequency_values(database: dict[str, Any], model: str) -> list[int]:
+    return [o["hz"] for o in link_frequency_block(database, model).get("options", [])]
+
+
+def link_frequency_default(database: dict[str, Any], model: str) -> int | None:
+    return link_frequency_block(database, model).get("default_hz")
+
+
+def link_frequency_is_selectable(database: dict[str, Any], model: str) -> bool:
+    """True when the overlay actually exposes a link-frequency parameter AND
+    the menu is enabled.
+
+    Two separate reasons a sensor with known values still offers no menu:
+    the overlay has no parameter to set (imx296, imx519), or the values are
+    recorded but the menu is deliberately held back pending hardware
+    verification (`"menu_enabled": false` -- imx477 until Gate 2).
+    """
+    block = link_frequency_block(database, model)
+    if not block:
+        return False
+    if not block.get("selectable", False):
+        return False
+    return block.get("menu_enabled", True) is not False
+
+
+def link_frequency_max_for_platform(
+    database: dict[str, Any], model: str, is_pi4: bool = False,
+) -> int | None:
+    """Receiver-side ceiling for this platform, or None if unrecorded.
+
+    Mirrors get_packing_for_platform: the per-platform block narrows what the
+    generic entry allows, it never widens it.
+    """
+    block = link_frequency_block(database, model)
+    if not block:
+        return None
+    by_platform = block.get("by_platform")
+    if not isinstance(by_platform, dict):
+        return None
+    entry = by_platform.get("pi4" if is_pi4 else "pi5")
+    if not isinstance(entry, dict):
+        return None
+    max_hz = entry.get("max_hz")
+    return max_hz if isinstance(max_hz, int) else None

--- a/src/module/sensor_detect.py
+++ b/src/module/sensor_detect.py
@@ -3,7 +3,6 @@ import signal
 import subprocess
 import re
 import logging
-import json
 import time
 from pathlib import Path
 from typing import Any, Dict, List

--- a/src/module/sensor_detect.py
+++ b/src/module/sensor_detect.py
@@ -8,6 +8,8 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List
 
+from module.sensor_database import load_sensor_database
+
 DEFAULT_SENSOR_DATABASE_FILE = "resources/sensors.json"
 FALLBACK_PACKING_INFO = {
     "imx296": "U",
@@ -103,20 +105,10 @@ class SensorDetect:
         return Path(__file__).resolve().parents[2] / path
 
     def _load_sensor_database(self) -> dict[str, Any]:
-        path = self._resolve_repo_path(self.sensor_database_file)
-        try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-        except OSError as exc:
-            logging.warning("Sensor database unavailable (%s): %s", path, exc)
-            return {"schema_version": 1, "sensors": {}}
-        except json.JSONDecodeError as exc:
-            logging.warning("Sensor database is invalid JSON (%s): %s", path, exc)
-            return {"schema_version": 1, "sensors": {}}
-
-        if not isinstance(data.get("sensors"), dict):
-            logging.warning("Sensor database %s has no sensors object", path)
-            return {"schema_version": 1, "sensors": {}}
-        return data
+        # Delegates to module.sensor_database, which boot_config also uses --
+        # two loaders would mean two sets of fallback rules to keep in step,
+        # which is the drift this database exists to prevent.
+        return load_sensor_database(str(self._resolve_repo_path(self.sensor_database_file)))
 
     def _packing_info_from_database(self) -> dict[str, str]:
         packing = dict(FALLBACK_PACKING_INFO)

--- a/tools/link_frequency_drift_check.py
+++ b/tools/link_frequency_drift_check.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Fail if link-frequency data gets copied out of the sensor database.
+
+resources/sensors.json is the one place the values live. Python reads it and
+ships the menus to the settings editor, so the page renders whatever it is
+given and knows none of the numbers itself.
+
+That arrangement is easy to undo by accident: a hardcoded value in the
+template, or a fallback list "just in case the fetch is slow", and there are
+two copies again -- drifting silently, exactly like the ACTION_METHODS
+catalogue. A comment does not catch that. This does.
+
+The check is deliberately about *data*, not logic. cfgOverlayLine() in
+JavaScript necessarily mirrors overlay_line_for() in Python, because the
+drawer renders a live preview of a line the server will write; that mirror is
+small, stable, and covered by tests on both sides. A copied frequency table
+is the failure mode worth gating.
+
+Usage: python3 tools/link_frequency_drift_check.py [--repo PATH] [--strict]
+Exit 1 on drift when --strict, else 0 with the findings printed.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+TEMPLATE = "src/module/app/templates/settings_editor.html"
+DATABASE = "resources/sensors.json"
+
+
+def link_frequency_values(database: dict) -> dict[int, str]:
+    """Every hz value in the database, mapped to the sensor it came from."""
+    found: dict[int, str] = {}
+    for name, entry in database.get("sensors", {}).items():
+        block = entry.get("link_frequency")
+        if not isinstance(block, dict):
+            continue
+        for key in ("options", "excluded"):
+            for option in block.get(key, []):
+                if isinstance(option, dict) and isinstance(option.get("hz"), int):
+                    found.setdefault(option["hz"], name)
+        default = block.get("default_hz")
+        if isinstance(default, int):
+            found.setdefault(default, name)
+    return found
+
+
+def scan(repo: Path) -> list[str]:
+    database = json.loads((repo / DATABASE).read_text(encoding="utf-8"))
+    values = link_frequency_values(database)
+    if not values:
+        return [f"{DATABASE} defines no link frequencies at all -- has the block been removed?"]
+
+    text = (repo / TEMPLATE).read_text(encoding="utf-8")
+    # Strip comments so an explanatory "720 MHz default" in prose doesn't trip
+    # the check. Only live code is a duplication risk.
+    code = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+
+    problems = []
+    for hz, sensor in sorted(values.items()):
+        # Bare integer literal, not part of a longer number.
+        if re.search(r"(?<![\d.])" + str(hz) + r"(?![\d.])", code):
+            problems.append(
+                f"{TEMPLATE} hardcodes {hz} ({sensor}). Link frequencies belong in "
+                f"{DATABASE}; the page is served them via boot_config.link_frequency_menus()."
+            )
+    return problems
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", default=".")
+    parser.add_argument("--strict", action="store_true")
+    args = parser.parse_args()
+
+    repo = Path(args.repo).resolve()
+    problems = scan(repo)
+
+    print("===== link frequency: one copy only ==============================")
+    if problems:
+        for problem in problems:
+            print(f"  DRIFT: {problem}")
+        print(f"\n{len(problems)} hardcoded value(s) found.")
+        return 1 if args.strict else 0
+
+    database = json.loads((repo / DATABASE).read_text(encoding="utf-8"))
+    counted = len(link_frequency_values(database))
+    print(f"  {counted} frequencies in {DATABASE}, none restated in the template. OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Makes `resources/sensors.json` the single source of truth for CSI-2 link frequencies, replacing the imx585-only table that was hardcoded in `boot_config.py` when the menu first shipped.

## Why

The hardcoded table was already a second place sensor capabilities are written down, next to `sensors.json` itself. It would only have grown as other sensors gained menus, and this repo has been bitten by two-copy drift before — the `ACTION_METHODS` catalogue is the standing example.

## What changed

All five sensors now carry a `link_frequency` block, sibling of `log_encode` — **including the ones with nothing to choose**, because an absent block reads as "capability unknown" and every one of these has a known answer:

| Sensor | Lanes | Default | Menu | Values |
|---|---|---|---|---|
| imx585 | 4 | 720 MHz | yes | 297 / 360 / 445.5 / 594 / 720 / 891 / 1039.5 MHz |
| imx283 | 4 | 720 MHz | yes | 360 / 720 MHz — 720 is also the ceiling |
| imx477 | 2 | 450 MHz | **gated off** | driver takes any ~3 MHz multiple (kernel ≥ 6.12.49) |
| imx296 | 1 | 594 MHz | no | fixed |
| imx519 | 2 | 408 MHz | no | fixed |

Notable entries:

- **imx585's 1188 MHz** is recorded under `excluded` with its reason (frame drops on Pi 5, unsupported on Pi 4), so it can't be re-added by someone reading only the driver's `link_freqs[]`.
- **imx283** closes a standing question. Sony ships exactly two register sequences, and 720 MHz is both default and silicon ceiling, so the only selectable value is *slower*. The 4K modes' 44/41 fps are the link ceiling at those bit depths — more frame rate means lower bit depth, not a faster link.
- **imx477's** menu is held back behind `menu_enabled: false` until its 750 MHz hardware gate passes. Its driver's check is arithmetic with no upper bound, so the recorded values are curated presets rather than a list the driver vouches for.

## Structure

One loader (`src/module/sensor_database.py`) now serves both `SensorDetect` and `boot_config`; two loaders would mean two sets of fallback rules to keep in step. Stdlib only, so `boot_config` stays importable with no Redis and no camera attached. A missing block means unsupported; a malformed one warns rather than passing silently as an absence.

The settings editor is served its menus from Python and holds no frequency values of its own. `tools/link_frequency_drift_check.py` fails the build if any database frequency reappears as a literal in the template, and is wired into `checks.yml`. It gates *data*, not logic: `cfgOverlayLine` necessarily mirrors `overlay_line_for` because the drawer previews a line the server writes.

## Verification

- 534 tests pass, including new database-schema assertions and rewritten link-frequency tests that now read from the database.
- All five CI checks green (four existing plus the new drift check).
- Drift check confirmed to *catch* injected duplication, not merely pass.
- JS preview and Python writer produce identical overlay lines across all 96 model/port/frequency combinations.
- Docs build clean.

## Not verified on hardware

None of this is Pi-tested. Gates 1–3 are written up with predictions stated in advance in `development/rp1-overclock/HARDWARE-GATES.md`, along with the two preconditions blocking them: the settings editor still cannot write `config.txt` on the dev Pi (missing sudoers grant for the privileged helper), and that Pi has an imx477 attached rather than an imx585.

One risk worth flagging for review: selecting a non-default imx283 value requires the `link-frequency` overlay parameter added to `Tiramisioux/imx283-v4l2-driver` `6.12.y` at `257c9cf`. An **older overlay rejects the unknown parameter and the camera will not enumerate at all**. The minimum revision is recorded in the database notes and in the docs, and it is Gate 3. Say the word if you would rather ship imx283 gated off like imx477 until that gate runs — it is a one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)