### PR TITLE
fix(web): phone usability — viewport meta for the settings editor, tap targets and type floors for the live GUI

### DIFF
--- a/docs/web-gui.md
+++ b/docs/web-gui.md
@@ -35,7 +35,9 @@ preview, right status rail) holds at any width or orientation, with the rails an
 shrinking smoothly on a narrow or portrait screen instead of restacking into a different layout
 — the same model `simple_gui.py` already uses for the HDMI GUI, which scales its entire
 1920×1080-authored layout by a single `disp_width/1920`, `disp_height/1080` ratio and never
-restacks either.
+restacks either. Two exceptions to the pure ratio: the clip name and the WAV badge have pixel
+floors (10px/8px) so they stay legible on a phone, where the HDMI ratio would shrink them below
+readable size.
 
 !!! note ""
 

--- a/src/module/app/templates/settings_editor.html
+++ b/src/module/app/templates/settings_editor.html
@@ -1,4 +1,6 @@
+<!DOCTYPE html>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <title>Cinemate — Settings</title>
 <style>
   @font-face {
@@ -439,7 +441,9 @@
   .filepath svg{ opacity:.6; flex:none; }
 
   /* Detected-modes readout on the Boot config page. */
-  .mode-table{ width:100%; border-collapse:collapse; font-size:12.5px; margin:2px 0 6px; }
+  .mode-table{ width:100%; border-collapse:collapse; font-size:12.5px; line-height:1.3; margin:2px 0 6px; }
+  /* line-height pinned: in quirks mode (pre-doctype) the UA table quirk reset it to
+     ~normal; without this, standards mode would inherit body's 1.5 and grow each row */
   .mode-table th{
     font-weight:700; color: var(--muted); padding:3px 0; text-align:left;
     border-bottom:1px solid var(--line); font-size:11px; text-transform:uppercase; letter-spacing:.04em;

--- a/src/module/app/templates/template.html
+++ b/src/module/app/templates/template.html
@@ -125,12 +125,19 @@
         }
 
         /* A transparent native select over the group keeps the platform
-           picker on touch devices while the styled text stays visible. */
+           picker on touch devices while the styled text stays visible.
+           The negative inset stretches the hit area past the group box —
+           the text is only ~18px tall on a phone, far under the ~44px
+           touch-target guideline. px, not em: em here would resolve
+           against the UA's hidden control font (13-16px depending on
+           engine), not the visible text. Invisible, so the only cost is
+           ambiguity where the top row wraps on a portrait phone: rows sit
+           4px apart there, so a lower row's select reaches ~4px into the
+           row above — a tap on those descender pixels opens the lower
+           group's picker. Recoverable, and only in the wrapped layout. */
         .group select {
             position: absolute;
-            inset: 0;
-            width: 100%;
-            height: 100%;
+            inset: -8px -6px;
             opacity: 0;
             border: 0;
             cursor: pointer;
@@ -154,10 +161,12 @@
         /* simple_gui draws the WAV pill at 14px against clip_name's 18px
            (~0.78x) -- smaller than clip_name itself, not the generic 0.58
            top-row badge ratio, which was sized against the full-height RES
-           value instead. */
+           value instead. The px floor is browser-only: the HDMI ratio
+           lands below legibility once the clamp()ed web sizes shrink
+           (~4.9px on a phone in landscape). */
         .badge.wav {
             background: var(--box);
-            font-size: calc(var(--value-size) * 0.34);
+            font-size: max(8px, calc(var(--value-size) * 0.34));
         }
         .badge.wav.recording { background: var(--wav-rec); }
         .badge.hidden { display: none; }
@@ -334,9 +343,11 @@
            it enough room for the full "CINEPI_25-07-01_220547_F10_C00000_
            000000009" string simple_gui actually shows (uncut — the DNG
            basename minus the _camN suffix, frame counter included) rather
-           than an arbitrary width that ellipsizes it early. */
+           than an arbitrary width that ellipsizes it early. The px floor
+           is browser-only: 0.44 of the clamp()ed web size bottoms out at
+           ~6.3px on a phone in landscape, under any legible size. */
         .group.clip .value {
-            font-size: calc(var(--value-size) * 0.44);
+            font-size: max(10px, calc(var(--value-size) * 0.44));
             overflow: hidden;
             text-overflow: ellipsis;
             max-width: 70vw;


### PR DESCRIPTION
## What

Two phone-usability fixes to the web surfaces, found during a design review of the dev-tip web UI, both verified in a desk browser harness before pushing.

### 1. Settings editor: doctype + viewport meta (`settings_editor.html`)

The template began at `<meta charset>` — **no doctype, no viewport meta**. Consequences on a phone:

- No viewport meta → the browser lays the page out at the **980px fallback viewport**, so `@media (max-width: 860px)` never fires in portrait. The hamburger + slide-in rail that already exist on dev were unreachable — the reported "no hamburger menu in vertical mode" bug.
- No doctype → **quirks mode** (`document.compatMode === "BackCompat"`).

Measured before the fix (mobile emulation, 375px device): `innerWidth: 980`, hamburger `display: none`. After: `innerWidth: 375`, standards mode, hamburger/drawer/scrim all working; desktop rendering unchanged. The one deliberate compensation: `.mode-table` pins `line-height: 1.3`, because standards mode removes the UA table quirk that previously kept that readout compact.

### 2. Live web GUI: tap targets + legibility floors (`template.html`)

Measured at 812×375 (phone landscape) in the harness:

| | before | after |
|---|---|---|
| top-row select hit area | 44×18px | 56×34px (47px clearance to neighbour) |
| clip name font | 6.3px | 10px floor |
| WAV badge font | 4.9px | 8px floor |

- The transparent native selects get a negative inset in **px** (not em — em would resolve against the UA's hidden control font, 13–16px depending on engine). No visual change.
- The two smallest text elements get browser-only px floors; on desktop the sizes are within half a pixel of before, so HDMI-GUI visual parity holds where it was ever visible.
- `docs/web-gui.md`'s "scales by a single ratio" paragraph gains a two-floor qualifier so it stays accurate.

## Verification

- Desk harness (static copy of the template + mocked Socket.IO feed shaped like `populate_values()`, plus the settings-editor stub-API harness): desktop 1440px and phone 375/812px, idle/recording/warning/dual-cam states — renders pixel-equivalent outside the intended changes.
- `tools/design_token_diff.py --strict` exits 0 — the generated `:root` token block is untouched.
- Adversarial review pass over the diff (quirks-mode-dependency, CSS-correctness, project-conventions lenses): no blockers. Known trade-off it surfaced, documented in the code comment: where the top row wraps on a portrait phone, adjacent rows sit 4px apart, so a lower row's enlarged select reaches ~4px into the row above — a tap on those descender pixels opens the lower group's picker. Recoverable, wrapped-portrait only.
- Not tested on the Pi itself — these are template-only changes served verbatim by Flask, but a quick phone check against a real unit after merge is the honest final gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)