### PR TITLE
fix: rp1_regime config.txt authority + drop AWB args on mono launch

### DIFF
--- a/_test/test_cinepi_multi_mono_awb.py
+++ b/_test/test_cinepi_multi_mono_awb.py
@@ -1,0 +1,73 @@
+"""A mono sensor has no CFA, so --awb/--awbgains are meaningless for it --
+cinepi_multi.py used to send them anyway (`--awb auto --awbgains 3.3,1.5` on
+a mono launch, per the 2026-08-27 hardware log). CinePiProcess._build_args()
+now omits both, and the cg_rb value they would have carried, for a mono
+CameraInfo -- and still sends them, unchanged, for a colour one.
+
+CinePiProcess._build_args() has a lot of surface area (storage profiles,
+CineMate Log resolution, dual-HDMI, ...), none of which this test seam
+touches: every dependency is a minimal fake returning defaults, so a failure
+here can only be the AWB guard, not one of those other reads.
+"""
+
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+sys.modules.setdefault("redis", types.SimpleNamespace(StrictRedis=object))
+sys.modules.setdefault("psutil", types.SimpleNamespace())
+
+from module.cinepi_multi import CameraInfo, CinePiProcess
+
+
+class FakeRedisController:
+    """get_value returns whatever default the caller asks for; nothing in
+    _build_args needs a real, moving value for this test."""
+
+    def get_value(self, key, default=None):
+        return default
+
+    def set_value(self, key, value):
+        pass
+
+
+class FakeSensorDetect:
+    def get_resolution_info(self, model_key, sensor_mode):
+        return {"width": 1920, "height": 1080, "bit_depth": 12}
+
+    def get_packing_for_platform(self, model_key, sensor_mode, is_pi4):
+        return "U"
+
+    def resolve_log_encode_target(self, model_key, bit_depth, requested, hdr):
+        return None
+
+
+def build_args(is_mono: bool) -> list[str]:
+    fmt = "MONO" if is_mono else "RGB"
+    cam = CameraInfo(0, "imx585", fmt, "i2c@88000")
+    proc = CinePiProcess(FakeRedisController(), FakeSensorDetect(), cam, primary=True, multi=False)
+    return proc._build_args()
+
+
+class MonoAwbArgsTests(unittest.TestCase):
+    def test_a_mono_launch_carries_no_awb_arguments(self):
+        args = build_args(is_mono=True)
+        self.assertNotIn("--awb", args)
+        self.assertNotIn("--awbgains", args)
+
+    def test_a_colour_launch_is_unaffected(self):
+        args = build_args(is_mono=False)
+        self.assertIn("--awb", args)
+        self.assertEqual(args[args.index("--awb") + 1], "auto")
+        self.assertIn("--awbgains", args)
+        # The default gain pair, since FakeRedisController.get_value always
+        # returns the caller's default and cinepi_multi.py falls back to it.
+        self.assertEqual(args[args.index("--awbgains") + 1], "2.5,2.2")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_test/test_rp1_regime.py
+++ b/_test/test_rp1_regime.py
@@ -7,10 +7,15 @@ nothing logged anywhere, because the one warning on that path fires when the
 *sensor* cannot supply enough blanking, which a too-high rate makes less likely
 to trigger, not more.
 
