### PR TITLE
fix(resolution): re-apply camera controls (incl. zoom) after a sensor-mode switch

### DIFF
--- a/_test/test_cinepi_controller_resolution_gui.py
+++ b/_test/test_cinepi_controller_resolution_gui.py
@@ -335,6 +335,24 @@ class ResolutionGuiStateTests(unittest.TestCase):
             ],
         )
 
+    def test_reapply_republishes_zoom_when_present(self):
+        # zoom joins the re-apply set now that cinepi-raw clears its
+        # last-applied-zoom dedup baseline on every camera restart: the
+        # restart resets the ISP's ScalerCrop to full frame, so the
+        # operator's zoom must be force-republished to reprogram the crop.
+        controller = self.controller()
+        controller.redis_controller.values[ParameterKey.ZOOM.value] = "2.0"
+
+        controller._reapply_camera_controls()
+
+        self.assertEqual(
+            controller.redis_controller.forced_sets,
+            [
+                (ParameterKey.SHUTTER_A.value, "180"),
+                (ParameterKey.ZOOM.value, "2.0"),
+            ],
+        )
+
     def test_reapply_skips_keys_redis_does_not_hold(self):
         # A key never seeded (fresh boot, sensor without colour gains yet)
         # must be skipped, not published as None/empty.

--- a/_test/test_cinepi_controller_resolution_gui.py
+++ b/_test/test_cinepi_controller_resolution_gui.py
@@ -25,15 +25,18 @@ class FakeRedis:
             ParameterKey.IS_RECORDING.value: "0",
         }
         self.sets = []
+        self.forced_sets = []
 
     def get_value(self, key, default=None):
         key = key.value if isinstance(key, ParameterKey) else key
         return self.values.get(key, default)
 
-    def set_value(self, key, value):
+    def set_value(self, key, value, *, force=False):
         key = key.value if isinstance(key, ParameterKey) else key
         self.values[key] = value
         self.sets.append((key, value))
+        if force:
+            self.forced_sets.append((key, value))
 
 
 class FakeSensorDetect:
@@ -282,6 +285,65 @@ class ResolutionGuiStateTests(unittest.TestCase):
         self.assertEqual(complete_calls, [])  # not fired until the timer actually runs
         complete_fn()
         self.assertEqual(complete_calls, [1])
+
+    def test_switch_complete_force_republishes_camera_facing_keys(self):
+        # LIVE-RESULTS-2026-08-27 §6: a mode switch resets the sensor's
+        # exposure to VMAX while Redis keeps the old shutter_a, and the
+        # operator's re-issued identical value is swallowed by set_value's
+        # same-value dedup. Once the new stream is up, the camera-facing
+        # keys must be force-republished so cinepi-raw reprograms the sensor.
+        controller = self.controller()
+        controller.redis_controller.values[ParameterKey.ISO.value] = "800"
+        controller.redis_controller.values[ParameterKey.CG_RB.value] = "2.5,1.8"
+        resolution_info = controller.sensor_detect.res_modes[1]
+        controller._publish_resolution_target_state(1, resolution_info, switching=True)
+        controller._resolution_switching_timer = mock.Mock()
+
+        controller.handle_cinepi_raw_message(
+            "[2026-05-31 18:00:31.405] [event_loop] [info] Raw stream: 3856x2180 : 7712 : SRGGB16"
+        )
+
+        self.assertEqual(
+            controller.redis_controller.forced_sets,
+            [
+                (ParameterKey.SHUTTER_A.value, "180"),
+                (ParameterKey.ISO.value, "800"),
+                (ParameterKey.CG_RB.value, "2.5,1.8"),
+            ],
+        )
+
+    def test_timer_fallback_also_force_republishes_camera_facing_keys(self):
+        # The fallback path must re-apply too: if the raw-stream log line is
+        # never seen, the sensor was still reconfigured and still reset.
+        controller = self.controller()
+        controller.redis_controller.values[ParameterKey.ISO.value] = "800"
+        resolution_info = controller.sensor_detect.res_modes[1]
+        controller._publish_resolution_target_state(1, resolution_info, switching=True)
+
+        with mock.patch.object(cinepi_controller_module.threading, "Timer") as fake_timer_cls:
+            fake_timer_cls.return_value = mock.Mock()
+            controller._schedule_resolution_switch_complete(1, resolution_info)
+            complete_fn = fake_timer_cls.call_args.args[1]
+
+        self.assertEqual(controller.redis_controller.forced_sets, [])
+        complete_fn()
+        self.assertEqual(
+            controller.redis_controller.forced_sets,
+            [
+                (ParameterKey.SHUTTER_A.value, "180"),
+                (ParameterKey.ISO.value, "800"),
+            ],
+        )
+
+    def test_reapply_skips_keys_redis_does_not_hold(self):
+        # A key never seeded (fresh boot, sensor without colour gains yet)
+        # must be skipped, not published as None/empty.
+        controller = self.controller()
+        del controller.redis_controller.values[ParameterKey.SHUTTER_A.value]
+
+        controller._reapply_camera_controls()
+
+        self.assertEqual(controller.redis_controller.forced_sets, [])
 
     def test_nonmatching_raw_stream_log_does_not_clear_resolution_switching(self):
         controller = self.controller()

