### PR TITLE
fix: the three open B9/B11 review findings (storage eject, timecode base, restart residual)

### DIFF
--- a/_test/test_b9_b11_remediation.py
+++ b/_test/test_b9_b11_remediation.py
@@ -1,0 +1,238 @@
+"""Regression cover for the three B9/B11 review findings.
+
+B9.1  a deliberate unmount must claim the device before unmounting, so
+      storage-automount does not remount it out from under the operator.
+B9.4  the SMPTE frame base must round half-up, matching the C++ side.
+B11.4 both getty-start sites must use --job-mode=fail, so a getty start
+      cannot cancel an in-flight cinemate-autostart restart.
+"""
+
+import os
+import re
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+
+class _DummyBus:
+    def read_byte(self, *_args):
+        raise OSError
+
+    def close(self):
+        pass
+
+
+sys.modules.setdefault("smbus", types.SimpleNamespace(SMBus=lambda *_args: _DummyBus()))
+sys.modules.setdefault("redis", types.SimpleNamespace(StrictRedis=object))
+
+from module import ssd_monitor
+from module.redis_controller import smpte_frame_base
+
+
+# ─────────────────────────── B9.4 — frame base ───────────────────────────
+class SmpteFrameBaseTests(unittest.TestCase):
+    def test_half_integer_rates_round_up_like_cxx(self):
+        """Python's built-in round() is banker's rounding and would give 24."""
+        self.assertEqual(smpte_frame_base(24.5), 25)
+        self.assertEqual(smpte_frame_base(23.5), 24)
+        self.assertEqual(smpte_frame_base(29.5), 30)
+
+    def test_matches_std_lround_on_ordinary_rates(self):
+        for fps, expected in (
+            (23.976, 24),
+            (24.0, 24),
+            (25.0, 25),
+            (29.97, 30),
+            (30.0, 30),
+            (47.952, 48),
+            (50.0, 50),
+            (59.94, 60),
+        ):
+            with self.subTest(fps=fps):
+                self.assertEqual(smpte_frame_base(fps), expected)
+
+    def test_accepts_strings_because_redis_values_are_strings(self):
+        self.assertEqual(smpte_frame_base("24.5"), 25)
+        self.assertEqual(smpte_frame_base("25"), 25)
+
+    def test_degenerate_input_clamps_to_one_and_never_raises(self):
+        for bad in (0, -1, 0.4, None, "", "not-a-number", float("nan"), float("inf")):
+            with self.subTest(value=bad):
+                self.assertGreaterEqual(smpte_frame_base(bad), 1)
+
+    def test_timecode_uses_the_shared_base(self):
+        """A 24.5 fps clip must show frames 0..24, not 0..23."""
+        controller = object.__new__(sys.modules["module.redis_controller"].RedisController)
+        controller.conform_frame_rate = 24.5
+        # One second in: the frame field must have wrapped exactly once at 25.
+        self.assertEqual(controller._format_timecode(1.0, 24.5), "00:00:01:00")
+        # The last frame before the wrap is 24, which base 24 could never reach.
+        self.assertTrue(controller._format_timecode(24 / 25, 24.5).endswith(":24"))
+
+
+# ─────────────────────────── B9.1 — eject intent ─────────────────────────
+class EjectIntentTests(unittest.TestCase):
+    def _monitor(self, tmpdir):
+        monitor = ssd_monitor.SSDMonitor.__new__(ssd_monitor.SSDMonitor)
+        monitor._mount_path = Path(tmpdir) / "RAW"
+        monitor._is_mounted = True
+        monitor._device_name = "nvme0n1p1"
+        monitor._redis = None
+        return monitor
+
+    def test_unmount_flags_the_device_before_unmounting(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            flag_dir = Path(tmp) / "eject"
+            monitor = self._monitor(tmp)
+            order = []
+
+            def fake_run(cmd, **_kw):
+                order.append(("umount", (flag_dir / "nvme0n1p1").exists()))
+                return types.SimpleNamespace(returncode=0)
+
+            with (
+                patch.object(ssd_monitor, "EJECT_FLAG_DIR", flag_dir),
+                patch.object(ssd_monitor.subprocess, "call"),
+                patch.object(ssd_monitor.subprocess, "run", side_effect=fake_run),
+            ):
+                monitor.unmount_drive()
+
+            self.assertTrue((flag_dir / "nvme0n1p1").exists(),
+                            "device should stay flagged after a deliberate eject")
+            # The flag has to exist *at the moment umount runs*, not merely
+            # afterwards -- storage-automount remounts in well under a second.
+            self.assertEqual(order, [("umount", True)])
+
+    def test_successful_mount_clears_the_flag(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            flag_dir = Path(tmp) / "eject"
+            flag_dir.mkdir(parents=True)
+            (flag_dir / "nvme0n1p1").touch()
+            monitor = self._monitor(tmp)
+            monitor._is_mounted = False
+
+            with (
+                patch.object(ssd_monitor, "EJECT_FLAG_DIR", flag_dir),
+                patch.object(monitor, "_find_raw_device", return_value="/dev/nvme0n1p1"),
+                patch.object(monitor, "_detect_device_filesystem", return_value="ext4"),
+                patch.object(monitor, "_mount_raw_device", return_value=True),
+            ):
+                self.assertTrue(monitor.mount_drive())
+
+            self.assertFalse((flag_dir / "nvme0n1p1").exists())
+
+    def test_failed_mount_leaves_the_drive_ejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            flag_dir = Path(tmp) / "eject"
+            flag_dir.mkdir(parents=True)
+            (flag_dir / "nvme0n1p1").touch()
+            monitor = self._monitor(tmp)
+            monitor._is_mounted = False
+
+            with (
+                patch.object(ssd_monitor, "EJECT_FLAG_DIR", flag_dir),
+                patch.object(monitor, "_find_raw_device", return_value="/dev/nvme0n1p1"),
+                patch.object(monitor, "_detect_device_filesystem", return_value="ext4"),
+                patch.object(monitor, "_mount_raw_device", return_value=False),
+            ):
+                self.assertFalse(monitor.mount_drive())
+
+            self.assertTrue((flag_dir / "nvme0n1p1").exists(),
+                            "a failed mount must not silently un-eject the drive")
+
+    def test_unwritable_flag_dir_does_not_block_the_unmount(self):
+        """Degrades to the old racy behaviour rather than refusing to unmount."""
+        with tempfile.TemporaryDirectory() as tmp:
+            monitor = self._monitor(tmp)
+            with (
+                patch.object(ssd_monitor, "EJECT_FLAG_DIR", Path("/proc/nope/eject")),
+                patch.object(ssd_monitor.subprocess, "call"),
+                patch.object(ssd_monitor.subprocess, "run") as run,
+            ):
+                monitor.unmount_drive()
+            run.assert_any_call(["sudo", "umount", str(monitor._mount_path)], check=True)
+
+
+class StorageAutomountEjectTests(unittest.TestCase):
+    """The service half of the protocol, loaded straight from the service file."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.source = (ROOT / "services" / "storage-automount"
+                      / "storage-automount.py").read_text()
+
+    def test_change_events_are_ignored_for_flagged_devices(self):
+        # The udev worker must screen the flag before the add/change split --
+        # umount's own "change" event is what used to undo a deliberate eject.
+        self.assertIn('if action in ("add", "change") and _is_eject_flagged(devnode):',
+                      self.source)
+
+    def test_add_raw_screens_the_flag(self):
+        add_raw = self.source.split("def _add_raw(", 1)[1].split("\ndef ", 1)[0]
+        self.assertIn("_is_eject_flagged(dev)", add_raw)
+
+    def test_promotion_skips_flagged_devices(self):
+        promote = self.source.split("def _promote_next(", 1)[1].split("\ndef ", 1)[0]
+        self.assertIn("_is_eject_flagged", promote)
+
+    def test_removal_clears_the_flag_so_replug_automounts(self):
+        self.assertIn("_clear_eject_flags_for(devnode", self.source)
+
+    def test_flag_dir_is_created_at_startup(self):
+        main = self.source.split("def main(", 1)[1]
+        self.assertIn("_init_eject_dir()", main)
+
+    def test_both_sides_agree_on_the_flag_location(self):
+        self.assertIn('CINEMATE_STORAGE_RUN_DIR", "/run/cinemate-storage"', self.source)
+        self.assertIn('CINEMATE_STORAGE_RUN_DIR", "/run/cinemate-storage"',
+                      (ROOT / "src" / "module" / "ssd_monitor.py").read_text())
+
+
+# ────────────────────────── B11.4 — getty job mode ───────────────────────
+class GettyJobModeTests(unittest.TestCase):
+    """Both getty-start sites on the stop path need --job-mode=fail.
+
+    In systemd's default "replace" job mode a getty start may reverse an
+    already-queued start job for cinemate-autostart (they Conflict), cancelling
+    a restart's own start half and leaving the unit inactive/dead with
+    Result=success -- so Restart= never fires and nothing retries it.
+    """
+
+    def test_console_handoff_script_uses_fail_job_mode(self):
+        script = (ROOT / "services" / "cinemate-autostart"
+                  / "cinemate-console-handoff.sh").read_text()
+        getty_lines = [ln for ln in script.splitlines()
+                       if "getty@tty1.service" in ln and not ln.lstrip().startswith("#")]
+        self.assertTrue(getty_lines, "expected a getty start in the handoff script")
+        for line in getty_lines:
+            with self.subTest(line=line):
+                self.assertIn("--job-mode=fail", line)
+
+    def test_main_py_console_restore_uses_fail_job_mode(self):
+        source = (ROOT / "src" / "main.py").read_text()
+        body = source.split("def restore_local_console_prompt(", 1)[1]
+        body = body.split("\ndef ", 1)[0]
+        commands = re.findall(r"\[[^\]]*getty@tty1\.service[^\]]*\]", body)
+        self.assertTrue(commands, "expected getty restart commands in main.py")
+        for command in commands:
+            with self.subTest(command=command):
+                self.assertIn("--job-mode=fail", command)
+
+    def test_unit_still_declares_the_conflict_it_relies_on(self):
+        # Dropping Conflicts= was tried on hardware and made things worse
+        # (TTYVHangup then SIGHUPs this unit's own ExecStartPre). The job-mode
+        # fix assumes the conflict is still declared.
+        unit = (ROOT / "services" / "cinemate-autostart"
+                / "cinemate-autostart.service").read_text()
+        self.assertIn("Conflicts=getty@tty1.service", unit)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/services/cinemate-autostart/cinemate-console-handoff.sh
+++ b/services/cinemate-autostart/cinemate-console-handoff.sh
@@ -49,17 +49,27 @@ fi
 # on hardware across many restarts, ExecStopPost now always completes in
 # well under a second.
 #
-# A separate, narrower race remains open: cinemate-autostart.service
-# declares Conflicts=getty@tty1.service, and on hardware this getty-start
-# has been observed to occasionally collide with the start half of an
-# in-flight `systemctl restart`, leaving the unit inactive instead of
-# active (not failed/hung -- a second restart recovers it). Tried and
-# rejected: --job-mode=ignore-dependencies (still collided), deferring via
-# a timer and re-checking is-active at fire time (a stale timer from a
-# prior restart can fire mid-transition of a later one and misread),
-# debouncing the timer (the cancel only runs at the end of this script,
-# after a stale timer may have already fired), and dropping Conflicts=
-# entirely (breaks worse: TTYVHangup=yes then SIGHUPs this unit's own
-# ExecStartPre if a getty is still alive on tty1, killing a fresh start,
-# not just a restart -- confirmed on hardware, reverted). Left open.
-sudo -n /bin/systemctl --no-block start getty@tty1.service >/dev/null 2>&1 || true
+# cinemate-autostart.service declares Conflicts=getty@tty1.service. In
+# systemd's default job mode ("replace") a getty start request is allowed to
+# reverse an already-queued start job for the conflicting unit -- so during a
+# `systemctl restart` this line could cancel the restart's own start half.
+# The unit then settled inactive/dead with Result=success (not failed), which
+# means Restart= never fired and nothing retried it: observed dead for 15+ s
+# with no self-recovery until a human re-issued the restart.
+#
+# --job-mode=fail makes systemd refuse exactly that reversal: if a start job
+# for a conflicting unit is already pending, this request fails instead of
+# cancelling it. During a restart the getty start is skipped (harmless --
+# cinemate reclaims tty1 seconds later anyway); during a plain stop there is
+# no pending start job, so getty starts as before.
+#
+# Previously tried and rejected: --job-mode=ignore-dependencies (a different
+# mode -- it relaxes ordering, not conflict reversal, so it still collided),
+# deferring via a timer and re-checking is-active at fire time (a stale timer
+# from a prior restart can fire mid-transition of a later one and misread),
+# debouncing the timer (the cancel only runs at the end of this script, after
+# a stale timer may have already fired), and dropping Conflicts= entirely
+# (breaks worse: TTYVHangup=yes then SIGHUPs this unit's own ExecStartPre if
+# a getty is still alive on tty1, killing a fresh start, not just a restart
+# -- confirmed on hardware, reverted).
+sudo -n /bin/systemctl --no-block --job-mode=fail start getty@tty1.service >/dev/null 2>&1 || true

--- a/services/storage-automount/storage-automount.py
+++ b/services/storage-automount/storage-automount.py
@@ -51,6 +51,27 @@ MOUNT_BASE = Path("/media")
 RAW_LABEL = "RAW"
 RAW_ACTIVE_PATH = MOUNT_BASE / RAW_LABEL  # primary recorder target (/media/RAW)
 
+# Eject-intent protocol (shared with cinemate's ssd_monitor.py).
+#
+# umount() makes the kernel emit a udev "change" event for the block device.
+# This service cannot tell that event apart from a genuine media change, so it
+# used to re-mount and re-promote a drive the operator had just deliberately
+# ejected -- typically inside a second, long before a human could physically
+# pull it. "Unmount, wait, then pull the drive" was therefore never a safe
+# sequence, which is a data-safety problem, not just an internal inconsistency.
+#
+# cinemate now touches /run/cinemate-storage/eject/<devname> *before* it
+# unmounts, and removes it when it deliberately mounts again. While that file
+# exists this service leaves the device alone. The flag is cleared here on a
+# real udev "remove" (the drive was physically pulled), so re-inserting it
+# automounts exactly as before.
+#
+# Both halves degrade safely on their own: an un-updated cinemate simply never
+# writes a flag (today's racy behaviour), and an un-updated service ignores the
+# flags. Neither can wedge a drive permanently unmounted.
+EJECT_STATE_DIR = Path(os.getenv("CINEMATE_STORAGE_RUN_DIR", "/run/cinemate-storage"))
+EJECT_FLAG_DIR = EJECT_STATE_DIR / "eject"
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Logging
 # ─────────────────────────────────────────────────────────────────────────────
@@ -515,6 +536,74 @@ def _unmount(dev: str):
     log.debug("_unmount complete for %s", dev)
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Eject intent (see EJECT_FLAG_DIR above)
+# ─────────────────────────────────────────────────────────────────────────────
+def _init_eject_dir():
+    """Create the shared eject-flag directory, writable by the cinemate user.
+
+    Only this service runs as root, and /run itself is root-owned, so cinemate
+    cannot create this directory itself. storage-automount.service is ordered
+    Before=cinemate-autostart.service, so it always exists by the time cinemate
+    needs it.
+    """
+    try:
+        EJECT_FLAG_DIR.mkdir(parents=True, exist_ok=True)
+        # The cinemate process runs as `pi` and must be able to create and
+        # remove flag files here.
+        os.chown(EJECT_STATE_DIR, PI_UID, PI_GID)
+        os.chown(EJECT_FLAG_DIR, PI_UID, PI_GID)
+        os.chmod(EJECT_FLAG_DIR, 0o755)
+    except OSError as exc:
+        log.warning("Could not prepare eject-flag dir %s (%s); deliberate "
+                    "unmounts will be re-grabbed as before", EJECT_FLAG_DIR, exc)
+
+
+def _eject_flag_path(dev: str) -> "Path":
+    """Flag file for a device node, keyed on its basename (e.g. nvme0n1p1)."""
+    return EJECT_FLAG_DIR / os.path.basename(dev)
+
+
+def _is_eject_flagged(dev: str) -> bool:
+    """True if cinemate deliberately ejected this device and has not remounted."""
+    try:
+        return _eject_flag_path(dev).exists()
+    except OSError:
+        return False
+
+
+def _clear_eject_flag(dev: str, reason: str = ""):
+    """Drop the eject flag so the device is eligible for automount again."""
+    path = _eject_flag_path(dev)
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        log.warning("Could not clear eject flag %s (%s)", path, exc)
+        return
+    log.info("Cleared eject flag for %s%s", dev, f" ({reason})" if reason else "")
+
+
+def _clear_eject_flags_for(devnode: str, reason: str = ""):
+    """Clear the flag for `devnode` and for any partition of it.
+
+    A whole-disk removal arrives as /dev/nvme0n1 while the flag cinemate wrote
+    is keyed on the partition it had mounted (/dev/nvme0n1p1), so clearing only
+    the exact devnode would strand the partition flag and the drive would stay
+    ignored after a replug.
+    """
+    _clear_eject_flag(devnode, reason)
+    try:
+        existing = list(EJECT_FLAG_DIR.iterdir())
+    except OSError:
+        return
+    for flag in existing:
+        candidate = f"/dev/{flag.name}"
+        if _is_partition_of(candidate, devnode):
+            _clear_eject_flag(candidate, reason)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # RAW Arbitration
 # ─────────────────────────────────────────────────────────────────────────────
 # Exactly one RAW drive is "active" (mounted at /media/RAW, the recorder
@@ -639,6 +728,9 @@ def _promote_next() -> bool:
         key=lambda t: t[0],
     )
     ordered = [d for _, d in standbys] + [d for d in _raw_pool if d not in _mounts]
+    # Never promote a drive the operator deliberately ejected, even if it is
+    # still a pool member -- promotion would silently undo the eject.
+    ordered = [d for d in ordered if not _is_eject_flagged(d)]
     for d in ordered:
         if _promote_to_active(d):
             return True
@@ -648,6 +740,13 @@ def _promote_next() -> bool:
 
 def _add_raw(dev: str):
     """Handle a freshly-detected RAW device: become active if none, else standby."""
+    if _is_eject_flagged(dev):
+        # Deliberately ejected by the operator and not yet remounted. The udev
+        # "change" event that brought us here is almost certainly the unmount's
+        # own event; re-grabbing now is exactly the race this flag exists to
+        # stop. A physical pull clears the flag on the "remove" event.
+        log.info("Ignoring %s: deliberately ejected, awaiting remount or replug", dev)
+        return
     _register_raw_add(dev)
     with _raw_lock:
         if dev == _active_raw:
@@ -780,6 +879,14 @@ def _udev_worker():
         if not devnode:
             continue
 
+        # A deliberately ejected device stays untouched until cinemate mounts it
+        # again or it is physically pulled. Checked before the add/change split
+        # because umount's own "change" event is indistinguishable from a real
+        # media change here, and acting on it is what used to undo the eject.
+        if action in ("add", "change") and _is_eject_flagged(devnode):
+            log.debug("Ignoring %s event for deliberately ejected %s", action, devnode)
+            continue
+
         # Partition added/changed
         if action in ("add", "change") and devtype == "partition":
             label, _ = _get_filesystem_info(devnode)
@@ -806,6 +913,10 @@ def _udev_worker():
         elif action == "remove" and devtype in ("partition", "disk"):
             log.debug("%s removed: %s", devtype, devnode)
             _on_block_removed(devnode)
+            # The drive is physically gone, so the eject intent has been served.
+            # Clearing it here is what makes replugging automount normally again
+            # rather than leaving the device permanently ignored.
+            _clear_eject_flags_for(devnode, "device removed")
             log.debug("Removal handling complete for %s", devnode)
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -1102,6 +1213,10 @@ def main():
     log.info("Mount base: %s", MOUNT_BASE)
     log.info("User: %d:%d", PI_UID, PI_GID)
     log.info("Log level: %s", LOG_LEVEL)
+
+    # Must exist before cinemate can signal an eject. /run is a tmpfs, so any
+    # flag left behind by an unclean shutdown is gone by the time we get here.
+    _init_eject_dir()
 
     # Initialize CFE HAT PCIe before scanning
     _cfe_hat_init()

--- a/src/main.py
+++ b/src/main.py
@@ -247,15 +247,28 @@ def restore_local_console_prompt() -> bool:
     """Restore a visible tty1 prompt after Cinemate stop (SSH or local launch)."""
     systemctl = shutil.which("systemctl")
     if systemctl:
-        # Restart getty@tty1 to ensure it's running and rendering
+        # Restart getty@tty1 to ensure it's running and rendering.
+        #
+        # --job-mode=fail is load-bearing, not cosmetic. cinemate-autostart
+        # declares Conflicts=getty@tty1.service, and in systemd's default
+        # "replace" job mode this request may reverse an already-queued start
+        # job for cinemate-autostart -- during `systemctl restart` that cancels
+        # the restart's own start half, leaving the unit inactive/dead with
+        # Result=success, so Restart= never fires and nothing retries it. In
+        # "fail" mode systemd refuses the reversal and this call fails instead,
+        # which is the harmless outcome: a restarting cinemate reclaims tty1
+        # moments later. The same flag is set on the ExecStopPost handoff
+        # script, which is the other getty-start site on the stop path.
         commands = []
         sudo = shutil.which("sudo")
         if sudo:
             commands.append(
-                [sudo, "-n", systemctl, "--no-block", "--no-ask-password", "restart", "getty@tty1.service"]
+                [sudo, "-n", systemctl, "--no-block", "--no-ask-password",
+                 "--job-mode=fail", "restart", "getty@tty1.service"]
             )
         commands.append(
-            [systemctl, "--no-block", "--no-ask-password", "restart", "getty@tty1.service"]
+            [systemctl, "--no-block", "--no-ask-password",
+             "--job-mode=fail", "restart", "getty@tty1.service"]
         )
 
         for command in commands:

--- a/src/module/redis_controller.py
+++ b/src/module/redis_controller.py
@@ -120,6 +120,30 @@ class ParameterKey(Enum):
 _KNOWN_PARAMETER_VALUES = {member.value for member in ParameterKey}
 
 
+def smpte_frame_base(fps) -> int:
+    """The integer SMPTE frame base for a (possibly fractional) frame rate.
+
+    This is the single Python definition of "base = round(fps)". Use it
+    everywhere a frame rate has to become a frame count -- do not re-derive it
+    with the built-in round(), which is banker's rounding: round(24.5) == 24
+    while the C++ side (std::lround in cinepi_sound.cpp's
+    nominalTimecodeFramerate() and in dng_encoder.cpp) yields 25. At
+    half-integer frame rates that one-frame disagreement is visible to the
+    operator as Redis/GUI timecode diverging from the timecode embedded in the
+    DNG and WAV (F-253).
+
+    Rounds half away from zero and clamps to >= 1, mirroring
+    nominalTimecodeFramerate()'s std::max(1.0, std::round(framerate)).
+    """
+    try:
+        rate = float(fps)
+    except (TypeError, ValueError):
+        return 1
+    if not math.isfinite(rate) or rate <= 0.0:
+        return 1
+    return max(1, int(math.floor(rate + 0.5)))
+
+
 def encode_log_encode_request(value) -> int:
     """False|True|10|12 -> 0|1|10|12 -- the redis-safe int encoding for
     ParameterKey.LOG_ENCODE_REQUEST (mirrors camera.camN.log_encode in
@@ -392,7 +416,7 @@ class RedisController:
         Return SMPTE time-code hh:mm:ss:ff for any positive offset in seconds.
         """
         rate = frame_rate if frame_rate is not None else self.conform_frame_rate
-        rate = int(round(rate))               # ensure integer fps
+        rate = smpte_frame_base(rate)         # ensure integer fps
 
         total_frames  = int(round(seconds_total * rate))
         frames        = total_frames % rate               # 0 … rate-1  (int)

--- a/src/module/simple_gui.py
+++ b/src/module/simple_gui.py
@@ -10,7 +10,7 @@ import logging
 from flask_socketio import SocketIO
 import re
 from module.utils import Utils
-from module.redis_controller import ParameterKey
+from module.redis_controller import ParameterKey, smpte_frame_base
 from module.dynamic_resolution import dynamic_resolution_indicator_active
 from module.design_tokens import DESIGN_TOKENS
 import json
@@ -784,7 +784,10 @@ class SimpleGUI(threading.Thread):
             "shutter_label":  "SHUTTER",
             "shutter_speed":  shutter_speed,
             "fps_label":      "FPS",
-            "fps":            round(float(self.redis_controller.get_value(ParameterKey.FPS_USER.value))),
+            # smpte_frame_base, not round(): the number shown here is the base
+            # the operator reads the recorded timecode against, so it has to
+            # agree with the C++ side at half-integer rates (F-253).
+            "fps":            smpte_frame_base(self.redis_controller.get_value(ParameterKey.FPS_USER.value)),
             "wb_label":       "WB",
             "color_temp":     f"{self.redis_controller.get_value(ParameterKey.WB_USER.value)} K",
             "color_temp_libcamera": f"/ {self.redis_listener.colorTemp}K",

--- a/src/module/ssd_monitor.py
+++ b/src/module/ssd_monitor.py
@@ -52,6 +52,25 @@ YANK_ERRNOS = {
     getattr(errno, "ESTALE", errno.EIO),
 }
 
+# Eject-intent protocol, read by services/storage-automount/storage-automount.py.
+#
+# storage-automount owns /media/RAW and reacts to udev events. A plain umount
+# makes the kernel emit a "change" event for the device, which that service
+# cannot distinguish from real media activity -- so it used to re-mount and
+# re-promote the drive within about a second of a deliberate eject. That made
+# "unmount, wait, then pull the drive" unsafe: the drive an operator believed
+# was ejected was in fact mounted again before they could reach for it.
+#
+# Touching a flag file here before unmounting tells the service the unmount was
+# deliberate, so it leaves the device alone until we mount it again or it is
+# physically removed. The service creates this directory at startup (it runs as
+# root and is ordered before cinemate); if it is missing we log and carry on,
+# which just restores the previous racy behaviour rather than blocking a
+# perfectly good unmount.
+EJECT_FLAG_DIR = Path(
+    os.getenv("CINEMATE_STORAGE_RUN_DIR", "/run/cinemate-storage")
+) / "eject"
+
 
 # ----------------------------------------------------------------------
 # SSDMonitor
@@ -865,9 +884,60 @@ class SSDMonitor:
         self._check_mount_status()
         return self._is_mounted
 
+    # ------------------------------------------------------------------
+    # eject intent (see EJECT_FLAG_DIR)
+    # ------------------------------------------------------------------
+    def _eject_flag_path(self, device: Optional[str] = None) -> Optional[Path]:
+        """Flag file for the RAW device, or None if the device is unknown."""
+        dev_name = device or self._device_name or self._get_device_name()
+        if not dev_name:
+            return None
+        return EJECT_FLAG_DIR / os.path.basename(dev_name)
+
+    def _set_eject_intent(self, device: Optional[str] = None) -> None:
+        """Tell storage-automount this unmount is deliberate, before unmounting.
+
+        Best-effort by design: if the flag cannot be written the unmount still
+        proceeds, it just races with the automounter the way it always did.
+        """
+        path = self._eject_flag_path(device)
+        if path is None:
+            logging.warning(
+                "eject intent: RAW device name unknown; storage-automount may "
+                "remount the drive right after this unmount"
+            )
+            return
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.touch()
+            logging.info("eject intent: flagged %s as deliberately ejected", path.name)
+        except OSError as exc:
+            logging.warning(
+                "eject intent: could not write %s (%s); storage-automount may "
+                "remount the drive right after this unmount", path, exc
+            )
+
+    def _clear_eject_intent(self, device: Optional[str] = None) -> None:
+        """Release the drive back to storage-automount after a deliberate mount."""
+        path = self._eject_flag_path(device)
+        if path is None:
+            return
+        try:
+            path.unlink()
+            logging.info("eject intent: cleared %s", path.name)
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            logging.warning("eject intent: could not clear %s (%s)", path, exc)
+
     def unmount_drive(self) -> None:
         if not self._is_mounted:
             return
+
+        # Claim the device before unmounting, not after: storage-automount has
+        # been observed re-mounting it in under a second, so a flag written
+        # afterwards can lose the race it exists to prevent.
+        self._set_eject_intent()
 
         # flush pending write-back pages before detaching
         subprocess.call(["sync"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
@@ -918,7 +988,14 @@ class SSDMonitor:
                 fs_hint,
             )
 
-        return self._mount_raw_device(raw_dev, fstype)
+        mounted = self._mount_raw_device(raw_dev, fstype)
+        if mounted:
+            # Deliberately mounted again, so the eject intent is spent and
+            # storage-automount may manage this device normally from here.
+            # Only on success: a failed mount leaves the drive ejected, which
+            # is the state the operator actually asked for.
+            self._clear_eject_intent(raw_dev)
+        return mounted
 
     def erase_drive(self) -> bool:
         """Erase all files from the mounted RAW volume."""
@@ -1024,6 +1101,12 @@ class SSDMonitor:
 
         device = f"/dev/{dev_name}"
 
+        # Claim the device before unmounting. This matters more here than for a
+        # plain eject: without it storage-automount can remount the partition in
+        # the window between the umount below and mkfs opening the device, so
+        # mkfs would run against a live mount.
+        self._set_eject_intent(dev_name)
+
         # Flush dirty pages before attempting unmount — pending writeback is the
         # most common cause of EBUSY on a clean-unmount attempt.
         subprocess.call(["sync"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
@@ -1067,6 +1150,10 @@ class SSDMonitor:
                     "format_drive(): could not unmount %s after eviction; aborting format",
                     self._mount_path,
                 )
+                # The drive is still mounted and we are not going to format it,
+                # so release the claim rather than leaving a mounted device
+                # flagged as ejected.
+                self._clear_eject_intent(dev_name)
                 return False
 
         # Allow the kernel time to release all block-layer references before


### PR DESCRIPTION
Fixes the three findings left open by the 2026-08-26 hardware session (S13). None of the files involved had changed on `dev` since, so all three were still live.

The cinepi-raw half of B9.4 is Tiramisioux/cinepi-raw#64. **Land both close together**: at half-integer rates neither alone makes the two sides agree. Today Python says 24 and C++ says 24-or-25 depending on sensor mode; this PR alone makes Python say 25 (agreeing whenever the mode happens to give 25), cinepi-raw#64 alone makes C++ say 25 always (so it would always disagree with Python's 24). Only both together give a stable 25/25.

## B9.1 — unmount did not eject the drive (safety-relevant)

A single isolated unmount, polled every second for ten seconds, never once read as unmounted. `umount` makes the kernel emit a udev `change` event, and the udev worker routed `add` and `change` identically into `_add_raw()` — so the unmount's own event re-registered and re-promoted the drive, typically inside a second. The comment already in that file claimed the service "never re-grabs a device a user unmounted out-of-band"; nothing implemented it.

This is a data-safety problem rather than an internal inconsistency: an operator who ejects from the GUI before physically pulling the drive gets it remounted before they can reach for it, so **"unmount, wait, pull" was never a safe sequence**. It also left a window in `format_drive()` where the partition could be remounted between the `umount` and `mkfs` opening the device — the format test that passed in S13 did so on timing luck.

Adds the ownership protocol F-160 says is missing, in its smallest useful form: cinemate touches `/run/cinemate-storage/eject/<devname>` before unmounting and removes it when it deliberately mounts again; while that file exists storage-automount leaves the device alone. Cleared on a real udev `remove`, so replugging automounts as before, and `/run` is a tmpfs so no flag survives a reboot.

Both halves degrade safely on their own — an un-updated cinemate never writes a flag (today's behaviour), an un-updated service ignores them — so neither can wedge a drive permanently unmounted.

## B9.4 — Python and C++ disagreed on the frame base

`round(fps)` was derived at four sites under three rounding rules. Python's `round()` is banker's rounding, so `round(24.5) == 24`, where the C++ recorder's `std::lround` gives 25 — putting the Redis/GUI timecode a whole frame base away from what is embedded in the DNG and WAV. Replaced with one canonical `smpte_frame_base()` helper used by both Python sites; the redundancy is what let the rules drift apart.

## B11.4 — restart could leave the camera stack down

Both getty-start sites on the stop path requested `getty@tty1` in systemd's default `replace` job mode. The unit declares `Conflicts=getty@tty1.service`, and in `replace` mode a start request may reverse an already-queued start job for the conflicting unit — cancelling the restart's own start half. It logged as `Job for cinemate-autostart.service canceled` with `Result=success`, which is why `Restart=` never fired and nothing retried. The residual was recorded as self-recovering; **it is not** — one instance sat inactive 15+ seconds with the camera stack down until a human re-issued the restart.

`--job-mode=fail` makes systemd refuse that reversal. It is not one of the four mitigations already tried and rejected on hardware — `--job-mode=ignore-dependencies` relaxes ordering, not conflict reversal.

## Verification

- Full suite: **565 passed, 330 subtests**, no regressions (was 547/311).
- 18 new tests, checked against an unmodified `origin/dev` checkout as a negative control: 9 fail there; the 3 that pass are guard assertions that should hold both before and after.
- **Not yet verified on hardware.** B9.1 and B11.4 both need a Pi run — see below.

## Suggested hardware gates

1. **B9.1** — repeat the isolated-unmount poll. Expect `MOUNTED` at zero of ten polls and a journal line reading "deliberately ejected, awaiting remount or replug"; then confirm replug automounts, and that a format still completes with no remount between `umount` and `mkfs`.
2. **B11.4** — 10× `systemctl restart cinemate-autostart`, 8 s settle. Expect 10/10 `active`, the getty request failing only during restarts, and a plain `systemctl stop` still handing the console to getty.
3. **B9.4** — a 24.5 fps take should wrap at 24→0 and `tc_cam0` should agree. Worth recording in two different sensor modes: pre-fix the base changed with the mode, which is the whole reason two sessions disagreed.

Note `storage-automount.py` is installed to `/usr/local/bin/`, so B9.1 needs a reinstall of the service file, not just a `git pull`.

Refs: F-160, F-253, F-283, B9.1, B9.4, B11.4, PI-010

🤖 Generated with [Claude Code](https://claude.com/claude-code)