-So every ambiguous case here has to resolve downward. The case that matters
-most is a config.txt with the overlay enabled on a board that has not rebooted
-yet: stated intent says 580, the hardware is still running stock, and believing
-the file would corrupt wide modes silently.
+So every ambiguous case here has to resolve downward, and config.txt's overlay
+line is the only thing this module trusts to decide. A live ``clk_sys`` read
+used to veto an enabled overlay back to stock when the clock looked too low --
+that assumed stock and overclocked read distinctly. On kernel 6.12.93 the
+measured rate is ~333 MHz in *both* regimes, so the veto's threshold no longer
+tells them apart: it is demoted to a logged observation with no effect on the
+decision, and these tests assert exactly that -- the measured value must not
+move the answer in either direction, including in the case the old veto
+existed for (overlay enabled, clock reading low).
 """
 
 import sys
@@ -66,21 +71,22 @@ class PixelRateTests(unittest.TestCase):
     def test_overlay_off_gives_the_stock_rate(self):
         self.assertEqual(self._rate(COMMENTED, STOCK_HZ), rp1_regime.PIXEL_RATE_STOCK)
 
-    def test_overlay_on_but_not_rebooted_yet_is_vetoed_down_to_stock(self):
-        # The dangerous case, and the whole reason the live clock is consulted.
-        self.assertEqual(self._rate(ENABLED, STOCK_HZ), rp1_regime.PIXEL_RATE_STOCK)
-
     def test_an_unreadable_clock_still_honours_the_switch(self):
         # debugfs needs root and sudo may be unavailable; the operator's stated
         # intent stands rather than the feature silently doing nothing.
         self.assertEqual(self._rate(ENABLED, None), rp1_regime.PIXEL_RATE_OVERCLOCKED)
 
-    def test_the_threshold_accepts_the_rate_the_overlay_actually_produces(self):
-        # The overlay asks for 300MHz; the hardware lands on 333.33MHz. An
-        # equality test against 300000000 would veto every real overclock.
-        self.assertGreater(OVERCLOCKED_HZ, rp1_regime.OVERCLOCK_CLK_THRESHOLD_HZ)
-        self.assertLess(STOCK_HZ, rp1_regime.OVERCLOCK_CLK_THRESHOLD_HZ)
-        self.assertEqual(self._rate(ENABLED, 300_000_000), rp1_regime.PIXEL_RATE_OVERCLOCKED)
+    def test_a_low_measured_clock_no_longer_vetoes_an_enabled_overlay(self):
+        # This used to be vetoed down to stock -- the exact case the old
+        # threshold existed for. Demoted to observation-only: config.txt's
+        # switch alone decides, so this now honours the overlay.
+        self.assertEqual(self._rate(ENABLED, STOCK_HZ), rp1_regime.PIXEL_RATE_OVERCLOCKED)
+
+    def test_a_high_measured_clock_does_not_promote_a_disabled_overlay(self):
+        # The 6.12.93 case the fix targets: clk_sys reads ~333 MHz even when
+        # config.txt's overlay line is commented out. The switch must still
+        # win, in this direction too.
+        self.assertEqual(self._rate(COMMENTED, OVERCLOCKED_HZ), rp1_regime.PIXEL_RATE_STOCK)
 
     def test_the_overclocked_rate_is_the_higher_one(self):
         self.assertGreater(rp1_regime.PIXEL_RATE_OVERCLOCKED, rp1_regime.PIXEL_RATE_STOCK)

--- a/docs/overclocking.md
+++ b/docs/overclocking.md
@@ -215,13 +215,20 @@ So every ambiguous case resolves downward:
 | Situation | Ceiling used |
 |---|---|
 | No RP1 (Pi 4 family) | none passed — libcamera's own default stands |
-| Overlay off | 380 MPix/s |
-| Overlay on, clock confirms it | 580 MPix/s |
-| Overlay on but clock still reads stock — *edited, not yet rebooted* | 380 MPix/s, with a warning naming the reboot |
-| Clock unreadable (no root for debugfs) | the switch is believed |
+| Overlay off in config.txt | 380 MPix/s |
+| Overlay on in config.txt | 580 MPix/s |
+| config.txt unreadable | 380 MPix/s (assumes stock) |
 
-The clock check is a threshold, not an equality test, precisely because the
-requested 300 MHz is not the 333.33 MHz that comes out.
+config.txt's overlay line is the only input to this decision. An earlier
+revision also read the live `clk_sys` rate and used a threshold to veto an
+enabled overlay back down to 380 when the clock still looked stock — the
+*edited, not yet rebooted* case. That assumed stock and overclocked clocks
+read distinctly (~200 MHz / ~333 MHz on an earlier 6.12.93 session). A later
+session on the same kernel measured `clk_sys` at ~333 MHz in *both* regimes,
+which silently defeated the veto's threshold in either direction rather than
+tripping it visibly. `clk_sys` is still read and logged alongside the chosen
+rate, but purely as an observation for a human comparing it against
+config.txt by hand — it no longer feeds the decision.
 
 ### Checking which regime is live
 
@@ -239,9 +246,14 @@ printf 'config.txt  : rp1-overclock %s\n' "$ovl"
 printf 'cinepi-raw  : %s\n' "${rate:-no --max-pixel-rate (libcamera default)}"
 ```
 
-Read the three lines together: the clock is ground truth, `config.txt` is
-intent, and the argument is what the pipeline was actually told. Intent
-disagreeing with the clock means you have not rebooted since toggling.
+Read the three lines together: `config.txt` is what cinemate believes and
+acts on, the argument is what the pipeline was actually told (and should
+match `config.txt` exactly), and the clock is a live, human-checked
+cross-reference only — cinemate's own decision does not read it. Intent
+disagreeing with the clock usually means you have not rebooted since
+toggling, but on this kernel `clk_sys` alone cannot confirm that; treat it as
+a hint; if you have not rebooted since editing config.txt, reboot before
+extending your capture plan to the ceiling you just enabled.
 
 The rest of this page is the manual build.
 
@@ -348,23 +360,30 @@ Reboot the Pi.
 
 ## 4. Verify
 
-First confirm the clock actually changed. This is the only check that
-distinguishes an active overclock from a commented-out overlay:
+Confirm cinemate's own decision, not the clock — on a 6.12.93 kernel
+`clk_sys` has been measured at ~333 MHz in *both* regimes, so it can no
+longer distinguish an active overclock from a commented-out overlay (see
+"Checking which regime is live" above). Check `config.txt` and the actual
+`cinepi-raw` launch argument agree instead:
+
+```bash
+grep -q '^dtoverlay=rp1-overclock' /boot/firmware/config.txt && echo enabled || echo stock
+pid=$(pgrep -x cinepi-raw | head -1)
+tr '\0' '\n' < /proc/$pid/cmdline 2>/dev/null | grep -A1 -x -- '--max-pixel-rate'
+```
+
+Stock is `380`, overclocked is `580`. If you want to read the clock anyway as
+a secondary sanity check:
 
 ```bash
 sudo grep -E '^[[:space:]]*(pll_sys|clk_sys) ' /sys/kernel/debug/clk/clk_summary
 ```
 
-The rate is the fifth column:
-
-| Clock | Stock | Overclocked |
-|---|---|---|
-| `pll_sys` | `200000000` | `333333333` |
-| `clk_sys` | `200000000` | `333333333` |
-
-**333333333, not 300000000.** The overlay asks for 300 MHz; the clock driver
-rounds to the nearest rate it can make from the 1 GHz PLL core. That is
-expected, and measured on a CM5 at 6.12.93.
+The rate is the fifth column. **333333333, not 300000000** — the overlay asks
+for 300 MHz; the clock driver rounds to the nearest rate it can make from the
+1 GHz PLL core. That figure alone does not tell you which regime is active on
+this kernel; it was only ever a reliable discriminator on an earlier
+6.12.93 session that measured stock at `200000000`.
 
 Then check the advertised modes:
 

--- a/src/module/cinepi_multi.py
+++ b/src/module/cinepi_multi.py
@@ -406,9 +406,13 @@ class CinePiProcess(Thread):
         # side-by-side strip. Either way the simple_gui columns keep their room.
         dox, doy, dpw, dph = px, py, aw, ah
 
-        # gains, shutter
-        cg_rb = self.redis_controller.get_value(ParameterKey.CG_RB.value) or '2.5,2.2'
-        
+        # gains, shutter. cg_rb is a colour red/blue gain pair -- meaningless
+        # for a mono sensor, which has no CFA to white-balance, so it is only
+        # fetched when it will actually be used below.
+        cg_rb = None if self.cam.is_mono else (
+            self.redis_controller.get_value(ParameterKey.CG_RB.value) or '2.5,2.2'
+        )
+
         # file paths
         tune = f'/home/pi/libcamera/src/ipa/rpi/pisp/data/{model_key}.json'
         if self.tuning_file_override.get('enabled') and self.tuning_file_override.get('path'):
@@ -464,9 +468,15 @@ class CinePiProcess(Thread):
             "--vflip",        str(vf),
             "--post-process-file", post,
             "--shutter", "20000",
-            "--awb", "auto",
-            "--awbgains", cg_rb,
         ]
+
+        # AWB is a colour-sensor concept: a mono tuning has no CFA and no
+        # measured colour gains for --awbgains to carry, so both are omitted
+        # entirely for a mono camera rather than sent with a meaningless
+        # colour gain pair (see cinepi/ccmp_preview.hpp's mono path in
+        # cinepi-raw for the same distinction on the preview side).
+        if not self.cam.is_mono:
+            args += ["--awb", "auto", "--awbgains", cg_rb]
 
         plain_arecord_timecode_offset = _plain_arecord_timecode_offset_frames()
         if plain_arecord_timecode_offset != 0:

--- a/src/module/rp1_regime.py
+++ b/src/module/rp1_regime.py
@@ -23,6 +23,19 @@ to be what limits the line time -- with nothing logged, because the one warning
 on that path fires when the *sensor* cannot supply enough blanking, which a
 too-high rate makes less likely to trigger. Everything here therefore fails
 towards the stock rate.
+
+THE CONFIG.TXT LINE IS THE ONLY AUTHORITY. An earlier revision of this module
+also read the live ``clk_sys`` rate and used it to veto an enabled overlay back
+down to stock when the measured clock looked too low for the switch to have
+taken effect yet. That veto assumed ``clk_sys`` reads distinctly per regime
+(measured ~200 MHz stock / ~333 MHz overclocked on an earlier 6.12.93 session).
+A later session on the same kernel measured ``clk_sys`` at ~333 MHz in *both*
+regimes -- the reading no longer discriminates stock from overclocked at all,
+which silently defeated the veto's threshold (a stock board reads as if the
+overlay had already taken effect) without ever tripping it visibly. Rather than
+carry a veto that can no longer distinguish the case it exists for, ``clk_sys``
+is read for the info log line only and has no effect on the decision in either
+direction -- config.txt's overlay line decides, full stop.
 """
 from __future__ import annotations
 