--- a/_test/test_redis_controller_set_value.py
+++ b/_test/test_redis_controller_set_value.py
@@ -4,6 +4,11 @@ visible-but-non-blocking fix: an un-enumerated key still gets written (a
 hard reject with no Pi available to verify every call site was judged too
 risky -- see the commit message), but it now logs a warning, once per key,
 so the drift is observable instead of silent.
+
+Also locks in set_value's force= escape hatch (LIVE-RESULTS-2026-08-27 §6):
+the same-value dedup must stay the default (publish-storm protection for
+per-frame keys), but force=True must punch through it so the mode-switch
+re-apply path can make cinepi-raw re-consume a value Redis already holds.
 """
 
 import sys
@@ -27,6 +32,7 @@ class _FakePubSub:
 class _FakeStrictRedis:
     def __init__(self, *args, **kwargs):
         self._store = {}
+        self.publishes = []
 
     def keys(self, pattern="*"):
         return []
@@ -38,7 +44,7 @@ class _FakeStrictRedis:
         self._store[key] = str(value).encode()
 
     def publish(self, channel, message):
-        pass
+        self.publishes.append((channel, message))
 
     def pubsub(self):
         return _FakePubSub()
@@ -95,6 +101,57 @@ class SetValueParameterKeyEnforcementTests(unittest.TestCase):
         # call site with no Pi available to verify every one of them.
         self.controller.set_value("totally_made_up_key", "42")
         self.assertEqual(self.controller.get_value("totally_made_up_key"), "42")
+
+
+class SetValueForceRepublishTests(unittest.TestCase):
+    """The publish IS the payload: cinepi-raw reprograms the live camera only
+    when a key lands on cp_controls, so after a sensor reconfigure resets the
+    camera behind Redis's back, a same-value re-issue must be publishable."""
+
+    def setUp(self):
+        self.controller = RedisController()
+
+    def _publishes_of(self, key):
+        return [m for (_c, m) in self.controller.r.publishes if m == key]
+
+    def test_same_value_write_is_deduped_by_default(self):
+        key = ParameterKey.SHUTTER_A.value
+        self.controller.set_value(key, "180")
+        self.controller.set_value(key, "180")
+        self.assertEqual(len(self._publishes_of(key)), 1)
+
+    def test_force_republishes_an_unchanged_value(self):
+        # The exact defect shape: Redis already says 180, the sensor no
+        # longer does. Without force the re-issue was silently swallowed.
+        key = ParameterKey.SHUTTER_A.value
+        self.controller.set_value(key, "180")
+        self.controller.set_value(key, "180", force=True)
+        self.assertEqual(len(self._publishes_of(key)), 2)
+        self.assertEqual(self.controller.get_value(key), "180")
+
+    def test_force_republish_notifies_local_subscribers_too(self):
+        # GUI surfaces listen on redis_parameter_changed; a forced re-apply
+        # must reach them the same way a normal write does.
+        key = ParameterKey.ISO.value
+        self.controller.set_value(key, "800")
+        seen = []
+        self.controller.redis_parameter_changed.subscribe(seen.append)
+        self.controller.set_value(key, "800", force=True)
+        self.assertEqual(seen, [{"key": key, "value": "800"}])
+
+    def test_force_still_writes_a_changed_value_normally(self):
+        key = ParameterKey.ISO.value
+        self.controller.set_value(key, "800")
+        self.controller.set_value(key, "1600", force=True)
+        self.assertEqual(self.controller.get_value(key), "1600")
+        self.assertEqual(len(self._publishes_of(key)), 2)
+
+    def test_force_does_not_bypass_the_none_guard(self):
+        key = ParameterKey.SHUTTER_A.value
+        self.controller.set_value(key, "180")
+        self.controller.set_value(key, None, force=True)
+        self.assertEqual(self.controller.get_value(key), "180")
+        self.assertEqual(len(self._publishes_of(key)), 1)
 
 
 if __name__ == "__main__":