@@ -39,11 +52,6 @@ CLK_SUMMARY_PATH = "/sys/kernel/debug/clk/clk_summary"
 # Measured on a CM5: stock 200 MHz -> 380 MPix/s, overlay -> 580 MPix/s.
 PIXEL_RATE_STOCK = 380.0
 PIXEL_RATE_OVERCLOCKED = 580.0
-
-# The overlay asks for 300 MHz and the hardware lands on 333.33 MHz, so this is
-# a threshold rather than an equality test. Anything meaningfully above stock
-# counts as the overclocked regime.
-OVERCLOCK_CLK_THRESHOLD_HZ = 250_000_000
 
 _OVERLAY_LINE_RE = re.compile(r"^\s*dtoverlay=rp1-overclock\s*$", re.MULTILINE)
 _CLK_SYS_RE = re.compile(r"^\s+clk_sys\s+\S+\s+\S+\s+\S+\s+(\d+)", re.MULTILINE)
@@ -97,12 +105,13 @@ def pixel_rate() -> float | None:
     unconstrained (zero) bound in libcamera, and passing a number there would
     invent a limit that does not exist.
 
-    config.txt is the operator's stated intent and the switch that sets it
-    forces a reboot, so it is normally authoritative. Where the live clock can
-    also be read, it is used to *veto* an overclocked answer the hardware does
-    not support -- the dangerous direction is claiming 580 on a board running
-    stock clocks, which is exactly what a config.txt edited but not yet
-    rebooted looks like.
+    config.txt's overlay line is the operator's stated intent and the only
+    input to this decision, in either direction: enabled means the overclocked
+    rate, commented out or absent means stock, unreadable falls to stock (see
+    overlay_enabled()). The live clock is read below and logged alongside the
+    answer, but never changes it -- see the module docstring for why a value
+    that no longer discriminates stock from overclocked on this kernel cannot
+    be allowed to override the switch either way.
     """
     if not is_rp1_platform():
         return None
@@ -110,18 +119,9 @@ def pixel_rate() -> float | None:
     requested_overclock = overlay_enabled()
     measured = measured_clk_sys_hz()
 
-    if requested_overclock and measured is not None:
-        if measured < OVERCLOCK_CLK_THRESHOLD_HZ:
-            logger.warning(
-                "config.txt enables rp1-overclock but clk_sys reads %d Hz -- "
-                "using the stock %.0f MPix/s ceiling. Reboot for the overlay to take effect.",
-                measured, PIXEL_RATE_STOCK,
-            )
-            return PIXEL_RATE_STOCK
-
     rate = PIXEL_RATE_OVERCLOCKED if requested_overclock else PIXEL_RATE_STOCK
     logger.info(
-        "RP1 regime: %s (clk_sys %s) -> %.0f MPix/s",
+        "RP1 regime: %s (clk_sys %s, observation only) -> %.0f MPix/s",
         "overclocked" if requested_overclock else "stock",
         f"{measured} Hz" if measured is not None else "unreadable",
         rate,


### PR DESCRIPTION
Companion to [cinepi-raw#66](https://github.com/Tiramisioux/cinepi-raw/pull/66) — same
`fix/mono-clearhdr-stack` branch name, same 2026-08-27 mono ClearHDR
forensics session. This PR carries the cinemate-side fixes; the preview
and sensor-mode fixes live in the cinepi-raw PR.

## What was broken

**1. `rp1_regime.pixel_rate()` let a live clock reading override the
config.txt switch it exists to trust.** `pixel_rate()` used the live
`clk_sys` rate to veto an enabled `dtoverlay=rp1-overclock` back down to the
stock 380 MPix/s ceiling whenever the clock still read low — the "edited,
not yet rebooted" case. That veto assumed `clk_sys` reads distinctly per
regime (an earlier 6.12.93 session measured ~200 MHz stock / ~333 MHz
overclocked). A later session on the *same* kernel measured `clk_sys` at
~333 MHz in **both** regimes:

> journal, 2026-08-27 19:52:46 — cinemate rp1_regime misclassifies stock
> clk_sys 333 MHz as overclocked and passes `--max-pixel-rate 580` with the
> overclock overlay commented out.

Once `clk_sys` stops discriminating the two regimes, the veto's 250 MHz
threshold can be satisfied by a board that is actually still stock — a
silent, wrong-direction failure on the module's own stated axis ("over-
stating the rate ... corrupts every mode wide enough for this bound to be
what limits the line time — with nothing logged").

**2. `cinepi_multi.py` sent `--awb auto --awbgains <cg_rb>` to every camera,
mono included.** A mono sensor has no CFA, so there is no white balance to
solve and no red/blue gain pair for `cg_rb` to describe — `CameraInfo`
already knows the sensor is mono (`cam.is_mono`, printed as
`CameraInfo(idx=0, imx585, mono, cam0)`), the launch-argument builder just
never checked it for this pair of flags.

**3. (Round 2, review finding) Removing the clk_sys veto reintroduced the
over-statement case it existed to catch, a different way.** The RP1
overclock overlay only takes effect on reboot; the settings-editor toggle
writes config.txt and restarts cinemate without necessarily rebooting the
board. With the veto gone, overlay-enabled-but-not-yet-rebooted now yields
580 handed to hardware still running stock — exactly the silent wide-mode
corruption `pixel_rate()`'s own docstring warns about, and the toggle makes
it a realistic path. (Separately, live during this session: a settings-pane
toggle write plus a subsequent revert away from that state was directly
observed disagreeing with what the browser tab displayed until reloaded —
not this guard's scenario, but the adjacent finding that prompted a closer
look at this whole area; see [cinemate#167](https://github.com/Tiramisioux/cinemate/pull/167).)

## The fix

- `rp1_regime.py`: config.txt's overlay line is now the *only* input to the
  stock/overclocked *direction*. `clk_sys` is still read and logged
  alongside the chosen rate (useful for a human cross-referencing by hand),
  but has no effect on the result — the veto branch and
  `OVERCLOCK_CLK_THRESHOLD_HZ` are removed rather than kept as a check that
  can no longer discriminate the case it existed for.
- **(Round 2) A new mtime-vs-boot-time guard for "enabled but not yet
  rebooted."** `config_txt_mtime()` vs `boot_time()` (the latter derived
  from `/proc/uptime`) replaces `clk_sys` as the discriminator for this one
  case: the reboot is what invalidates staleness, so if config.txt was
  modified at or after the current boot, its overlay line hasn't been acted
  on yet and cannot be believed to describe the *running* hardware,
  regardless of what it says. Resolves to stock with a warning naming the
  reboot. A few seconds of slack around the boundary always resolves toward
  vetoing (stock), never toward believing the overlay — `/boot/firmware` is
  VFAT (2s mtime granularity) and the Pi has no RTC, so a closer read isn't
  meaningful anyway. An unreadable mtime or boot time makes the guard
  abstain (matches the existing unreadable-input philosophy — the overlay
  line stands alone, same as before this guard existed). Every ambiguity
  still resolves to the stock rate.
- `cinepi_multi.py`: `--awb`/`--awbgains` (and the `cg_rb` Redis read that
  feeds the latter) are now skipped entirely when `cam.is_mono`, rather than
  sent with a meaningless colour gain pair.
- **(Round 2, minor finding) Mono symmetry in the mode-switch republish.**
  `_reapply_camera_controls()` (from PR #164) force-republishes
  `cg_rb` after every resolution switch unconditionally. Since `cg_rb` is a
  colour-sensor concept, it's now skipped for a mono sensor too
  (`self.current_sensor.endswith("_mono")`, the same convention this file
  already uses elsewhere) — harmless before, now consistent with the mono
  rule above.

## No behaviour change for colour sensors / the ordinary case

- `rp1_regime.pixel_rate()` returns identical values to before whenever the
  requested regime, the measured clock, and the mtime-vs-boot-time guard all
  agree — true for every hardware-verified session to date. The mtime guard
  only ever pushes toward stock; it never promotes a disabled overlay.
- `cinepi_multi.py`'s AWB args and `_reapply_camera_controls()`'s republish
  set are completely unchanged for a colour camera — both guards only skip
  the mono branch.

## Tests

- `_test/test_rp1_regime.py`: replaces the veto/threshold tests with tests
  asserting the measured clock does not move the answer in either direction.
  **(Round 2)** `PixelRateTests._rate()` now defaults to a "comfortably
  rebooted" mtime/boot pair so every pre-existing test is unaffected by the
  new guard; a new `MtimeGuardTests` class covers edited-after-boot with the
  overlay on (stock, warned — confirmed to fail against the pre-guard module
  with `AttributeError: no config_txt_mtime`), edited-before-boot with it on
  (overclocked), edited-after-boot with it off (still stock, no promotion
  either way), the near-tie slack boundary, and both unreadable-input cases.
  New `BootTimeHelperTests` covers `boot_time()`'s own uptime parsing.
- `_test/test_cinepi_multi_mono_awb.py`: calls `CinePiProcess._build_args()`
  directly with a fake `redis_controller`/`sensor_detect` standing in for
  everything else the method touches, and asserts a mono `CameraInfo`
  carries neither `--awb` nor `--awbgains` while a colour one is unaffected.
  Checked against unfixed `cinepi_multi.py` first — both flags are present
  on a mono launch there.
- **(Round 2)** `_test/test_cinepi_controller_resolution_gui.py`: new test
  seeds `cg_rb`/`iso` in Redis with `current_sensor = "imx585_mono"` and
  asserts `_reapply_camera_controls()` force-republishes `shutter_a`/`iso`
  but not `cg_rb`; confirmed to fail against the unfixed method (cg_rb
  appeared in the republish set). The existing colour-sensor test in the
  same file is untouched and still asserts `cg_rb` *is* republished there.
- `docs/overclocking.md` updated: the regime table regains the "edited, not
  yet rebooted" row, and the "Checking which regime is live" section
  explains the mtime guard and what to check when the launched rate doesn't
  match config.txt.
- Full `_test` suite: 595 tests, 0 failures, no regressions.

**Pi-unverified** — this branch has not been run on hardware.

## Pi verification plan (operator runs later)

1. Pull `fix/mono-clearhdr-stack` on the Pi in both `cinemate` and
   `cinepi-raw` (see the companion PR for the rebuild step), restart
   cinemate.
2. Confirm the launch line shows `--max-pixel-rate 380.0` with the overclock
   line commented in `/boot/firmware/config.txt`, and `580.0` with it
   active *and the board rebooted since* — regardless of what `clk_sys`
   measures at the time.
3. **(Round 2)** Toggle the overlay on via the settings editor (or edit
   config.txt directly) and check the launch line *before* rebooting:
   expect `380.0` and a `was modified at or after the current boot` warning
   in the log, not `580.0`. Reboot, then confirm it flips to `580.0`.
4. Confirm no `--awb`/`--awbgains` arguments appear on a mono camera's
   launch line, and that a colour camera's launch line is unchanged.
5. **(Round 2)** Trigger a resolution switch on a mono camera and confirm
   the launch/republish log does not force-republish `cg_rb`, while a
   colour camera's switch still does.
6. Re-run the 1440-vs-1782 ClearHDR comparison cleanly (hardware log,
   2026-08-27 entries) — prior evidence was contaminated by both bugs here
   plus the ones in the companion cinepi-raw PR.
7. Apply the rp1-cfe kernel patch artifact (prepared, untested — see
   `development/mono-clearhdr-fixes/` in the workspace) if 16-bit mono
   ClearHDR is next on the list; it is a separate, deliberately unapplied
   change to a different layer (the kernel module), not part of either PR.