--- a/src/module/cinepi_controller.py
+++ b/src/module/cinepi_controller.py
@@ -33,17 +33,20 @@ RAW_STREAM_READY_RE = re.compile(r"\bRaw stream:\s*(\d+)x(\d+)\b", re.IGNORECASE
 
 # Keys cinepi-raw applies to the LIVE camera only when the key is published on
 # cp_controls (SetControls handlers in cinepi_controller.cpp): shutter_a ->
-# ExposureTime, iso -> AnalogueGain, cg_rb -> ColourGains. A camera
-# reconfigure resets those sensor controls while Redis keeps the operator's
-# values, so they must be re-published after every mode switch. zoom is
-# deliberately absent: cinepi-raw's zoom handler keeps its own last-value
-# dedup, so a same-value republish is dropped on that side regardless. The
-# ClearHDR knobs are also absent: cinepi-raw re-applies those itself when a
-# ClearHDR mode is selected.
+# ExposureTime, iso -> AnalogueGain, cg_rb -> ColourGains, zoom ->
+# ScalerCrop. A camera reconfigure resets those sensor/ISP controls while
+# Redis keeps the operator's values, so they must be re-published after every
+# mode switch. zoom requires the companion cinepi-raw fix (branch
+# fix/mode-switch-control-reapply): its handler dedups against the last
+# APPLIED zoom, and that baseline is now cleared on every camera restart so
+# this republish reprograms the crop instead of being dropped. The ClearHDR
+# knobs are absent: cinepi-raw re-applies those itself when a ClearHDR mode
+# is selected.
 CAMERA_CONTROL_REAPPLY_KEYS = (
     ParameterKey.SHUTTER_A,
     ParameterKey.ISO,
     ParameterKey.CG_RB,
+    ParameterKey.ZOOM,
 )
 
 

--- a/src/module/cinepi_controller.py
+++ b/src/module/cinepi_controller.py
@@ -31,6 +31,21 @@ GUI_RESOLUTION_PREVIEW_DELAY_SECONDS = 0.12
 GUI_RESOLUTION_SWITCHING_HOLD_SECONDS = 2.5
 RAW_STREAM_READY_RE = re.compile(r"\bRaw stream:\s*(\d+)x(\d+)\b", re.IGNORECASE)
 
+# Keys cinepi-raw applies to the LIVE camera only when the key is published on
+# cp_controls (SetControls handlers in cinepi_controller.cpp): shutter_a ->
+# ExposureTime, iso -> AnalogueGain, cg_rb -> ColourGains. A camera
+# reconfigure resets those sensor controls while Redis keeps the operator's
+# values, so they must be re-published after every mode switch. zoom is
+# deliberately absent: cinepi-raw's zoom handler keeps its own last-value
+# dedup, so a same-value republish is dropped on that side regardless. The
+# ClearHDR knobs are also absent: cinepi-raw re-applies those itself when a
+# ClearHDR mode is selected.
+CAMERA_CONTROL_REAPPLY_KEYS = (
+    ParameterKey.SHUTTER_A,
+    ParameterKey.ISO,
+    ParameterKey.CG_RB,
+)
+
 
 def _safe_int(value):
     try:
@@ -1119,11 +1134,36 @@ class CinePiController:
         # is deliberately a separate hook from _notify_resolution_change: that one
         # fires when the switch *starts*, so the browser can show "switching..."
         # immediately, well before there is a new stream to reconnect to (F-290).
+        try:
+            self._reapply_camera_controls()
+        except Exception:
+            logging.exception("Camera-control re-apply after resolution switch failed.")
         for callback in list(self._resolution_switch_complete_callbacks):
             try:
                 callback()
             except Exception:
                 logging.exception("Resolution switch-complete callback failed.")
+
+    def _reapply_camera_controls(self) -> None:
+        """Force-republish the camera-facing control keys after a reconfigure.
+
+        A mode switch (seamless cam_init reconfigure or a full cinepi-raw
+        restart) resets the sensor's exposure/gain/colour state to defaults
+        while Redis still holds the operator's values. cinepi-raw only
+        reprograms the live camera when a key is published on cp_controls, and
+        set_value's same-value dedup swallows a re-issued identical value --
+        so the operator's `set shutter a 180` after a mode switch was a
+        silent no-op and camera state diverged from Redis state
+        (LIVE-RESULTS-2026-08-27 §6). This runs once the new stream is
+        actually up: publishing right after cam_init would race cinepi-raw's
+        deferred reconfigure (its handler only sets cameraInit_ = true) and
+        the controls would be reset again underneath us.
+        """
+        for key in CAMERA_CONTROL_REAPPLY_KEYS:
+            value = self.redis_controller.get_value(key.value)
+            if value is None or str(value) == "":
+                continue
+            self.redis_controller.set_value(key.value, value, force=True)
 
     def _pace_resolution_change(self, recording: bool) -> None:
         min_interval = (

--- a/src/module/redis_controller.py
+++ b/src/module/redis_controller.py
@@ -273,8 +273,20 @@ class RedisController:
         return as_bool(self.cache.get(ParameterKey.STORAGE_PREROLL_ACTIVE.value, "0"))
 
         # ────────────────────────── public helpers ───────────────────────
-    def set_value(self, key, value):
-        """Write key, publish, update cache, emit consolidated log output."""
+    def set_value(self, key, value, *, force=False):
+        """Write key, publish, update cache, emit consolidated log output.
+
+        force=True publishes even when the value is unchanged. The same-value
+        early-out below is deliberate storm protection for per-frame keys
+        (framecount, fps_actual, the recording timers) -- but it also means a
+        re-issued command can never reach cinepi-raw while Redis already holds
+        that value. That is wrong in exactly one situation: the camera has
+        been reconfigured behind Redis's back (a sensor-mode switch resets
+        exposure to VMAX), so sensor state and Redis state disagree and the
+        publish itself is the payload. The mode-switch re-apply path
+        (CinePiController._reapply_camera_controls) passes force=True;
+        every other caller keeps the dedup.
+        """
         if value is None:
             logging.warning(f"Attempted to set Redis key '{key}' to None. Ignoring.")
             return
@@ -297,7 +309,7 @@ class RedisController:
 
         # ─── Redis write / publish / cache ───────────────────────────
         with self.lock:
-            if str(self.cache.get(key_name)) == str(value):
+            if not force and str(self.cache.get(key_name)) == str(value):
                 return                             # unchanged – nothing to do
             self.r.set(key_name, value)
             self.r.publish("cp_controls", key_name)


### PR DESCRIPTION
## Summary

A sensor-mode switch (seamless cam_init reconfigure or a full cinepi-raw restart) resets the sensor's exposure/gain/colour state and the ISP's ScalerCrop while Redis keeps the operator's values — and `set_value`'s same-value dedup swallowed a re-issued identical value, so the camera silently diverged from Redis state (operator workaround was to set a different value, then the target; LIVE-RESULTS-2026-08-27 §6).

## Change

- `set_value` gains a keyword-only `force=` escape hatch; the same-value dedup itself stays (publish-storm protection).
- The resolution-switch **completion** path (raw-stream evidence or the fallback timer — not cam_init, which would race cinepi-raw's deferred reconfigure) force-republishes the camera-facing keys: `shutter_a`, `iso`, `cg_rb`, and now `zoom`.
- `zoom` was initially excluded because cinepi-raw's handler kept its own last-value dedup, making a republish a no-op. The companion PR Tiramisioux/cinepi-raw#65 makes that dedup track the last zoom *applied* to the ISP, cleared on every camera restart, so the republish now reprograms the crop. Requires that PR to be effective for zoom; the other keys work standalone.

## Testing

- `python3 -m unittest _test.test_cinepi_controller_resolution_gui _test.test_redis_controller_set_value` — 22 tests, all pass, including a new test that zoom is force-republished on switch-complete.
- Desk-only so far; **Pi verification pending**: set shutter/iso/zoom, switch sensor mode, confirm all take effect without re-stepping values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)